### PR TITLE
feat: exclude LLM/OpenAI tests from nightly runs to avoid API costs (#183)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,9 +94,10 @@ jobs:
         export PYTHONPATH="${PYTHONPATH}:$(pwd)"
         # Run all tests (unit + integration + e2e) with comprehensive metrics collection
         # Note: E2E tests are limited to 1 episode per test (code quality validation)
+        # Excludes LLM/OpenAI tests to avoid API costs (see issue #183)
         pytest tests/unit/ tests/integration/ tests/e2e/ \
           -v \
-          -m "not nightly" \
+          -m "not nightly and not llm" \
           -n $(python3 -c "import os; print(max(1, (os.cpu_count() or 2) - 2))") \
           --durations=20 \
           --junitxml=reports/junit.xml \

--- a/Makefile
+++ b/Makefile
@@ -231,11 +231,12 @@ test-nightly:
 	# Runs all 15 episodes across 5 podcasts (p01-p05)
 	# Sequential execution per podcast, parallel episodes within podcast (2 workers)
 	# NOT marked with @pytest.mark.e2e - separate category from regular E2E tests
+	# Excludes LLM/OpenAI tests to avoid API costs (see issue #183)
 	@echo "Running nightly tests with production models..."
 	@echo "Podcasts: p01-p05 (15 episodes total)"
 	@echo "Models: Whisper base, BART-large-cnn, LED-large-16384"
 	@mkdir -p reports
-	@E2E_TEST_MODE=nightly pytest tests/e2e/ -m "nightly" -v -n 2 --disable-socket --allow-hosts=127.0.0.1,localhost --durations=20 --junitxml=reports/junit-nightly.xml --json-report --json-report-file=reports/pytest-nightly.json
+	@E2E_TEST_MODE=nightly pytest tests/e2e/ -m "nightly and not llm" -v -n 2 --disable-socket --allow-hosts=127.0.0.1,localhost --durations=20 --junitxml=reports/junit-nightly.xml --json-report --json-report-file=reports/pytest-nightly.json
 
 test:
 	# All tests: serial tests first (sequentially), then parallel execution for the rest

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -1896,6 +1896,8 @@ The nightly workflow implements **RFC-025 Layer 3** (Comprehensive Analysis). Un
 
 **Duration:** ~4-5 hours (includes all tests with production models: Whisper base, BART-large-cnn, LED-large-16384)
 
+**Important:** OpenAI/LLM provider tests are **excluded** from nightly runs to avoid API costs (see issue #183). The nightly build uses only local ML models (Whisper, spaCy, Transformers). This excludes ~50 tests marked with `@pytest.mark.llm`.
+
 **Steps:**
 1. Checkout code (full history for trend tracking)
 2. Free disk space
@@ -1903,8 +1905,10 @@ The nightly workflow implements **RFC-025 Layer 3** (Comprehensive Analysis). Un
 4. Cache ML models (for faster execution)
 5. Install full dependencies (including ML + pytest-json-report)
 6. Preload **production** ML models via `make preload-ml-models-production` (if cache miss)
-7. Run regular tests (unit + integration + e2e, excluding nightly-only tests):
+7. Run regular tests (unit + integration + e2e, excluding nightly-only and LLM tests):
+   - Marker: `-m "not nightly and not llm"`
 8. Run **nightly-only tests** via `make test-nightly`:
+   - Marker: `-m "nightly and not llm"`
    - Uses production models: Whisper base, BART-large-cnn, LED-large-16384
    - Processes all 15 episodes across 5 podcasts (p01-p05)
    - Validates full pipeline with production-quality models

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -419,7 +419,7 @@ The test suite is organized into three main categories:
 - **Slow E2E tests**: Run only on push to main (includes slow/ml_models, parallel execution, network guard, with re-runs)
 - **Test execution**: Parallel by default (`-n auto`), use `pytest -n 0` for sequential debugging
 - **Flaky test reruns**: Enabled for integration and E2E tests (`--reruns 2 --reruns-delay 1`)
-- **Nightly workflow**: Comprehensive test suite with full metrics collection, trend tracking, and dashboard generation (RFC-025 Layer 3)
+- **Nightly workflow**: Comprehensive test suite with full metrics collection, trend tracking, and dashboard generation (RFC-025 Layer 3). **Note:** LLM/OpenAI tests are excluded (`-m "not llm"`) to avoid API costs (see issue #183)
 
 **For detailed test execution commands, parallel execution, flaky test reruns, and coverage, see [Testing Guide - Test Execution Details](TESTING_GUIDE.md#test-execution-details).**
 

--- a/docs/guides/TESTING_GUIDE.md
+++ b/docs/guides/TESTING_GUIDE.md
@@ -103,8 +103,8 @@ pytest tests/unit/ --cov=podcast_scraper --cov-report=term-missing
 | `@pytest.mark.ml_models` | Requires ML dependencies |
 | `@pytest.mark.slow` | Slow-running tests |
 | `@pytest.mark.network` | Hits external network |
-| `@pytest.mark.llm` | Uses LLM APIs (may incur costs) |
-| `@pytest.mark.openai` | Uses OpenAI specifically |
+| `@pytest.mark.llm` | Uses LLM APIs (excluded from nightly to avoid costs) |
+| `@pytest.mark.openai` | Uses OpenAI specifically (subset of `llm`) |
 
 ## Network Isolation
 


### PR DESCRIPTION
## Summary

Excludes LLM/OpenAI provider tests from nightly builds to avoid API costs while maintaining comprehensive testing with local ML models.

## Changes

- **Nightly workflow** (`.github/workflows/nightly.yml`): Added `-m "not llm"` marker filter to exclude LLM tests from both regular and nightly-only test runs
- **Makefile**: Updated `test-nightly` target to exclude LLM tests with `-m "nightly and not llm"`
- **Documentation**: Updated CI_CD.md, TESTING_STRATEGY.md, and TESTING_GUIDE.md to document the exclusion

## Impact

- **Cost savings**: Prevents API costs from running ~50 OpenAI provider tests during nightly builds
- **Testing coverage**: Nightly builds still run comprehensive tests with production local ML models (Whisper, spaCy, Transformers)
- **Documentation**: Clear documentation of the exclusion policy

## Related

Fixes #183