### PR TITLE
Validate api docs after versioning

### DIFF
--- a/config.py
+++ b/config.py
@@ -56,6 +56,108 @@ DEFAULT_SUMMARY_WORD_OVERLAP = 150  # Per SUMMARY_REVIEW.md: 100-200 words recom
 
 
 class Config(BaseModel):
+    """Configuration model for podcast scraping pipeline.
+
+    This Pydantic model defines all configuration options for podcast_scraper, with
+    automatic validation and type checking. Configuration can be created programmatically
+    or loaded from JSON/YAML files using `load_config_file()`.
+
+    The configuration is organized into several categories:
+
+    - **RSS Feed**: Source feed URL and episode limits
+    - **Output**: Directory structure, file naming, and run management
+    - **HTTP**: Request behavior, timeouts, and user agents
+    - **Transcription**: Whisper model selection and language settings
+    - **Screenplay**: Speaker detection and formatting options
+    - **Metadata**: Episode metadata generation settings
+    - **Summarization**: AI-powered episode summary generation
+    - **Processing**: Parallelization and execution control
+    - **Logging**: Log levels and output destinations
+
+    All fields support validation and provide sensible defaults. The model is immutable
+    (frozen) after creation to prevent accidental modification.
+
+    Attributes:
+        rss_url: RSS feed URL to scrape. Required unless loading from config file.
+        output_dir: Output directory path. Auto-generated from RSS URL if not provided.
+        max_episodes: Maximum number of episodes to process. None processes all episodes.
+        user_agent: HTTP User-Agent header for requests.
+        timeout: Request timeout in seconds (minimum: 1).
+        delay_ms: Delay between requests in milliseconds.
+        prefer_types: Preferred transcript types or extensions (e.g., ["text/vtt", ".srt"]).
+        transcribe_missing: Enable Whisper transcription for episodes without transcripts.
+        whisper_model: Whisper model name (e.g., "base", "small", "medium").
+        screenplay: Format transcripts as screenplay with speaker labels.
+        screenplay_gap_s: Minimum gap in seconds between speaker segments.
+        screenplay_num_speakers: Number of speakers for Whisper diarization.
+        screenplay_speaker_names: Manual speaker names list (overrides auto-detection).
+        run_id: Optional run identifier. Use "auto" for timestamp-based ID.
+        log_level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+        log_file: Optional log file path for file output.
+        workers: Number of parallel download workers.
+        skip_existing: Skip episodes with existing output files.
+        clean_output: Remove output directory before processing.
+        reuse_media: Reuse existing media files instead of re-downloading.
+        dry_run: Preview planned work without saving files.
+        language: Language code for transcription (e.g., "en", "fr", "de").
+        ner_model: spaCy NER model name for speaker detection.
+        auto_speakers: Enable automatic speaker name detection using NER.
+        cache_detected_hosts: Cache detected host names across episodes.
+        generate_metadata: Generate per-episode metadata documents.
+        metadata_format: Metadata file format ("json" or "yaml").
+        metadata_subdirectory: Optional subdirectory for metadata files.
+        generate_summaries: Generate episode summaries using AI models.
+        summary_provider: Summary generation provider ("local", "openai", "anthropic").
+        summary_model: Model identifier for MAP-phase summarization.
+        summary_reduce_model: Optional separate model for REDUCE-phase summarization.
+        summary_max_length: Maximum summary length in tokens.
+        summary_min_length: Minimum summary length in tokens.
+        summary_device: Device for model execution ("cpu", "cuda", "mps", or None).
+        summary_batch_size: Batch size for parallel processing.
+        summary_chunk_size: Chunk size in tokens for long transcripts.
+        summary_word_chunk_size: Chunk size in words for word-based chunking.
+        summary_word_overlap: Overlap in words for word-based chunking.
+        summary_cache_dir: Custom cache directory for transformer models.
+        summary_prompt: Optional custom prompt for summarization.
+        save_cleaned_transcript: Save cleaned transcript to separate file.
+
+    Example:
+        Create configuration programmatically:
+
+        >>> from podcast_scraper import Config
+        >>> cfg = Config(
+        ...     rss_url="https://example.com/feed.xml",
+        ...     output_dir="./transcripts",
+        ...     max_episodes=50,
+        ...     transcribe_missing=True,
+        ...     whisper_model="base"
+        ... )
+
+    Example:
+        Load configuration from file:
+
+        >>> from podcast_scraper import Config, load_config_file
+        >>> config_dict = load_config_file("config.yaml")
+        >>> cfg = Config(**config_dict)
+
+    Example:
+        Configuration with metadata and summaries:
+
+        >>> cfg = Config(
+        ...     rss_url="https://example.com/feed.xml",
+        ...     generate_metadata=True,
+        ...     metadata_format="yaml",
+        ...     generate_summaries=True,
+        ...     summary_model="facebook/bart-base",
+        ...     summary_device="mps"
+        ... )
+
+    See Also:
+        - `load_config_file()`: Load configuration from JSON/YAML files
+        - `run_pipeline()`: Execute pipeline with configuration
+        - API Reference: https://chipi.github.io/podcast_scraper/api/configuration/
+    """
+
     rss_url: Optional[str] = Field(default=None, alias="rss")
     output_dir: Optional[str] = Field(default=None, alias="output_dir")
     max_episodes: Optional[int] = Field(default=None, alias="max_episodes")

