### PR TITLE
fix: preload base.en instead of base for nightly Whisper model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,14 +228,14 @@ test-e2e-data-quality:
 
 test-nightly:
 	# Nightly-only tests: comprehensive tests with production ML models (p01-p05 full suite)
-	# Uses production models: Whisper base, BART-large-cnn, LED-large-16384
+	# Uses production models: Whisper base.en, BART-large-cnn, LED-large-16384
 	# Runs all 15 episodes across 5 podcasts (p01-p05)
 	# Sequential execution per podcast, parallel episodes within podcast (2 workers)
 	# NOT marked with @pytest.mark.e2e - separate category from regular E2E tests
 	# Excludes LLM/OpenAI tests to avoid API costs (see issue #183)
 	@echo "Running nightly tests with production models..."
 	@echo "Podcasts: p01-p05 (15 episodes total)"
-	@echo "Models: Whisper base, BART-large-cnn, LED-large-16384"
+	@echo "Models: Whisper base.en, BART-large-cnn, LED-large-16384"
 	@mkdir -p reports
 	@E2E_TEST_MODE=nightly pytest tests/e2e/ -m "nightly and not llm" -v -n 2 --disable-socket --allow-hosts=127.0.0.1,localhost --durations=20 --junitxml=reports/junit-nightly.xml --json-report --json-report-file=reports/pytest-nightly.json
 


### PR DESCRIPTION
## Problem

Nightly tests were failing because the Whisper model `base.en.pt` was not found in cache. The error showed:
```
RuntimeError: Failed to load any Whisper model. Tried: ['base.en']. Last error: Network downloads are blocked in E2E tests.
```

## Root Cause

1. The nightly config uses `whisper_model="base"` 
2. The code converts `base` → `base.en` for English language (in `ml_provider.py`)
3. The preload script was caching `base.pt` (not `base.en.pt`)
4. When the code tried to load `base.en`, it wasn't in cache → network download blocked → test fails

## Solution

- **Fixed production preload**: Changed from `base` to `base.en` in `scripts/preload_ml_models.py`
- **Enhanced logging**: Added detailed logging to show:
  - What models are cached (with sizes and locations)
  - Download source, cache location, and model sizes in preload script
  - All cached models when a mismatch occurs (in cache helpers)

## Changes

- `scripts/preload_ml_models.py`: Preload `base.en` instead of `base` in production mode
- `tests/integration/ml_model_cache_helpers.py`: Enhanced skip messages to list all cached models
- `Makefile`: Updated comments to reflect `base.en` model name

## Testing

- ✅ All pre-commit checks passed
- ✅ `make ci-fast` passed
- ✅ Code formatted and linted

This should fix the nightly test failures where all 5 nightly tests were failing due to missing `base.en.pt` in cache.