### PR TITLE
docs: update README with stable/dev installation instructions and ignore WORKTREE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ data/results/
 # Local ML model cache - ignore all contents except README.md
 .cache/*
 !.cache/README.md
+
+# Worktree-specific files
+WORKTREE.md

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ and hands-on work with edge and cloud AI/ML technologies.
 
 ### Install
 
+#### Stable (recommended)
+
+Use the latest released version for normal usage.
+
+```bash
+git clone https://github.com/chipi/podcast_scraper.git
+cd podcast_scraper
+git checkout <latest-release-tag>   # e.g. v2.3.0
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[ml]"
+```
+
+#### Development (main)
+
+Use this if you are contributing or experimenting. This branch may contain
+unreleased changes.
+
 ```bash
 git clone https://github.com/chipi/podcast_scraper.git
 cd podcast_scraper
@@ -46,6 +63,8 @@ pip install -e ".[ml]"
 ```
 
 ### Run
+
+Replace `https://example.com/feed.xml` with your podcast's RSS feed URL.
 
 ```bash
 # Download existing transcripts
@@ -62,7 +81,7 @@ python3 -m podcast_scraper.cli https://example.com/feed.xml \
 ```
 
 Output is organized into `output/` with subdirectories: `transcripts/` for transcript files
-and `metadata/` for JSON/YAML metadata.
+and `metadata/` for JSON/YAML metadata. Use `--output-dir` to customize the location (default: `./output/`).
 
 ---
 
@@ -72,6 +91,8 @@ and `metadata/` for JSON/YAML metadata.
 | -------- | ----------- |
 | [CLI Reference](docs/api/CLI.md) | All command-line options |
 | [Configuration](docs/api/CONFIGURATION.md) | Config files and environment variables |
+| [Guides](docs/guides/) | Development, testing, and usage guides |
+| [Troubleshooting](docs/guides/TROUBLESHOOTING.md) | Common issues and solutions |
 | [Full Documentation](https://chipi.github.io/podcast_scraper/) | Complete docs site |
 
 **Contributing?** See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Cherry-picked commit from main branch that adds:
- Updated README with stable/dev installation instructions
- Added `WORKTREE.md` to `.gitignore` for worktree-specific files

## Changes

- **README.md**: Added clear installation instructions for stable (2.3.x) vs development (2.4.x) versions
- **.gitignore**: Added `WORKTREE.md` to ignore worktree-specific context files

## Context

This is part of the 2.4 stabilization effort. The changes help users understand which version to install and keep worktree-specific files local.

## PR Target

- Base: `release/2.4` (worktree stabilization branch)
- Type: Documentation + tooling improvement
- Safe for 2.4.x release