### PR TITLE
Link pr 56 to issue 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,16 @@ docker run --rm \
   --config /app/config.yaml
 ```
 
+**Note:** The Docker image preloads the `base.en` Whisper model by default for optimal English transcription performance. To preload different models during build, use the `WHISPER_PRELOAD_MODELS` build argument:
+
+```bash
+# Preload multiple models
+docker build --build-arg WHISPER_PRELOAD_MODELS="base.en,small.en" -t podcast-scraper .
+
+# Preload multilingual model
+docker build --build-arg WHISPER_PRELOAD_MODELS="base" -t podcast-scraper .
+```
+
 The service API is optimized for non-interactive use and provides structured exit codes:
 
 - `0`: Success

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     XDG_CACHE_HOME=/opt/whisper-cache
 
-ARG WHISPER_PRELOAD_MODELS=base
+ARG WHISPER_PRELOAD_MODELS=base.en
 ENV WHISPER_PRELOAD_MODELS=${WHISPER_PRELOAD_MODELS}
 
 RUN apt-get update \
@@ -29,7 +29,7 @@ if model_csv:
 else:
     models = []
 if not models:
-    models = ["base"]
+    models = ["base.en"]
 
 for name in models:
     print(f"Preloading Whisper model: {name}")


### PR DESCRIPTION
Update Dockerfile to default to `base.en` Whisper model and update README.md to reflect this change and close issue 13.

The Docker image will now default to `base.en` for optimal English transcription performance, while maintaining full flexibility for users who need multilingual support. This aligns with RFC-010's language-aware model selection strategy.

---
<a href="https://cursor.com/background-agent?bcId=bc-a50963af-8375-4b2f-a212-b5fa5e00a305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a50963af-8375-4b2f-a212-b5fa5e00a305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

