### PR TITLE
ci: add unit tests as gate for nightly-only-tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@
 # 1. lint, build, preload-ml-models-nightly run in parallel (no deps)
 # 2. security-quality and test-unit run in parallel (both gate: lint, build)
 # 3. test-integration and test-e2e run in parallel (both gate: preload-ml-models-nightly only)
-# 4. nightly-only-tests gates: test-integration, test-e2e
+# 4. nightly-only-tests gates: test-unit, test-integration, test-e2e
 # 5. nightly-metrics gates: security-quality, nightly-only-tests
 # 6. nightly-docs gates nightly-metrics (very last step, final validation)
 #
@@ -552,12 +552,12 @@ jobs:
 
   # ===========================================================================
   # Nightly-only tests - production models, full podcast suite
-  # Only runs after integration and E2E tests pass (expensive, run as final stage)
+  # Only runs after unit, integration and E2E tests pass (expensive, run as final stage)
   # ===========================================================================
   nightly-only-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 360  # 6 hours for production model tests
-    needs: [nightly-test-integration, nightly-test-e2e]
+    needs: [nightly-test-unit, nightly-test-integration, nightly-test-e2e]
     env:
       HF_HOME: /home/runner/.cache/huggingface
       HF_HUB_CACHE: /home/runner/.cache/huggingface/hub


### PR DESCRIPTION
## Summary

Adds `nightly-test-unit` as a dependency for `nightly-only-tests` to ensure unit tests pass before running expensive nightly-only tests.

## Changes

- Added `nightly-test-unit` to `nightly-only-tests` dependencies
- Updated dependency flow comment to reflect the change
- Updated job comment to clarify it runs after unit, integration, and E2E tests pass

## Rationale

Nightly-only tests are expensive (6 hour timeout, production models). It makes sense to ensure all test layers (unit, integration, E2E) pass before running these expensive tests.

## Type

- [x] CI/CD improvements