### PR TITLE
fix: Security update urllib3 and markdownlint fixes for v2.3.1

### DIFF
--- a/docs/releases/RELEASE_v2.3.0.md
+++ b/docs/releases/RELEASE_v2.3.0.md
@@ -386,6 +386,7 @@ Each episode in `data/eval/` should contain:
 - **Example Configs**: Updated example configuration files with better formatting and comments
 
 **Files Updated:**
+
 - CI workflows (`.github/workflows/docs.yml`, `.github/workflows/python-app.yml`)
 - Linting configurations (`.flake8`, `.markdownlint.json`)
 - Project configuration (`Makefile`, `pyproject.toml`, `.gitignore`)
@@ -395,6 +396,7 @@ Each episode in `data/eval/` should contain:
 - Example configuration files
 
 **Impact:**
+
 - All CI checks now pass consistently
 - Improved code maintainability and readability
 - Better documentation formatting and navigation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core dependencies only - for full install use: pip install -e .[ml]
 # Or for development: pip install -e .[dev,ml,docs]
 requests>=2.31.0
+urllib3>=2.6.0
 tqdm>=4.66.0
 defusedxml>=0.7.1
 platformdirs>=3.11.0


### PR DESCRIPTION
## Summary

This PR addresses security vulnerabilities and markdown linting issues for release v2.3.1.

## Changes

- **Security**: Updated `urllib3` from 2.5.0 to >=2.6.0 to resolve security vulnerabilities:
  - GHSA-gm62-xv2j-4w53
  - GHSA-2xpw-w6gg-jr37
- **Documentation**: Fixed markdownlint MD032 issues in `RELEASE_v2.3.0.md` by adding blank lines around lists

## Testing

- ✅ Full CI suite passes locally (`make ci`)
- ✅ All 214 tests pass
- ✅ Security audit shows no known vulnerabilities
- ✅ Markdown linting passes

## Impact

- Resolves security vulnerabilities in urllib3 dependency
- Improves documentation formatting compliance
- No breaking changes

## Related

Fixes security vulnerabilities identified by `pip-audit` in CI pipeline.