### PR TITLE
fix: ignore PYSEC-2022-42969 in pip-audit (py package)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,8 @@ quality: complexity deadcode docstrings spelling
 		(echo "⚠️  Editable install failed, using non-editable install" && \
 		 $(PYTHON) -m pip install --quiet .[ml])
 	# Audit all installed packages (including ML dependencies from pyproject.toml)
-	pip-audit --skip-editable
+	# Ignore PYSEC-2022-42969: py package vulnerability (transitive dep of interrogate, deprecated, not exploitable here)
+	pip-audit --skip-editable --ignore-vuln PYSEC-2022-42969
 
 docs:
 	mkdocs build --strict


### PR DESCRIPTION
## Summary

Fixes nightly build failure caused by `pip-audit` detecting a vulnerability in the `py` package.

## Problem

```
Found 1 known vulnerability in 1 package
Name Version ID               Fix Versions
---- ------- ---------------- ------------
py   1.11.0  PYSEC-2022-42969
```

## Root Cause

The `py` package (v1.11.0) is a transitive dependency of `interrogate` (our docstring coverage tool). It has a known path traversal vulnerability ([PYSEC-2022-42969](https://osv.dev/vulnerability/PYSEC-2022-42969)).

## Why This is Safe to Ignore

1. **Dev-only dependency**: `py` is only used during development/CI, not in production
2. **Not exploitable**: The vulnerable `py.path.local` is not used in our codebase
3. **No fix available**: The `py` package is deprecated with no patched version

## Solution

Added `--ignore-vuln PYSEC-2022-42969` flag to `pip-audit` in the Makefile to unblock CI while acknowledging the risk is accepted.

## Long-term Consideration

Consider replacing `interrogate` with an alternative docstring coverage tool that doesn't depend on the deprecated `py` package. This can be tracked in a separate issue if needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Makefile audit tweak**
> 
> - Updates `quality` target to run `pip-audit --skip-editable --ignore-vuln PYSEC-2022-42969`
> - Adds context comment noting the ignored vuln is for the deprecated `py` package (transitive of `interrogate`) and not applicable in this project
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a940db0ad3fceaecd783cb8d95e16b16f4e4dc2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->