### PR TITLE
docs: add guide file loading instructions to AI guidelines

### DIFF
--- a/.ai-coding-guidelines.md
+++ b/.ai-coding-guidelines.md
@@ -27,6 +27,46 @@
 3. ✅ Reference this file for all decisions
 4. ✅ Check this file when unsure about patterns or workflows
 
+## 📚 COMPLETE GUIDE FILE SET (LOAD ALL WHEN REQUESTED)
+
+**When the user asks to "load ai coding guidelines" or "load coding guidelines", you MUST load ALL of these files:**
+
+1. ✅ **`.ai-coding-guidelines.md`** (this file) - Main AI coding guidelines
+2. ✅ **`docs/guides/CURSOR_AI_BEST_PRACTICES_GUIDE.md`** - Cursor AI best practices and model selection
+3. ✅ **`docs/guides/DEVELOPMENT_GUIDE.md`** - Detailed development guide (code style, testing, CI/CD, architecture)
+4. ✅ **`docs/guides/TESTING_GUIDE.md`** - Testing guide (unit, integration, E2E implementation)
+5. ✅ **`docs/guides/MD_STYLE_REFERENCE.md`** - Markdown style quick reference
+6. ✅ **`docs/guides/MARKDOWN_LINTING_GUIDE.md`** - Complete markdown linting guide
+
+**Why load all of them:**
+
+- `.ai-coding-guidelines.md` provides critical workflow rules
+- `CURSOR_AI_BEST_PRACTICES_GUIDE.md` provides model selection and workflow optimization
+- `DEVELOPMENT_GUIDE.md` provides detailed technical patterns and implementation details
+- `TESTING_GUIDE.md` provides comprehensive testing implementation details
+- `MD_STYLE_REFERENCE.md` and `MARKDOWN_LINTING_GUIDE.md` provide markdown formatting standards
+
+**Loading pattern:**
+
+```python
+
+# When user says "load ai coding guidelines" or "load coding guidelines":
+
+# 1. Read .ai-coding-guidelines.md
+
+# 2. Read docs/guides/CURSOR_AI_BEST_PRACTICES_GUIDE.md
+
+# 3. Read docs/guides/DEVELOPMENT_GUIDE.md
+
+# 4. Read docs/guides/TESTING_GUIDE.md
+
+# 5. Read docs/guides/MD_STYLE_REFERENCE.md
+
+# 6. Read docs/guides/MARKDOWN_LINTING_GUIDE.md
+
+# 7. Acknowledge all files loaded and summarize key points
+
+```text
 **CRITICAL RULES (MUST FOLLOW ALWAYS - NO EXCEPTIONS):**
 
 **🚨 COMMIT WORKFLOW - MANDATORY CHECKLIST (NO EXCEPTIONS):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,46 @@
 - ✅ Always wait for explicit user approval before committing
 - ✅ Always run `make ci` before pushing to PR (new or updated)
 
+## 📚 COMPLETE GUIDE FILE SET (LOAD ALL WHEN REQUESTED)
+
+**When the user asks to "load ai coding guidelines" or "load coding guidelines", you MUST load ALL of these files:**
+
+1. ✅ **`.ai-coding-guidelines.md`** - Main AI coding guidelines (PRIMARY source of truth)
+2. ✅ **`docs/guides/CURSOR_AI_BEST_PRACTICES_GUIDE.md`** - Cursor AI best practices and model selection
+3. ✅ **`docs/guides/DEVELOPMENT_GUIDE.md`** - Detailed development guide (code style, testing, CI/CD, architecture)
+4. ✅ **`docs/guides/TESTING_GUIDE.md`** - Testing guide (unit, integration, E2E implementation)
+5. ✅ **`docs/guides/MD_STYLE_REFERENCE.md`** - Markdown style quick reference
+6. ✅ **`docs/guides/MARKDOWN_LINTING_GUIDE.md`** - Complete markdown linting guide
+
+**Why load all of them:**
+
+- `.ai-coding-guidelines.md` provides critical workflow rules
+- `CURSOR_AI_BEST_PRACTICES_GUIDE.md` provides model selection and workflow optimization
+- `DEVELOPMENT_GUIDE.md` provides detailed technical patterns and implementation details
+- `TESTING_GUIDE.md` provides comprehensive testing implementation details
+- `MD_STYLE_REFERENCE.md` and `MARKDOWN_LINTING_GUIDE.md` provide markdown formatting standards
+
+**Loading pattern:**
+
+```python
+
+# When user says "load ai coding guidelines" or "load coding guidelines":
+
+# 1. Read .ai-coding-guidelines.md
+
+# 2. Read docs/guides/CURSOR_AI_BEST_PRACTICES_GUIDE.md
+
+# 3. Read docs/guides/DEVELOPMENT_GUIDE.md
+
+# 4. Read docs/guides/TESTING_GUIDE.md
+
+# 5. Read docs/guides/MD_STYLE_REFERENCE.md
+
+# 6. Read docs/guides/MARKDOWN_LINTING_GUIDE.md
+
+# 7. Acknowledge all files loaded and summarize key points
+
+```text
 ## Full Guidelines
 
 **All detailed guidelines, patterns, and rules are in `.ai-coding-guidelines.md`**
