### PR TITLE
fix: use test Whisper model in integration and E2E tests

### DIFF
--- a/tests/e2e/test_edge_cases_e2e.py
+++ b/tests/e2e/test_edge_cases_e2e.py
@@ -24,7 +24,7 @@ PACKAGE_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 if PACKAGE_ROOT not in sys.path:
     sys.path.insert(0, PACKAGE_ROOT)
 
-from podcast_scraper import Config, run_pipeline, service
+from podcast_scraper import Config, config, run_pipeline, service
 
 
 @pytest.mark.e2e
@@ -39,6 +39,7 @@ class TestSpecialCharactersInTitles:
                 rss_url=e2e_server.urls.feed("edgecases"),
                 output_dir=tmpdir,
                 max_episodes=1,  # Only episode 1 has special chars
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should handle special characters gracefully
@@ -70,6 +71,7 @@ class TestUnicodeCharacters:
                 rss_url=e2e_server.urls.feed("edgecases"),
                 output_dir=tmpdir,
                 max_episodes=2,  # Episode 2 has Unicode
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should handle Unicode gracefully
@@ -109,6 +111,7 @@ class TestVeryLongTitles:
                 rss_url=e2e_server.urls.feed("edgecases"),
                 output_dir=tmpdir,
                 max_episodes=3,  # Episode 3 has very long title
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should handle long titles gracefully (may truncate filename)
@@ -147,6 +150,7 @@ class TestMissingOptionalFields:
                 rss_url=e2e_server.urls.feed("edgecases"),
                 output_dir=tmpdir,
                 max_episodes=4,  # Episode 4 has missing fields
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should handle missing fields gracefully
@@ -182,6 +186,7 @@ class TestEmptyDescriptions:
                 rss_url=e2e_server.urls.feed("edgecases"),
                 output_dir=tmpdir,
                 max_episodes=5,  # Episode 5 has empty description
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should handle empty description gracefully
@@ -215,6 +220,7 @@ class TestRelativeURLs:
                 rss_url=e2e_server.urls.feed("edgecases"),
                 output_dir=tmpdir,
                 max_episodes=6,  # Episode 6 has relative URLs
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should resolve relative URLs correctly
@@ -250,6 +256,7 @@ class TestAllEdgeCasesTogether:
                 rss_url=e2e_server.urls.feed("edgecases"),
                 output_dir=tmpdir,
                 max_episodes=6,  # All edge case episodes
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should handle all edge cases gracefully
@@ -284,6 +291,7 @@ class TestAllEdgeCasesTogether:
                 output_dir=tmpdir,
                 max_episodes=2,  # First 2 episodes (avoid episode 3 with long title)
                 generate_metadata=True,
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should handle edge cases with metadata
@@ -330,6 +338,7 @@ class TestAllEdgeCasesTogether:
                 rss_url=e2e_server.urls.feed("edgecases"),
                 output_dir=tmpdir,
                 max_episodes=2,  # First 2 episodes (avoid episode 3 with long title)
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run service - should handle edge cases gracefully

--- a/tests/e2e/test_error_handling_e2e.py
+++ b/tests/e2e/test_error_handling_e2e.py
@@ -40,6 +40,7 @@ class TestHTTPErrorHandling:
                 rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
                 output_dir=tmpdir,
                 max_episodes=1,
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should raise ValueError when RSS feed fails
@@ -59,6 +60,7 @@ class TestHTTPErrorHandling:
                 rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
                 output_dir=tmpdir,
                 max_episodes=1,
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should raise ValueError after retries fail
@@ -79,6 +81,7 @@ class TestHTTPErrorHandling:
                 rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
                 output_dir=tmpdir,
                 max_episodes=1,
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should handle 404 gracefully
@@ -101,6 +104,7 @@ class TestHTTPErrorHandling:
                 rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
                 output_dir=tmpdir,
                 max_episodes=1,
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should handle 500 gracefully (with retries)
@@ -148,6 +152,7 @@ class TestHTTPErrorHandling:
                 rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
                 output_dir=tmpdir,
                 max_episodes=1,
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run service - should handle error gracefully
@@ -177,6 +182,7 @@ class TestInvalidRSSFeed:
                 rss_url=invalid_url,
                 output_dir=tmpdir,
                 max_episodes=1,
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should raise ValueError when RSS feed fails
@@ -193,6 +199,7 @@ class TestInvalidRSSFeed:
                 rss_url=invalid_url,
                 output_dir=tmpdir,
                 max_episodes=1,
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should raise ValueError when RSS feed fails
@@ -213,6 +220,7 @@ class TestInvalidConfig:
                 rss_url="not-a-valid-url",
                 output_dir=tmpdir,
                 max_episodes=1,
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should raise ValueError when URL is invalid
@@ -226,6 +234,7 @@ class TestInvalidConfig:
                 rss_url="not-a-valid-url",
                 output_dir=tmpdir,
                 max_episodes=1,
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run service - should handle invalid config gracefully
@@ -251,6 +260,7 @@ class TestPartialFailureHandling:
                 rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
                 output_dir=tmpdir,
                 max_episodes=3,  # Process multiple episodes
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should handle partial failures
@@ -274,6 +284,7 @@ class TestPartialFailureHandling:
                 rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
                 output_dir=tmpdir,
                 max_episodes=3,  # Process multiple episodes
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Run pipeline - should handle mixed scenarios

--- a/tests/integration/test_workflow_integration.py
+++ b/tests/integration/test_workflow_integration.py
@@ -246,6 +246,8 @@ class TestIntegrationMain(unittest.TestCase):
                             "10",
                             "--log-level",
                             "DEBUG",
+                            "--whisper-model",
+                            config.TEST_DEFAULT_WHISPER_MODEL.replace(".en", ""),
                         ]
                     )
                     self.assertEqual(exit_code, 0)
@@ -553,6 +555,7 @@ class TestLibraryAPIIntegration(unittest.TestCase):
             cfg = podcast_scraper.Config(
                 rss_url=rss_url,
                 output_dir=self.temp_dir,
+                whisper_model=config.TEST_DEFAULT_WHISPER_MODEL,
             )
 
             # Should handle empty feed gracefully


### PR DESCRIPTION
## Problem
Integration and E2E tests were failing because they defaulted to `base.en` (production Whisper model) but CI only preloads `tiny.en` (test model). This caused 2 integration test failures and 18 E2E test failures.

## Solution
- Added `whisper_model=config.TEST_DEFAULT_WHISPER_MODEL` to all `Config()` calls in integration and E2E tests
- Added `--whisper-model` CLI argument to `test_config_override_precedence_integration`
- Imported `config` module in `test_edge_cases_e2e.py`

## Changes
- `tests/integration/test_workflow_integration.py`: Fixed 2 tests
- `tests/e2e/test_edge_cases_e2e.py`: Fixed 9 Config() calls
- `tests/e2e/test_error_handling_e2e.py`: Fixed 9 Config() calls

## Validation
- ✅ `make ci-fast`: Passed
- ✅ `make test-integration`: 297 passed
- ✅ `make test-e2e`: 124 passed
- ✅ All pre-commit checks passed

All tests now consistently use the test model (`tiny.en`) that is preloaded in CI.