### PR TITLE
refactor: remove hardcoded model names from codebase (#206)

### DIFF
--- a/scripts/preload_ml_models.py
+++ b/scripts/preload_ml_models.py
@@ -422,7 +422,11 @@ def main() -> None:
     parser.add_argument(
         "--production",
         action="store_true",
-        help="Preload production models (Whisper base.en, BART-large-cnn, LED-large-16384)",
+        help=(
+            f"Preload production models (Whisper {config.PROD_DEFAULT_WHISPER_MODEL}, "
+            f"BART {config.PROD_DEFAULT_SUMMARY_MODEL}, "
+            f"LED {config.PROD_DEFAULT_SUMMARY_REDUCE_MODEL})"
+        ),
     )
     args = parser.parse_args()
 
@@ -430,32 +434,38 @@ def main() -> None:
         print("Preloading ALL ML models (test + production) for nightly tests...")
         print("")
         print("Test models (for regular tests in nightly):")
-        print("  - Whisper: tiny.en")
-        print("  - Transformers: facebook/bart-base, allenai/led-base-16384")
+        print(f"  - Whisper: {config.TEST_DEFAULT_WHISPER_MODEL}")
+        print(
+            f"  - Transformers: {config.TEST_DEFAULT_SUMMARY_MODEL}, "
+            f"{config.TEST_DEFAULT_SUMMARY_REDUCE_MODEL}"
+        )
         print("")
         print("Production models (for nightly-only tests):")
-        print("  - Whisper: base.en")
-        print("  - Transformers: facebook/bart-large-cnn, allenai/led-large-16384")
+        print(f"  - Whisper: {config.PROD_DEFAULT_WHISPER_MODEL}")
+        print(
+            f"  - Transformers: {config.PROD_DEFAULT_SUMMARY_MODEL}, "
+            f"{config.PROD_DEFAULT_SUMMARY_REDUCE_MODEL}"
+        )
         print("")
-        print("Common: en_core_web_sm (spaCy)")
+        print(f"Common: {config.DEFAULT_NER_MODEL} (spaCy)")
         print("")
 
         # Include BOTH test AND production models
         # Nightly workflow runs both regular tests (need test models) and
         # nightly-only tests (need production models)
         whisper_models = [
-            "tiny.en",  # Test model (for regular tests in nightly)
-            "base.en",  # Production model (for nightly-only tests)
+            config.TEST_DEFAULT_WHISPER_MODEL,  # Test model (for regular tests in nightly)
+            config.PROD_DEFAULT_WHISPER_MODEL,  # Production model (for nightly-only tests)
         ]
         transformers_models = [
             # Test models
-            config.TEST_DEFAULT_SUMMARY_MODEL,  # facebook/bart-base
-            config.TEST_DEFAULT_SUMMARY_REDUCE_MODEL,  # allenai/led-base-16384
+            config.TEST_DEFAULT_SUMMARY_MODEL,
+            config.TEST_DEFAULT_SUMMARY_REDUCE_MODEL,
             # Production models
-            "facebook/bart-large-cnn",  # Production MAP model
-            "allenai/led-large-16384",  # Production REDUCE model (from issue #175)
+            config.PROD_DEFAULT_SUMMARY_MODEL,  # Production MAP model
+            config.PROD_DEFAULT_SUMMARY_REDUCE_MODEL,  # Production REDUCE model
         ]
-        spacy_models = ["en_core_web_sm"]  # Same for both
+        spacy_models = [config.DEFAULT_NER_MODEL]  # Same for both
 
         preload_whisper_models(whisper_models)
         print("")

--- a/src/podcast_scraper/config.py
+++ b/src/podcast_scraper/config.py
@@ -72,6 +72,14 @@ TEST_DEFAULT_SUMMARY_REDUCE_MODEL = (
 # Note: TEST_DEFAULT_NER_MODEL uses DEFAULT_NER_MODEL ("en_core_web_sm")
 # - same for tests and production
 
+# Production defaults (quality models for production use)
+# These are used in production deployments and nightly-only tests
+PROD_DEFAULT_WHISPER_MODEL = "base.en"  # Better quality than tiny.en, English-only
+PROD_DEFAULT_SUMMARY_MODEL = "facebook/bart-large-cnn"  # Large, ~2GB, best quality for production
+PROD_DEFAULT_SUMMARY_REDUCE_MODEL = (
+    "allenai/led-large-16384"  # Large, ~2.5GB, production quality for long-context
+)
+
 # OpenAI model defaults (Issue #191)
 # Test defaults: cheapest models for dev/testing (minimize API costs)
 # Production defaults: best quality/cost balance

--- a/tests/e2e/test_nightly_full_suite_e2e.py
+++ b/tests/e2e/test_nightly_full_suite_e2e.py
@@ -2,7 +2,8 @@
 
 This test suite runs comprehensive tests with:
 - All 5 podcasts (p01-p05) with all 3 episodes each (15 total episodes)
-- Production ML models: Whisper base, BART-large-cnn, LED-large-16384
+- Production ML models: PROD_DEFAULT_WHISPER_MODEL,
+  PROD_DEFAULT_SUMMARY_MODEL, PROD_DEFAULT_SUMMARY_REDUCE_MODEL
 - Full pipeline validation (transcription → NER → summarization → metadata)
 
 These tests are marked with @pytest.mark.nightly (NOT @pytest.mark.e2e) to
@@ -17,6 +18,7 @@ from pathlib import Path
 
 import pytest
 
+from podcast_scraper import config
 from tests.conftest import create_test_config
 
 
@@ -24,10 +26,10 @@ def create_nightly_config(output_dir: str, rss_url: str):
     """Create config for nightly tests with production models.
 
     Uses production ML models:
-    - Whisper: base (production quality)
-    - Summary MAP: facebook/bart-large-cnn (production quality)
-    - Summary REDUCE: allenai/led-large-16384 (production quality, from issue #175)
-    - NER: en_core_web_sm (same for tests and production)
+    - Whisper: PROD_DEFAULT_WHISPER_MODEL (production quality)
+    - Summary MAP: PROD_DEFAULT_SUMMARY_MODEL (production quality)
+    - Summary REDUCE: PROD_DEFAULT_SUMMARY_REDUCE_MODEL (production quality)
+    - NER: DEFAULT_NER_MODEL (same for tests and production)
 
     Args:
         output_dir: Output directory for test results
@@ -40,11 +42,11 @@ def create_nightly_config(output_dir: str, rss_url: str):
         rss_url=rss_url,
         output_dir=output_dir,
         transcribe_missing=True,
-        whisper_model="base",  # Production Whisper model
+        whisper_model=config.PROD_DEFAULT_WHISPER_MODEL,  # Production Whisper model
         generate_metadata=True,
         generate_summaries=True,
-        summary_model="facebook/bart-large-cnn",  # Production MAP model
-        summary_reduce_model="allenai/led-large-16384",  # Production REDUCE model
+        summary_model=config.PROD_DEFAULT_SUMMARY_MODEL,  # Production MAP model
+        summary_reduce_model=config.PROD_DEFAULT_SUMMARY_REDUCE_MODEL,  # Production REDUCE model
         auto_speakers=True,
         speaker_detector_provider="spacy",
         summary_provider="transformers",


### PR DESCRIPTION
## Summary

Adds production model constants to `config.py` and updates all references to use config constants instead of hardcoded model names, centralizing model configuration.

## Changes

### Phase 1: Add Production Constants to `config.py`

Added three new production model constants:
- `PROD_DEFAULT_WHISPER_MODEL = "base.en"`
- `PROD_DEFAULT_SUMMARY_MODEL = "facebook/bart-large-cnn"`
- `PROD_DEFAULT_SUMMARY_REDUCE_MODEL = "allenai/led-large-16384"`

These complement the existing test defaults and provide a single source of truth for production model names.

### Phase 2: Update References

1. **`scripts/preload_ml_models.py`**:
   - Updated `--production` help text to use config constants
   - Updated print statements to use f-strings with config values
   - Updated model lists to use `config.PROD_DEFAULT_*` constants
   - Updated spaCy model reference to use `config.DEFAULT_NER_MODEL`

2. **`tests/e2e/test_nightly_full_suite_e2e.py`**:
   - Updated `create_nightly_config()` to use production config constants
   - Updated docstring to reference config constants

## Benefits

- **DRY Principle**: All model names centralized in `config.py`
- **Easier Maintenance**: Change model name in one place, updates everywhere
- **Self-Documenting**: Clear separation between test and production defaults
- **Type Safety**: Constants can be imported and type-checked

## Files Updated

- ✅ `src/podcast_scraper/config.py` - Added production constants
- ✅ `scripts/preload_ml_models.py` - Updated to use constants
- ✅ `tests/e2e/test_nightly_full_suite_e2e.py` - Updated to use constants

## Testing

- All linting checks passed (black, isort, flake8, mypy)
- Code follows existing patterns and conventions

## Related

- Issue #207 - Uses these constants in cache key hashing (already implemented)
- Issue #191 - Standardized OpenAI model configuration (similar pattern)

Fixes #206