### PR TITLE
fix: Remove Pipeline from runtime import and update cache_utils for transformers compatibility (#161)

### DIFF
--- a/src/podcast_scraper/cache_utils.py
+++ b/src/podcast_scraper/cache_utils.py
@@ -64,12 +64,19 @@ def get_transformers_cache_dir() -> Path:
         return local_cache
     # Fallback to default Transformers cache
     try:
-        from transformers import file_utils
+        # Try modern huggingface_hub API first (transformers 4.20+)
+        from huggingface_hub import constants
 
-        return Path(file_utils.default_cache_path)
+        return Path(constants.HF_HUB_CACHE)
     except ImportError:
-        # If transformers not installed, return standard location
-        return Path.home() / ".cache" / "huggingface" / "hub"
+        try:
+            # Fallback to transformers file_utils (older versions)
+            from transformers import file_utils
+
+            return Path(file_utils.default_cache_path)
+        except (ImportError, AttributeError):
+            # If neither available, return standard location
+            return Path.home() / ".cache" / "huggingface" / "hub"
 
 
 def get_spacy_cache_dir() -> Optional[Path]:

--- a/src/podcast_scraper/summarizer.py
+++ b/src/podcast_scraper/summarizer.py
@@ -557,7 +557,6 @@ class SummaryModel:
         from transformers import (  # noqa: F401
             AutoModelForSeq2SeqLM,
             AutoTokenizer,
-            Pipeline,
             pipeline,
         )
 


### PR DESCRIPTION
## 🔧 Fixes Issue #161

This PR fixes the `cannot import name 'Pipeline' from 'transformers'` error that occurs with transformers 4.50+.

## 📋 Changes

### 1. `summarizer.py` - Fix Pipeline Import Error
- **Problem**: `Pipeline` was imported at runtime but moved to internal API in transformers 4.50+
- **Solution**: Removed `Pipeline` from runtime import (line 560). It's only needed for type hints, which are already correctly handled in the `TYPE_CHECKING` block.
- **Impact**: Fixes ImportError for users with transformers 4.50+ (e.g., 4.57.3)

### 2. `cache_utils.py` - Proactive Compatibility Fix
- **Problem**: Uses deprecated `transformers.file_utils.default_cache_path` which may be removed in future versions
- **Solution**: Updated to use modern `huggingface_hub.constants.HF_HUB_CACHE` API with fallback to legacy API for older transformers versions
- **Impact**: Prevents future compatibility issues and supports both old and new transformers versions

## 🧪 Testing

- [x] No linter errors
- [x] Changes are backward compatible (fallback to legacy API)
- [x] Type hints remain correct (Pipeline still in TYPE_CHECKING block)

## 📝 Technical Details

| File | Change | Reason |
|------|--------|--------|
| `summarizer.py` | Removed `Pipeline` from runtime import | Pipeline moved to internal API in transformers 4.50+ |
| `cache_utils.py` | Use `huggingface_hub.constants.HF_HUB_CACHE` | Modern API, with fallback for compatibility |

## 🔗 Related

- Closes #161