@@ -39,13 +79,20 @@
 
 **When working on related tasks, read these files:**
 
+**Core Guide Files (load all when user asks to "load ai coding guidelines"):**
+- **`.ai-coding-guidelines.md`** - Main AI coding guidelines (PRIMARY source of truth)
+- **`docs/guides/CURSOR_AI_BEST_PRACTICES_GUIDE.md`** - Cursor AI best practices and model selection
 - **`docs/guides/DEVELOPMENT_GUIDE.md`** - Detailed technical information (code style, testing, CI/CD,
   architecture, logging, documentation standards)
 
+
+- **`docs/guides/TESTING_GUIDE.md`** - Testing guide (unit, integration, E2E implementation)
+- **`docs/guides/MD_STYLE_REFERENCE.md`** - Markdown style quick reference
 - **`docs/guides/MARKDOWN_LINTING_GUIDE.md`** - Complete markdown linting guide (automated fixing, table
   formatting, pre-commit hooks, CI/CD integration)
 
+**Additional Reference Files:**
 - **`docs/TESTING_STRATEGY.md`** - Comprehensive testing approach
 - **`docs/ARCHITECTURE.md`** - Architecture design and module responsibilities
 
-**These files are referenced in `.ai-coding-guidelines.md` but should be read directly when working on related tasks.**
+**See the "📚 COMPLETE GUIDE FILE SET" section above for the complete loading pattern.**


### PR DESCRIPTION
## Summary

Adds explicit instructions to `.ai-coding-guidelines.md` and `CLAUDE.md` to ensure all 6 guide files are loaded when users request "load ai coding guidelines".

## Changes

- Added "📚 COMPLETE GUIDE FILE SET (LOAD ALL WHEN REQUESTED)" section to both files
- Lists all 6 guide files that must be loaded:
  1. `.ai-coding-guidelines.md` - Main AI coding guidelines
  2. `docs/guides/CURSOR_AI_BEST_PRACTICES_GUIDE.md` - Cursor AI best practices
  3. `docs/guides/DEVELOPMENT_GUIDE.md` - Detailed development guide
  4. `docs/guides/TESTING_GUIDE.md` - Testing guide
  5. `docs/guides/MD_STYLE_REFERENCE.md` - Markdown style reference
  6. `docs/guides/MARKDOWN_LINTING_GUIDE.md` - Markdown linting guide
- Includes loading pattern checklist for AI assistants
- Updated "Key Documentation Files" section in CLAUDE.md

## Files Changed

- `.ai-coding-guidelines.md` - Added guide file loading section (40 lines added)
- `CLAUDE.md` - Added same section and updated references (49 lines added, 1 deleted)

## Why

Ensures AI assistants always load all relevant guide files when requested, providing complete context for development work. This makes the "load ai coding guidelines" command more reliable and comprehensive.

## Testing

- ✅ Markdown linting passes
- ✅ Files are properly formatted
- ✅ Both entry points (`.ai-coding-guidelines.md` and `CLAUDE.md`) updated consistently