### PR TITLE
fix: bump cache key to v5 (v4 was corrupted)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,10 +61,10 @@ jobs:
           ~/.cache/huggingface
         # Use separate cache key for nightly to include BOTH test and production models
         # Regular CI uses 'ml-models-*' with only test models
-        # v4: Fixed validation script (sed instead of tr), removed restore-keys to prevent
-        #     restoring corrupted old caches (v2/v3 had path issues)
+        # v5: v4 was saved with only Whisper models (192MB), before HF models downloaded
+        #     GitHub cache is immutable, so must bump to v5 to get fresh cache
         # NOTE: No restore-keys! We want exact match or clean cache miss, not partial restore
-        key: ml-models-nightly-${{ runner.os }}-v4
+        key: ml-models-nightly-${{ runner.os }}-v5
 
     - name: Install full dependencies (including ML)
       run: |


### PR DESCRIPTION
## Problem

Cache v4 was saved from a failed run BEFORE Hugging Face models were downloaded.

**Evidence:**
```
Cache Size: ~192 MB (201361938 B)
Cache restored from key: ml-models-nightly-Linux-v4
```

That 192 MB is ONLY Whisper models:
- tiny.en: 73 MB ✅
- base.en: 139 MB ✅
- **Hugging Face models: MISSING** ❌ (~8 GB never saved)

## Root Cause

**GitHub Actions cache is immutable.** Once a cache key exists, it can never be overwritten.

The v4 cache was created during a run that:
1. Downloaded Whisper models (fast)
2. Failed at some step BEFORE HF models were downloaded
3. GitHub's "Post" cache step saved whatever was present (only Whisper)

Every subsequent run:
1. Cache HIT for v4 → restore corrupt 192 MB cache
2. Preload step SKIPPED (cache hit)
3. Validation FAILS (no HF models)

## Fix

Bump cache key: `v4` → `v5`

This forces:
1. Cache MISS → preload runs → downloads ALL models (~8 GB)
2. Validation PASSES
3. Tests run without skips
4. Job succeeds → v5 cache saved correctly