### PR TITLE
ci: use hashFiles() for automatic ML model cache invalidation (#207)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -265,7 +265,8 @@ jobs:
           ~/.cache/whisper
           ~/.cache/huggingface
         # NOTE: spaCy removed - installed as pip package via .[ml]
-        key: ml-models-${{ runner.os }}-v1
+        # Cache key automatically invalidates when model definitions change
+        key: ml-models-${{ runner.os }}-${{ hashFiles('scripts/preload_ml_models.py', 'src/podcast_scraper/config.py') }}
         restore-keys: |
           ml-models-${{ runner.os }}-
     - name: Set up Python 3.11 (only if cache miss - needed for model download)
@@ -328,7 +329,8 @@ jobs:
           ~/.cache/whisper
           ~/.cache/huggingface
         # NOTE: spaCy removed - installed as pip package via .[ml]
-        key: ml-models-${{ runner.os }}-v1
+        # Cache key automatically invalidates when model definitions change
+        key: ml-models-${{ runner.os }}-${{ hashFiles('scripts/preload_ml_models.py', 'src/podcast_scraper/config.py') }}
         restore-keys: |
           ml-models-${{ runner.os }}-
     - name: Install full dependencies (including ML)
@@ -427,7 +429,8 @@ jobs:
           ~/.cache/whisper
           ~/.cache/huggingface
         # NOTE: spaCy removed - installed as pip package via .[ml]
-        key: ml-models-${{ runner.os }}-v1
+        # Cache key automatically invalidates when model definitions change
+        key: ml-models-${{ runner.os }}-${{ hashFiles('scripts/preload_ml_models.py', 'src/podcast_scraper/config.py') }}
         restore-keys: |
           ml-models-${{ runner.os }}-
     - name: Install dev dependencies with ML (pytest-socket for network guard)
@@ -518,7 +521,8 @@ jobs:
           ~/.cache/whisper
           ~/.cache/huggingface
         # NOTE: spaCy removed - installed as pip package via .[ml]
-        key: ml-models-${{ runner.os }}-v1
+        # Cache key automatically invalidates when model definitions change
+        key: ml-models-${{ runner.os }}-${{ hashFiles('scripts/preload_ml_models.py', 'src/podcast_scraper/config.py') }}
         restore-keys: |
           ml-models-${{ runner.os }}-
     - name: Install dev dependencies (pytest-socket for network guard)
@@ -614,7 +618,8 @@ jobs:
           ~/.cache/whisper
           ~/.cache/huggingface
         # NOTE: spaCy removed - installed as pip package via .[ml]
-        key: ml-models-${{ runner.os }}-v1
+        # Cache key automatically invalidates when model definitions change
+        key: ml-models-${{ runner.os }}-${{ hashFiles('scripts/preload_ml_models.py', 'src/podcast_scraper/config.py') }}
         restore-keys: |
           ml-models-${{ runner.os }}-
     - name: Install full dependencies (including ML)


### PR DESCRIPTION
## Summary

Replaces static version suffixes (`v1`) with `hashFiles()` to automatically invalidate ML model cache when model definitions change.

## Changes

- Updated 5 cache keys in `python-app.yml` to use `hashFiles()`
- Cache key now includes hash of `scripts/preload_ml_models.py` and `src/podcast_scraper/config.py`
- Matches the pattern already used in `nightly.yml`
- Added comment explaining automatic cache invalidation

## Benefits

- **Automatic**: Change model config → cache key changes → fresh cache
- **No manual version bumping**: Removes human error
- **Self-documenting**: Cache key shows what it depends on
- **Consistent**: Both workflows now use the same approach

## Files Updated

- ✅ `.github/workflows/python-app.yml` - Updated 5 cache keys
- ℹ️ `.github/workflows/nightly.yml` - Already uses `hashFiles()` (no changes needed)

## Testing

- YAML syntax validation passed
- Cache keys follow the same pattern as `nightly.yml` (already proven to work)

Fixes #207