--- a/models.py
+++ b/models.py
@@ -8,7 +8,26 @@ from typing import List, Optional, Tuple
 
 @dataclass
 class RssFeed:
-    """Represents a parsed RSS feed with metadata and episode items."""
+    """Represents a parsed RSS feed with metadata and episode items.
+
+    This dataclass holds the parsed RSS feed information including the feed title,
+    all episode items as XML elements, the base URL for resolving relative links,
+    and a list of detected authors.
+
+    Attributes:
+        title: The podcast feed title (from <title> element).
+        items: List of XML elements representing individual episodes (<item> elements).
+        base_url: Base URL of the RSS feed, used for resolving relative URLs.
+        authors: List of author names extracted from the feed metadata.
+
+    Example:
+        >>> feed = RssFeed(
+        ...     title="My Podcast",
+        ...     items=[item1, item2],
+        ...     base_url="https://example.com/feed.xml",
+        ...     authors=["John Doe"]
+        ... )
+    """
 
     title: str
     items: List[ET.Element]
@@ -18,7 +37,32 @@ class RssFeed:
 
 @dataclass
 class Episode:
-    """Represents a podcast episode with metadata and content URLs."""
+    """Represents a podcast episode with metadata and content URLs.
+
+    This dataclass encapsulates all information about a single podcast episode,
+    including its position in the feed, title information, transcript URLs,
+    and media file details.
+
+    Attributes:
+        idx: Episode index in the feed (0-based, starting from most recent).
+        title: Original episode title from RSS feed.
+        title_safe: Filesystem-safe version of the title for use in filenames.
+        item: Original XML element from the RSS feed containing all episode data.
+        transcript_urls: List of (url, mime_type) tuples for available transcripts.
+        media_url: URL of the podcast media file (audio/video). None if not available.
+        media_type: MIME type of the media file (e.g., "audio/mpeg"). None if not available.
+
+    Example:
+        >>> episode = Episode(
+        ...     idx=0,
+        ...     title="Episode 1: Introduction",
+        ...     title_safe="episode-1-introduction",
+        ...     item=xml_element,
+        ...     transcript_urls=[("https://example.com/transcript.vtt", "text/vtt")],
+        ...     media_url="https://example.com/audio.mp3",
+        ...     media_type="audio/mpeg"
+        ... )
+    """
 
     idx: int
     title: str
@@ -31,7 +75,29 @@ class Episode:
 
 @dataclass
 class TranscriptionJob:
-    """Represents a media transcription job for Whisper."""
+    """Represents a media transcription job for Whisper.
+
+    This dataclass tracks information needed to transcribe a podcast episode's
+    media file using Whisper. It includes episode metadata and paths to temporary
+    media files, along with any detected speaker names for diarization.
+
+    Attributes:
+        idx: Episode index in the feed (0-based, starting from most recent).
+        ep_title: Original episode title from RSS feed.
+        ep_title_safe: Filesystem-safe version of the title for output filenames.
+        temp_media: Path to the temporary downloaded media file to transcribe.
+        detected_speaker_names: Optional list of speaker names detected from episode
+            metadata or show notes. Used for screenplay formatting if available.
+
+    Example:
+        >>> job = TranscriptionJob(
+        ...     idx=0,
+        ...     ep_title="Episode 1: Introduction",
+        ...     ep_title_safe="episode-1-introduction",
+        ...     temp_media="/tmp/episode-1.mp3",
+        ...     detected_speaker_names=["Alice", "Bob"]
+        ... )
+    """
 
     idx: int
     ep_title: str


### PR DESCRIPTION
Add comprehensive Google-style docstrings to `Config` class and enhance model docstrings to fully complete public API documentation.

This PR addresses the critical missing docstring for the `Config` class and improves existing model docstrings, ensuring all public API components are now fully documented for auto-generation via mkdocstrings, thereby completing issue #39.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc9377dd-cfec-4d17-8fc0-c632c5fa0508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc9377dd-cfec-4d17-8fc0-c632c5fa0508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

