### PR TITLE
fix: use separate cache key for nightly with all models

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,7 +45,7 @@ jobs:
         cache: "pip"
         cache-dependency-path: pyproject.toml
 
-    - name: Cache ML models
+    - name: Cache ML models (production + test models for nightly)
       uses: actions/cache@v4
       id: cache-models
       with:
@@ -53,9 +53,11 @@ jobs:
           ~/.cache/whisper
           ~/.local/share/spacy
           ~/.cache/huggingface
-        key: ml-models-${{ runner.os }}-v1
+        # Use separate cache key for nightly to include BOTH test and production models
+        # Regular CI uses 'ml-models-*' with only test models
+        key: ml-models-nightly-${{ runner.os }}-v2
         restore-keys: |
-          ml-models-${{ runner.os }}-
+          ml-models-nightly-${{ runner.os }}-
 
     - name: Install full dependencies (including ML)
       run: |

--- a/scripts/preload_ml_models.py
+++ b/scripts/preload_ml_models.py
@@ -427,20 +427,35 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.production:
-        print("Preloading PRODUCTION ML models...")
-        print("Models: Whisper base.en, BART-large-cnn, LED-large-16384, en_core_web_sm")
-        print("This will download and cache production models for nightly tests.")
+        print("Preloading ALL ML models (test + production) for nightly tests...")
+        print("")
+        print("Test models (for regular tests in nightly):")
+        print("  - Whisper: tiny.en")
+        print("  - Transformers: facebook/bart-base, allenai/led-base-16384")
+        print("")
+        print("Production models (for nightly-only tests):")
+        print("  - Whisper: base.en")
+        print("  - Transformers: facebook/bart-large-cnn, allenai/led-large-16384")
+        print("")
+        print("Common: en_core_web_sm (spaCy)")
         print("")
 
-        # Production models
-        # Note: Use "base.en" (not "base") because the code converts "base" to "base.en"
-        # for English language, and Whisper caches models with the exact name used
-        whisper_models = ["base.en"]  # Production Whisper model (English variant)
+        # Include BOTH test AND production models
+        # Nightly workflow runs both regular tests (need test models) and
+        # nightly-only tests (need production models)
+        whisper_models = [
+            "tiny.en",  # Test model (for regular tests in nightly)
+            "base.en",  # Production model (for nightly-only tests)
+        ]
         transformers_models = [
+            # Test models
+            config.TEST_DEFAULT_SUMMARY_MODEL,  # facebook/bart-base
+            config.TEST_DEFAULT_SUMMARY_REDUCE_MODEL,  # allenai/led-base-16384
+            # Production models
             "facebook/bart-large-cnn",  # Production MAP model
             "allenai/led-large-16384",  # Production REDUCE model (from issue #175)
         ]
-        spacy_models = ["en_core_web_sm"]  # Same for production
+        spacy_models = ["en_core_web_sm"]  # Same for both
 
         preload_whisper_models(whisper_models)
         print("")


### PR DESCRIPTION
## Problem

Nightly build was failing with:
- **17 skipped tests** - `facebook/bart-base` not cached
- **5 failed nightly tests** - `base.en` Whisper model not cached

Root cause: Nightly workflow used the same cache key (`ml-models-Linux-v1`) as main CI. Main CI runs more frequently and populates the cache with **test models only**. When nightly runs and gets a cache hit, it skips production model preload.

## Solution

1. **Separate cache key**: Use `ml-models-nightly-Linux-v2` for nightly workflow
2. **Include all models in production preload**: Update `--production` flag to preload BOTH test AND production models

### Models now cached for nightly:

| Type | Test Models | Production Models |
|------|-------------|-------------------|
| Whisper | `tiny.en` | `base.en` |
| Transformers | `facebook/bart-base`, `allenai/led-base-16384` | `facebook/bart-large-cnn`, `allenai/led-large-16384` |
| spaCy | `en_core_web_sm` | `en_core_web_sm` |

This ensures nightly has all models needed for:
- Regular tests (`not nightly` marker) - need test models
- Nightly-only tests (`nightly` marker) - need production models

## Testing

After merge, manually trigger nightly workflow to build fresh cache with all models.