### PR TITLE
ci: add unit tests as gate for coverage-unified

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -3,7 +3,7 @@
 # 1. lint, build, preload-ml-models run in parallel (no deps)
 # 2. security-quality and test-unit run in parallel (both gate: lint, build)
 # 3. test-integration and test-e2e run in parallel (both gate: preload-ml-models only)
-# 4. coverage-unified gates: security-quality + all test jobs
+# 4. coverage-unified gates: security-quality + all test jobs (including test-unit)
 # 5. docs gates coverage-unified (very last step, final validation)
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
@@ -712,7 +712,7 @@ jobs:
   # Waits for all test jobs to complete, then combines their coverage reports
   coverage-unified:
     runs-on: ubuntu-latest
-    needs: [security-quality, test-integration, test-integration-fast, test-e2e, test-e2e-fast]  # Wait for security/quality and all test jobs
+    needs: [security-quality, test-unit, test-integration, test-integration-fast, test-e2e, test-e2e-fast]  # Wait for security/quality and all test jobs
     if: always()
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Adds `test-unit` as a dependency for `coverage-unified` to ensure unit tests pass before generating the unified coverage report.

## Changes

- Added `test-unit` to `coverage-unified` dependencies
- Updated dependency flow comment to reflect the change

## Rationale

The unified coverage report combines coverage from all test layers (unit, integration, E2E). It makes sense to ensure unit tests pass before generating this report, similar to how we gate `nightly-only-tests` with unit tests in the nightly workflow.

## Type

- [x] CI/CD improvements