### PR TITLE
fix: correct cache validation path conversion and remove restore-keys

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,10 +61,10 @@ jobs:
           ~/.cache/huggingface
         # Use separate cache key for nightly to include BOTH test and production models
         # Regular CI uses 'ml-models-*' with only test models
-        # v3: Added HF_HOME env vars to fix cache path mismatch
-        key: ml-models-nightly-${{ runner.os }}-v3
-        restore-keys: |
-          ml-models-nightly-${{ runner.os }}-
+        # v4: Fixed validation script (sed instead of tr), removed restore-keys to prevent
+        #     restoring corrupted old caches (v2/v3 had path issues)
+        # NOTE: No restore-keys! We want exact match or clean cache miss, not partial restore
+        key: ml-models-nightly-${{ runner.os }}-v4
 
     - name: Install full dependencies (including ML)
       run: |
@@ -139,8 +139,9 @@ jobs:
         echo "  Exists: $([ -d "$HF_CACHE" ] && echo "Yes" || echo "No")"
 
         for model in "facebook/bart-base" "allenai/led-base-16384" "facebook/bart-large-cnn" "allenai/led-large-16384"; do
-          # Convert model name to cache directory format
-          MODEL_DIR="models--$(echo $model | tr '/' '--')"
+          # Convert model name to cache directory format (facebook/bart-base -> models--facebook--bart-base)
+          # Note: tr doesn't work for string replacement, must use sed
+          MODEL_DIR="models--$(echo $model | sed 's|/|--|g')"
           MODEL_PATH="$HF_CACHE/$MODEL_DIR"
           if [ -d "$MODEL_PATH" ]; then
             SIZE=$(du -sh "$MODEL_PATH" | cut -f1)


### PR DESCRIPTION
## Problem

The validation step was checking wrong paths and the old corrupted cache was being restored.

## Root Causes

### Bug 1: `tr` doesn't do string replacement

```bash
# What we had:
MODEL_DIR="models--$(echo $model | tr '/' '--')"
# facebook/bart-base → facebook-bart-base (WRONG - single dash)

# What we need:
MODEL_DIR="models--$(echo $model | sed 's|/|--|g')"
# facebook/bart-base → facebook--bart-base (CORRECT - double dash)
```

The `tr` command does **character-by-character** replacement, not string replacement. So `tr '/' '--'` just replaces `/` with `-` (the second `-` is ignored).

### Bug 2: `restore-keys` restored corrupted v2 cache

The workflow had:
```yaml
key: ml-models-nightly-Linux-v3
restore-keys: |
  ml-models-nightly-Linux-
```

This meant: "if v3 doesn't exist, restore anything starting with `ml-models-nightly-Linux-`"

What happened:
1. v3 didn't exist → restored v2 (192 MB corrupted cache)
2. Preload step ran and downloaded ~8 GB of models correctly
3. Validation failed (due to Bug 1)
4. Job failed → **cache v3 was never saved** (GitHub only saves on success)

## Solution

1. **Fix path conversion**: Use `sed 's|/|--|g'` instead of `tr '/' '--'`
2. **Bump cache to v4**: New clean cache
3. **Remove `restore-keys`**: No fallback = clean miss → preload runs → validation passes → v4 saved

## Expected Flow After This Fix

```
1. Cache lookup: ml-models-nightly-Linux-v4 → MISS (doesn't exist yet)
2. Preload runs: Downloads all models (~8 GB)
3. Validation: models--facebook--bart-base found ✅
4. Tests run: No skipped tests
5. Job succeeds: v4 cache saved
6. Next run: Cache hit → skip preload → validation passes → fast execution
```