### PR TITLE
docs: show deployment metadata in footer (#220)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,6 +79,24 @@ jobs:
       - name: Build MkDocs site
         run: |
           export PYTHONPATH="${PYTHONPATH}:$(pwd)"
+          # Generate deployment metadata
+          DEPLOY_TIME=$(date -u +"%Y-%m-%d %H:%M UTC")
+          DEPLOY_BRANCH="${{ github.ref_name }}"
+          DEPLOY_SHA="${{ github.sha }}"
+          DEPLOY_SHA_SHORT="${DEPLOY_SHA:0:7}"
+          DEPLOY_URL="https://github.com/${{ github.repository }}/commit/${DEPLOY_SHA}"
+          
+          # Create deploy-info.json
+          mkdir -p .build/site
+          cat > .build/site/deploy-info.json << EOF
+          {
+            "timestamp": "${DEPLOY_TIME}",
+            "branch": "${DEPLOY_BRANCH}",
+            "commit": "${DEPLOY_SHA_SHORT}",
+            "commitUrl": "${DEPLOY_URL}"
+          }
+          EOF
+          
           mkdocs build --strict
 
       - name: Download latest metrics from CI workflow

--- a/docs/javascripts/deploy-info.js
+++ b/docs/javascripts/deploy-info.js
@@ -1,0 +1,72 @@
+// Display deployment metadata in the footer
+(function() {
+  function loadDeployInfo() {
+    // Load deployment info JSON (absolute path from site root)
+    // Site URL is https://chipi.github.io/podcast_scraper/ so base path is /podcast_scraper/
+    fetch('/podcast_scraper/deploy-info.json')
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Deploy info not found');
+        }
+        return response.json();
+      })
+      .then(data => {
+        // Format timestamp for display
+        const timestamp = new Date(data.timestamp.replace(' UTC', 'Z'));
+        const formattedDate = timestamp.toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+          timeZone: 'UTC',
+          timeZoneName: 'short'
+        });
+
+        // Create deployment info element
+        const deployInfo = document.createElement('div');
+        deployInfo.className = 'md-footer-deploy-info';
+        deployInfo.innerHTML = `
+          <span class="deploy-label">📄 Docs updated:</span>
+          <span class="deploy-date">${formattedDate}</span>
+          <span class="deploy-separator">•</span>
+          <span class="deploy-branch">${data.branch}</span>
+          <span class="deploy-separator">@</span>
+          <a href="${data.commitUrl}" class="deploy-commit" target="_blank" rel="noopener">${data.commit}</a>
+        `;
+
+        // Find the footer and insert deployment info
+        const footer = document.querySelector('.md-footer');
+        if (footer) {
+          // Check if already added
+          if (footer.querySelector('.md-footer-deploy-info')) {
+            return;
+          }
+          // Insert before the footer inner content
+          const footerInner = footer.querySelector('.md-footer__inner');
+          if (footerInner) {
+            footerInner.insertBefore(deployInfo, footerInner.firstChild);
+          } else {
+            footer.insertBefore(deployInfo, footer.firstChild);
+          }
+        }
+      })
+      .catch(error => {
+        // Silently fail if deploy-info.json doesn't exist (e.g., local builds)
+        console.debug('Deployment info not available:', error);
+      });
+  }
+
+  // Try to load immediately if DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', loadDeployInfo);
+  } else {
+    loadDeployInfo();
+  }
+
+  // Also subscribe to Material theme navigation events if available
+  if (typeof document$ !== 'undefined') {
+    document$.subscribe(loadDeployInfo);
+  }
+})();
+

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,1 +1,56 @@
 /* Custom styles for documentation site */
+
+/* Deployment info in footer */
+.md-footer-deploy-info {
+  width: 100%;
+  padding: 0.5rem 0;
+  margin-bottom: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--md-default-fg-color--light);
+  text-align: center;
+  border-bottom: 1px solid var(--md-default-fg-color--lighter);
+}
+
+.md-footer-deploy-info .deploy-label {
+  font-weight: 500;
+  margin-right: 0.25rem;
+}
+
+.md-footer-deploy-info .deploy-date {
+  margin-right: 0.5rem;
+}
+
+.md-footer-deploy-info .deploy-separator {
+  margin: 0 0.5rem;
+  opacity: 0.6;
+}
+
+.md-footer-deploy-info .deploy-branch {
+  font-family: var(--md-code-font);
+  font-size: 0.875em;
+  background-color: var(--md-code-bg-color);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.125rem;
+  margin: 0 0.25rem;
+}
+
+.md-footer-deploy-info .deploy-commit {
+  font-family: var(--md-code-font);
+  font-size: 0.875em;
+  color: var(--md-primary-fg-color);
+  text-decoration: none;
+  margin-left: 0.25rem;
+}
+
+.md-footer-deploy-info .deploy-commit:hover {
+  text-decoration: underline;
+}
+
+/* Dark mode adjustments */
+[data-md-color-scheme="slate"] .md-footer-deploy-info {
+  color: var(--md-default-fg-color--light);
+}
+
+[data-md-color-scheme="slate"] .md-footer-deploy-info .deploy-branch {
+  background-color: var(--md-code-bg-color);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,6 +164,7 @@ extra_css:
 extra_javascript:
   - https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js
   - javascripts/mermaid.js
+  - javascripts/deploy-info.js
 extra:
   version:
     provider: manual


### PR DESCRIPTION
## Summary

Adds deployment metadata (timestamp, branch, commit SHA) to the documentation footer, so users can see when docs were last updated and which version they're viewing.

## Changes

- **Generate deployment metadata**: Added step in `docs.yml` workflow to create `deploy-info.json` with:
  - Deployment timestamp (UTC)
  - Branch name (e.g., `main`)
  - Commit SHA (short, 7 chars)
  - Commit URL (link to GitHub)
  
- **Display in footer**: Created `docs/javascripts/deploy-info.js` to:
  - Load `deploy-info.json` after page load
  - Display metadata in footer (non-intrusive)
  - Handle missing file gracefully (local builds)
  
- **Styling**: Added CSS in `docs/stylesheets/extra.css` for:
  - Clean, readable footer display
  - Responsive design
  - Dark mode support

- **Configuration**: Updated `mkdocs.yml` to include the new JavaScript file

## Display Format

The footer will show:
```
📄 Docs updated: Jan 6, 2025, 02:32 PM UTC • main @ e8d2d7f
```

Where `e8d2d7f` is a clickable link to the GitHub commit.

## Implementation Details

- Uses build-time injection (Option A from issue)
- JSON file generated during `mkdocs build`
- JavaScript loads asynchronously (doesn't block page load)
- Gracefully handles missing file (e.g., local builds)
- Works with Material for MkDocs theme

## Testing

- YAML syntax validation passed
- JavaScript follows Material theme patterns
- CSS uses Material theme variables for consistency

Fixes #220