### PR TITLE
debug: add cache path debugging step to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -176,6 +176,58 @@ jobs:
     - name: Create reports directory
       run: mkdir -p reports
 
+    - name: Debug cache paths before tests
+      run: |
+        echo "🔍 Debugging cache paths..."
+        echo ""
+        echo "=== Environment Variables ==="
+        echo "HF_HOME=$HF_HOME"
+        echo "HF_HUB_CACHE=$HF_HUB_CACHE"
+        echo "TRANSFORMERS_CACHE=$TRANSFORMERS_CACHE"
+        echo "HOME=$HOME"
+        echo ""
+        echo "=== Cache directory contents ==="
+        ls -la $HOME/.cache/ || echo "No $HOME/.cache"
+        ls -la $HOME/.cache/huggingface/ || echo "No $HOME/.cache/huggingface"
+        ls -la $HOME/.cache/huggingface/hub/ || echo "No $HOME/.cache/huggingface/hub"
+        echo ""
+        echo "=== Python cache detection ==="
+        python3 -c "
+        import os
+        from pathlib import Path
+
+        print('--- Environment ---')
+        print(f'HF_HOME={os.environ.get(\"HF_HOME\", \"NOT SET\")}')
+        print(f'HF_HUB_CACHE={os.environ.get(\"HF_HUB_CACHE\", \"NOT SET\")}')
+        print(f'TRANSFORMERS_CACHE={os.environ.get(\"TRANSFORMERS_CACHE\", \"NOT SET\")}')
+
+        print()
+        print('--- huggingface_hub constants ---')
+        try:
+            from huggingface_hub import constants
+            print(f'HF_HUB_CACHE={constants.HF_HUB_CACHE}')
+            print(f'HF_HOME={constants.HF_HOME}')
+            hf_cache = Path(constants.HF_HUB_CACHE)
+            print(f'HF_HUB_CACHE exists: {hf_cache.exists()}')
+            if hf_cache.exists():
+                print(f'Contents: {list(hf_cache.iterdir())[:10]}')
+        except Exception as e:
+            print(f'Error: {e}')
+
+        print()
+        print('--- podcast_scraper cache_utils ---')
+        try:
+            from podcast_scraper.cache_utils import get_transformers_cache_dir, get_project_root
+            print(f'project_root={get_project_root()}')
+            cache_dir = get_transformers_cache_dir()
+            print(f'get_transformers_cache_dir()={cache_dir}')
+            print(f'cache_dir.exists()={cache_dir.exists()}')
+            if cache_dir.exists():
+                print(f'Contents: {list(cache_dir.iterdir())[:10]}')
+        except Exception as e:
+            print(f'Error: {e}')
+        "
+
     - name: Run comprehensive test suite with metrics
       run: |
         export PYTHONPATH="${PYTHONPATH}:$(pwd)"


### PR DESCRIPTION
## Purpose

This is a **debug PR** to diagnose why tests can't find cached models even though validation passes.

## The Mystery

1. ✅ Validation step shows cache exists: `/home/runner/.cache/huggingface/hub` with 11GB of models
2. ❌ Tests say: "Cache directory exists: False" for the same path
3. 🤔 Something is changing between validation and tests

## What This Debug PR Does

Adds a debugging step BEFORE tests run that prints:

1. **Environment variables:**
   - `HF_HOME`, `HF_HUB_CACHE`, `TRANSFORMERS_CACHE`, `HOME`

2. **Shell-level cache listing:**
   - `ls -la $HOME/.cache/`
   - `ls -la $HOME/.cache/huggingface/`
   - `ls -la $HOME/.cache/huggingface/hub/`

3. **Python-level cache detection:**
   - What `huggingface_hub.constants.HF_HUB_CACHE` returns
   - Whether that path exists
   - What `get_transformers_cache_dir()` returns
   - Whether that path exists
   - Directory contents if exists

## Expected Output

This will show us whether:
- The env vars are being inherited correctly
- The shell sees the cache directory
- Python's `huggingface_hub.constants` sees the correct path
- Our `get_transformers_cache_dir()` is returning the right path

Once we identify the mismatch, we can fix it properly.