### PR TITLE
docs: Add release notes for v2.3.2

### DIFF
--- a/docs/releases/RELEASE_v2.3.2.md
+++ b/docs/releases/RELEASE_v2.3.2.md
@@ -1,0 +1,247 @@
+# Release v2.3.2 - Security Tests & Thread-Safety Fixes
+
+**Release Date:** December 2025  
+**Type:** Patch Release  
+**Last Updated:** December 10, 2025
+
+## Summary
+
+v2.3.2 is a **patch release** focused on **comprehensive security test coverage** and **critical thread-safety fixes** for parallel summarization. This release addresses code review feedback by adding extensive security tests, fixing thread-safety issues with shared REDUCE models, and improving overall code quality and reliability.
+
+## Key Changes
+
+### 🔒 Security Test Coverage
+
+#### Comprehensive Security Tests Added
+
+**New Test Suite: `tests/test_summarizer_security.py` (442 lines)**
+
+- **`_validate_model_source()` tests**: Validates trusted sources (facebook, google, sshleifer, allenai) and warns on untrusted sources
+  - Tests trusted source recognition
+  - Tests untrusted source warnings
+  - Verifies no sensitive information is logged
+- **Revision pinning tests**: Verifies revision parameter is passed to tokenizer and model, stored correctly, and not passed when None
+  - Tests revision passed to tokenizer
+  - Tests revision passed to model
+  - Tests revision stored in model instance
+  - Tests None revision handling
+- **`prune_cache()` security tests**: Comprehensive tests for cache pruning security checks
+  - Prevents deletion of home directory and `~/.cache` root
+  - Prevents deletion outside safe locations
+  - Prevents path traversal attacks
+  - Validates dry-run vs actual deletion behavior
+  - Tests subdirectory deletion within allowed locations
+
+**Impact**: Significantly improves security test coverage, ensuring critical security functions are properly tested and validated.
+
+### 🔧 Thread-Safety Fixes
+
+#### Per-Worker REDUCE Models
+
+**Problem**: Parallel summarization was sharing a single REDUCE model instance across all worker threads, leading to thread-safety issues and potential race conditions.
+
+**Solution**:
+
+- Preloads per-worker REDUCE model instances (or reuses MAP model when `reduce_model == summary_model`)
+- Each worker thread gets its own MAP and REDUCE model instances
+- Proper cleanup of worker REDUCE models in `finally` block
+
+**Implementation Details**:
+
+- Extracts REDUCE model configuration at pipeline level
+- Preloads `max_workers` REDUCE model instances before starting `ThreadPoolExecutor`
+- Uses `threading.local()` to assign models to worker threads
+- Reuses MAP model for REDUCE phase when they're the same model
+- Ensures proper cleanup even if model loading fails
+
+**Files**: `workflow.py`
+
+**Impact**: Eliminates thread-safety issues in parallel summarization, enabling safe concurrent processing.
+
+#### Fallback Path Consistency
+
+**Problem**: When worker model preloading fails and the code falls back to sequential processing, `reduce_model` was not passed to `_summarize_single_episode`, causing REDUCE-phase settings to be silently ignored.
+
+**Solution**:
+
+- Ensures `reduce_model` is passed in the fallback path
+- Maintains consistent behavior between parallel and sequential processing paths
+- Added explicit comment clarifying the behavior
+
+**Files**: `workflow.py`
+
+**Impact**: Ensures consistent behavior regardless of processing path (parallel vs sequential).
+
+### ⚡ Performance Improvements
+
+#### REDUCE Model Reuse Across Episodes
+
+**Optimization**: REDUCE model is now loaded once at pipeline level and reused across all episodes, avoiding redundant model downloads and memory usage.
+
+**Implementation**:
+
+- REDUCE model loaded once in `run_pipeline()` if different from MAP model
+- Passed through to `generate_episode_metadata()` and `_generate_episode_summary()`
+- Reused across all episodes instead of creating new instance per episode
+
+**Files**: `workflow.py`, `metadata.py`
+
+**Impact**: Reduces memory usage and eliminates redundant model downloads for episodes using the same REDUCE model.
+
+### 🛠️ Code Quality Improvements
+
+#### GitHub Actions Workflow Fixes
+
+**Fixed Invalid Workflow File Syntax**:
+
+- **Fixed**: Added missing `branches:` key under `pull_request:` in `docs.yml`
+- **Fixed**: Removed `paths-ignore` from all workflow files (GitHub Actions doesn't allow both `paths` and `paths-ignore` in the same event)
+- **Impact**: All workflows now validate correctly and trigger as expected
+- **Files**: `.github/workflows/docker.yml`, `.github/workflows/docs.yml`, `.github/workflows/python-app.yml`, `.github/workflows/snyk.yml`
+
+#### Linting Fixes
+
+**Code Quality**:
+
+- **Fixed**: E501 line length errors in `workflow.py` (lines 1577, 1588, 1596)
+- **Fixed**: Markdown table formatting issues in `docs/TYPE_HINTS_ANALYSIS.md` (MD060 compliance)
+- **Updated**: Pre-commit hook to include E501 checks (line too long)
+- **Impact**: All linting checks now pass, code follows style guidelines
+
+**Files**: `workflow.py`, `docs/TYPE_HINTS_ANALYSIS.md`, `.github/hooks/pre-commit`
+
+### 📚 Documentation Improvements
+
+#### README Updates
+
+- **Clarified**: `[ml]` extra dependency installation requirements
+- **Added**: Explicit note that ML features (speaker detection, transcription, summarization) require `pip install -e ".[ml]"`
+- **Impact**: Users have clearer guidance on installing ML dependencies
+
+**Files**: `README.md`
+
+## Technical Details
+
+### Thread-Safety Implementation
+
+**Before (Thread-Unsafe)**:
+```python
+# Single REDUCE model shared across all workers
+reduce_model = summarizer.SummaryModel(...)
+for episode in episodes:
+    _summarize_single_episode(..., reduce_model=reduce_model)  # Shared instance
+```
+
+**After (Thread-Safe)**:
+```python
+# Preload per-worker REDUCE models
+worker_reduce_models = []
+for i in range(max_workers):
+    if has_separate_reduce_models:
+        worker_reduce_models.append(summarizer.SummaryModel(**reduce_model_kwargs))
+    elif reduce_model_is_same_as_map:
+        worker_reduce_models.append(worker_models[i])  # Reuse MAP model
+    else:
+        worker_reduce_models.append(None)
+
+# Each worker gets its own REDUCE model
+def _get_worker_models():
+    thread_local.reduce_model = worker_reduce_models[idx]
+    return thread_local.map_model, thread_local.reduce_model
+```
+
+### Security Test Coverage
+
+**New Test Categories**:
+
+1. **Model Source Validation** (8 tests):
+   - Trusted source recognition
+   - Untrusted source warnings
+   - No sensitive info logging
+
+2. **Revision Pinning** (6 tests):
+   - Revision passed to tokenizer
+   - Revision passed to model
+   - Revision stored correctly
+   - None revision handling
+
+3. **Cache Pruning Security** (10 tests):
+   - Prevents deletion of protected directories
+   - Prevents path traversal
+   - Validates dry-run behavior
+   - Tests allowed subdirectory deletion
+
+**Total**: 24 new security tests
+
+### REDUCE Model Reuse
+
+**Before**:
+```python
+# REDUCE model created per episode
+def _generate_episode_summary(...):
+    reduce_model = summary_model
+    if reduce_model_name != summary_model.model_name:
+        reduce_model = summarizer.SummaryModel(...)  # New instance per episode
+```
+
+**After**:
+```python
+# REDUCE model loaded once, reused across episodes
+reduce_model = None
+if cfg.generate_summaries:
+    if reduce_model_name != model_name:
+        reduce_model = summarizer.SummaryModel(...)  # Loaded once
+
+# Passed through to all episodes
+generate_episode_metadata(..., reduce_model=reduce_model)
+```
+
+## Configuration Changes
+
+**No Breaking Changes**: All changes are backward compatible.
+
+## Migration Notes
+
+### For Users Upgrading from v2.3.1
+
+**No Action Required**:
+
+- All changes are internal improvements
+- No configuration changes needed
+- No API changes
+- Backward compatible
+
+**Benefits**:
+
+- Improved thread safety in parallel summarization
+- Better test coverage for security functions
+- More reliable GitHub Actions workflows
+
+## Testing
+
+- **272 tests passing** (24 new security tests)
+- **Comprehensive security test coverage** for critical functions
+- **Thread-safety verified** for parallel summarization
+- **All CI checks passing** (formatting, linting, type checking, security, tests, docs, package build)
+
+## Contributors
+
+- Security test implementation
+- Thread-safety fixes for parallel processing
+- Code quality improvements
+- Workflow file fixes
+- Documentation updates
+
+## Related Issues & PRs
+
+- #81: Code Review Improvements: Security Tests & Thread-Safety Fixes (v2.3.2)
+- #82: Hotfix: Fix invalid workflow files in v2.3.1
+
+## Next Steps
+
+- Continue adding type hints (planned for v2.4.0)
+- Further optimize parallel processing
+- Enhance documentation
+- Address summary quality improvements (Issue #83)
+
+**Full Changelog**: <https://github.com/chipi/podcast_scraper/compare/v2.3.1...v2.3.2>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - API Migration Guide: api/API_MIGRATION_GUIDE.md
       - API Versioning: api/API_VERSIONING.md
   - Releases:
+      - v2.3.2 - Security Tests & Thread-Safety Fixes: releases/RELEASE_v2.3.2.md
       - v2.3.1 - Security Fixes & Code Quality Improvements: releases/RELEASE_v2.3.1.md
       - v2.3.0 - Episode Summarization & Public API: releases/RELEASE_v2.3.0.md
       - v2.2.0 - Metadata Generation & Code Quality: releases/RELEASE_v2.2.0.md


### PR DESCRIPTION
## Summary

Adds comprehensive release notes for v2.3.2 documenting all changes since v2.3.1.

## Changes

- **New file**: `docs/releases/RELEASE_v2.3.2.md` - Complete release notes
- **Updated**: `mkdocs.yml` - Added v2.3.2 to releases navigation

## Release Notes Highlights

### 🔒 Security Test Coverage
- 24 new comprehensive security tests (`tests/test_summarizer_security.py`)
- Tests for `_validate_model_source()`, revision pinning, and `prune_cache()` security

### 🔧 Thread-Safety Fixes
- Per-worker REDUCE models for parallel summarization
- Fallback path consistency improvements

### ⚡ Performance Improvements
- REDUCE model reuse across episodes

### 🛠️ Code Quality
- GitHub Actions workflow fixes
- Linting improvements (E501, markdown formatting)

### 📚 Documentation
- README updates for ML dependencies

## Related

- Part of v2.3.2 release preparation
- Documents changes from PR #81 and #82

## Checklist

- [x] Release notes follow existing format
- [x] Markdown linting passes
- [x] Added to mkdocs.yml navigation
- [x] All changes documented