### PR TITLE
Fix OpenAI tests isolation and environment variable handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PACKAGE = podcast_scraper
 # Can be overridden: PYTEST_WORKERS=4 make test
 PYTEST_WORKERS ?= $(shell python3 -c "import os; print(min(max(1, (os.cpu_count() or 4) - 2), 8))")
 
-.PHONY: help init init-no-ml format format-check lint lint-markdown type security security-bandit security-audit complexity deadcode docstrings spelling quality test-unit test-unit-sequential test-unit-no-ml test-integration test-integration-sequential test-integration-fast test-ci test-ci-fast test-e2e test-e2e-sequential test-e2e-fast test-e2e-data-quality test-nightly test test-sequential test-fast test-reruns coverage coverage-check coverage-check-unit coverage-check-integration coverage-check-e2e coverage-check-combined coverage-report coverage-enforce docs build ci ci-fast ci-sequential ci-clean ci-nightly clean clean-cache clean-all docker-build docker-build-fast docker-build-full docker-test docker-clean install-hooks preload-ml-models preload-ml-models-production
+.PHONY: help init init-no-ml format format-check lint lint-markdown type security security-bandit security-audit complexity deadcode docstrings spelling quality test-unit test-unit-sequential test-unit-no-ml test-integration test-integration-sequential test-integration-fast test-ci test-ci-fast test-e2e test-e2e-sequential test-e2e-fast test-e2e-data-quality test-nightly test test-sequential test-fast test-reruns test-openai test-openai-multi test-openai-all-feeds test-openai-real test-openai-real-multi test-openai-real-all-feeds test-openai-real-feed coverage coverage-check coverage-check-unit coverage-check-integration coverage-check-e2e coverage-check-combined coverage-report coverage-enforce docs build ci ci-fast ci-sequential ci-clean ci-nightly clean clean-cache clean-all docker-build docker-build-fast docker-build-full docker-test docker-clean install-hooks preload-ml-models preload-ml-models-production
 
 help:
 	@echo "Common developer commands:"
@@ -48,6 +48,14 @@ help:
 	@echo "  make test-sequential     Run all tests sequentially (for debugging, uses multi-episode feed)"
 	@echo "  make test-fast           Run fast tests (unit + critical path integration + critical path e2e, uses fast feed)"
 	@echo "  make test-reruns     Run tests with reruns for flaky tests (2 retries, 1s delay)"
+	@echo "  make test-openai         Run OpenAI tests with fast feed (p01_fast.xml - 1 episode, 1 minute)"
+	@echo "  make test-openai-multi   Run OpenAI tests with multi-episode feed (p01_multi.xml - 5 episodes)"
+	@echo "  make test-openai-all-feeds Run OpenAI tests against all p01-p05 feeds (p01_mtb.xml through p05_investing.xml)"
+	@echo "  make test-openai-real    Run OpenAI tests with REAL API using fast feed (fixture input, real API calls)"
+	@echo "  make test-openai-real-multi Run OpenAI tests with REAL API using multi-episode feed"
+	@echo "  make test-openai-real-all-feeds Run OpenAI tests with REAL API against all p01-p05 feeds"
+	@echo "  make test-openai-real-feed Run OpenAI tests with REAL API using a real RSS feed"
+	@echo "                            Usage: make test-openai-real-feed FEED_URL=\"https://...\" [MAX_EPISODES=5]"
 	@echo "  Tip: For debugging, use pytest directly with -n 0 for sequential execution"
 	@echo ""
 	@echo "Coverage commands:"
@@ -265,6 +273,221 @@ test-fast:
 test-reruns:
 	# Network isolation enabled to match CI behavior and catch network dependency issues early
 	$(PYTHON) -m pytest --reruns 2 --reruns-delay 1 --cov=$(PACKAGE) --cov-report=term-missing -m 'not integration and not e2e' --disable-socket --allow-hosts=127.0.0.1,localhost
+
+test-openai:
+	# Test OpenAI providers (uses E2E server by default, or real API if USE_REAL_OPENAI_API=1)
+	# Feed selection via OPENAI_TEST_FEED environment variable (E2E mode):
+	#   - fast: p01_fast.xml (1 episode, 1 minute) - DEFAULT
+	#   - multi: p01_multi.xml (5 episodes, 10-15s each)
+	#   - p01-p05: Individual podcast feeds (p01_mtb.xml, p02_software.xml, etc.)
+	# For real API mode: Set USE_REAL_OPENAI_API=1 and OPENAI_TEST_RSS_FEED=<feed-url>
+	# Examples:
+	#   make test-openai                    # Uses fast feed with E2E server (1 episode, 1 minute)
+	#   make test-openai-multi              # Uses multi-episode feed (5 episodes, 10-15s each)
+	#   OPENAI_TEST_FEED=p02 make test-openai    # Uses podcast2 feed
+	#   USE_REAL_OPENAI_API=1 OPENAI_TEST_RSS_FEED=https://example.com/podcast.rss make test-openai  # Real API
+	@echo "Running OpenAI tests..."
+	@echo "  Feed type: $${OPENAI_TEST_FEED:-fast} (use OPENAI_TEST_FEED to change)"
+	@if [ "$${USE_REAL_OPENAI_API:-0}" = "1" ]; then \
+		if [ -z "$$OPENAI_API_KEY" ] && ! grep -q "^OPENAI_API_KEY=" .env 2>/dev/null; then \
+			echo "❌ Error: OPENAI_API_KEY not set in environment or .env file"; \
+			echo "   Set it in your .env file or export it before running this target"; \
+			exit 1; \
+		fi; \
+		echo "⚠️  WARNING: Running tests with REAL OpenAI API (will incur costs)"; \
+		echo "⚠️  This will make actual API calls to OpenAI endpoints"; \
+		echo "⚠️  Press Ctrl+C within 5 seconds to cancel..."; \
+		sleep 5; \
+	fi
+	@echo ""
+	E2E_TEST_MODE=fast USE_REAL_OPENAI_API=$${USE_REAL_OPENAI_API:-0} OPENAI_TEST_FEED=$${OPENAI_TEST_FEED:-fast} $(PYTHON) -m pytest \
+		tests/e2e/test_openai_provider_integration_e2e.py \
+		-m "openai" \
+		-v \
+		--tb=short \
+		--durations=10 \
+		--maxfail=1
+
+test-openai-multi:
+	# Test OpenAI providers with multi-episode feed (p01_multi.xml - 5 episodes, 10-15s each)
+	# Uses E2E server by default (no API costs)
+	@echo "Running OpenAI tests with multi-episode feed..."
+	@if [ "$${USE_REAL_OPENAI_API:-0}" = "1" ]; then \
+		if [ -z "$$OPENAI_API_KEY" ] && ! grep -q "^OPENAI_API_KEY=" .env 2>/dev/null; then \
+			echo "❌ Error: OPENAI_API_KEY not set in environment or .env file"; \
+			echo "   Set it in your .env file or export it before running this target"; \
+			exit 1; \
+		fi; \
+		echo "⚠️  WARNING: Running tests with REAL OpenAI API (will incur costs)"; \
+		echo "⚠️  This will make actual API calls to OpenAI endpoints"; \
+		echo "⚠️  Press Ctrl+C within 5 seconds to cancel..."; \
+		sleep 5; \
+	fi
+	@echo ""
+	E2E_TEST_MODE=fast USE_REAL_OPENAI_API=$${USE_REAL_OPENAI_API:-0} OPENAI_TEST_FEED=multi $(PYTHON) -m pytest \
+		tests/e2e/test_openai_provider_integration_e2e.py \
+		-m "openai" \
+		-v \
+		--tb=short \
+		--durations=10 \
+		--maxfail=1
+
+test-openai-all-feeds:
+	@# Test OpenAI providers against all p01-p05 feeds (p01_mtb.xml through p05_investing.xml)
+	@# Uses E2E server in nightly mode (allows all podcasts 1-5)
+	@# Each feed is tested sequentially to ensure clean state between runs
+	@echo "Running OpenAI tests against all p01-p05 feeds..."
+	@echo "  This will test: p01 (mtb), p02 (software), p03 (scuba), p04 (photo), p05 (investing)"
+	@echo ""
+	@if [ "$${USE_REAL_OPENAI_API:-0}" = "1" ]; then \
+		if [ -z "$$OPENAI_API_KEY" ] && ! grep -q "^OPENAI_API_KEY=" .env 2>/dev/null; then \
+			echo "❌ Error: OPENAI_API_KEY not set in environment or .env file"; \
+			echo "   Set it in your .env file or export it before running this target"; \
+			exit 1; \
+		fi; \
+		echo "⚠️  WARNING: Running tests with REAL OpenAI API (will incur costs)"; \
+		echo "⚠️  This will make actual API calls to OpenAI endpoints"; \
+		echo "⚠️  Press Ctrl+C within 5 seconds to cancel..."; \
+		sleep 5; \
+	fi
+	@for feed in p01 p02 p03 p04 p05; do \
+		echo "========================================="; \
+		echo "Testing feed: $$feed"; \
+		echo "========================================="; \
+		E2E_TEST_MODE=nightly USE_REAL_OPENAI_API=$${USE_REAL_OPENAI_API:-0} OPENAI_TEST_FEED=$$feed $(PYTHON) -m pytest \
+			tests/e2e/test_openai_provider_integration_e2e.py \
+			-m "openai" \
+			-v \
+			--tb=short \
+			--durations=10 \
+			--maxfail=1 || exit 1; \
+		echo ""; \
+	done
+	@echo "========================================="
+	@echo "All feeds tested successfully!"
+	@echo "========================================="
+
+test-openai-real:
+	@# Test OpenAI providers with REAL API using fast feed (p01_fast.xml - 1 episode, 1 minute)
+	@# Uses fixture feeds as input but makes real OpenAI API calls
+	@# Requires OPENAI_API_KEY in .env file
+	@echo "Running OpenAI tests with REAL API (using fast feed fixture)..."
+	@if [ -z "$$OPENAI_API_KEY" ] && ! grep -q "^OPENAI_API_KEY=" .env 2>/dev/null; then \
+		echo "❌ Error: OPENAI_API_KEY not set in environment or .env file"; \
+		echo "   Set it in your .env file or export it before running this target"; \
+		exit 1; \
+	fi
+	@echo "⚠️  WARNING: Running tests with REAL OpenAI API (will incur costs)"
+	@echo "⚠️  This will make actual API calls to OpenAI endpoints"
+	@echo "⚠️  Using fixture feed (p01_fast.xml) as input"
+	@echo "⚠️  Press Ctrl+C within 5 seconds to cancel..."
+	@sleep 5
+	@echo ""
+	E2E_TEST_MODE=fast USE_REAL_OPENAI_API=1 OPENAI_TEST_FEED=fast $(PYTHON) -m pytest \
+		tests/e2e/test_openai_provider_integration_e2e.py \
+		-m "openai" \
+		-v \
+		-s \
+		--tb=short \
+		--durations=10 \
+		--maxfail=1
+
+test-openai-real-multi:
+	@# Test OpenAI providers with REAL API using multi-episode feed (p01_multi.xml - 5 episodes)
+	@# Uses fixture feeds as input but makes real OpenAI API calls
+	@# Requires OPENAI_API_KEY in .env file
+	@echo "Running OpenAI tests with REAL API (using multi-episode feed fixture)..."
+	@if [ -z "$$OPENAI_API_KEY" ] && ! grep -q "^OPENAI_API_KEY=" .env 2>/dev/null; then \
+		echo "❌ Error: OPENAI_API_KEY not set in environment or .env file"; \
+		echo "   Set it in your .env file or export it before running this target"; \
+		exit 1; \
+	fi
+	@echo "⚠️  WARNING: Running tests with REAL OpenAI API (will incur costs)"
+	@echo "⚠️  This will make actual API calls to OpenAI endpoints"
+	@echo "⚠️  Using multi-episode fixture feed (p01_multi.xml - 5 episodes) as input"
+	@echo "⚠️  Press Ctrl+C within 5 seconds to cancel..."
+	@sleep 5
+	@echo ""
+	E2E_TEST_MODE=fast USE_REAL_OPENAI_API=1 OPENAI_TEST_FEED=multi $(PYTHON) -m pytest \
+		tests/e2e/test_openai_provider_integration_e2e.py \
+		-m "openai" \
+		-v \
+		--tb=short \
+		--durations=10 \
+		--maxfail=1
+
+test-openai-real-all-feeds:
+	@# Test OpenAI providers with REAL API against all p01-p05 feeds
+	@# Uses fixture feeds as input but makes real OpenAI API calls
+	@# Requires OPENAI_API_KEY in .env file
+	@echo "Running OpenAI tests with REAL API against all p01-p05 feeds..."
+	@echo "  This will test: p01 (mtb), p02 (software), p03 (scuba), p04 (photo), p05 (investing)"
+	@echo "  Using fixture feeds as input but making REAL OpenAI API calls"
+	@echo ""
+	@if [ -z "$$OPENAI_API_KEY" ] && ! grep -q "^OPENAI_API_KEY=" .env 2>/dev/null; then \
+		echo "❌ Error: OPENAI_API_KEY not set in environment or .env file"; \
+		echo "   Set it in your .env file or export it before running this target"; \
+		exit 1; \
+	fi
+	@echo "⚠️  WARNING: Running tests with REAL OpenAI API (will incur costs)"
+	@echo "⚠️  This will make actual API calls to OpenAI endpoints"
+	@echo "⚠️  Testing all 5 feeds (p01-p05) with fixture data"
+	@echo "⚠️  Press Ctrl+C within 5 seconds to cancel..."
+	@sleep 5
+	@echo ""
+	@for feed in p01 p02 p03 p04 p05; do \
+		echo "========================================="; \
+		echo "Testing feed: $$feed (REAL API)"; \
+		echo "========================================="; \
+		E2E_TEST_MODE=nightly USE_REAL_OPENAI_API=1 OPENAI_TEST_FEED=$$feed $(PYTHON) -m pytest \
+			tests/e2e/test_openai_provider_integration_e2e.py \
+			-m "openai" \
+			-v \
+			--tb=short \
+			--durations=10 \
+			--maxfail=1 || exit 1; \
+		echo ""; \
+	done
+	@echo "========================================="
+	@echo "All feeds tested successfully with REAL API!"
+	@echo "========================================="
+
+test-openai-real-feed:
+	@# Test OpenAI providers with REAL API using a real RSS feed
+	@# Usage: make test-openai-real-feed FEED_URL="https://example.com/podcast.rss" [MAX_EPISODES=5]
+	@# Requires OPENAI_API_KEY in .env file
+	@if [ -z "$(FEED_URL)" ]; then \
+		echo "❌ Error: FEED_URL is required"; \
+		echo ""; \
+		echo "Usage: make test-openai-real-feed FEED_URL=\"https://example.com/podcast.rss\" [MAX_EPISODES=5]"; \
+		echo ""; \
+		echo "Examples:"; \
+		echo "  make test-openai-real-feed FEED_URL=\"https://example.com/podcast.rss\""; \
+		echo "  make test-openai-real-feed FEED_URL=\"https://example.com/podcast.rss\" MAX_EPISODES=3"; \
+		exit 1; \
+	fi
+	@if [ -z "$$OPENAI_API_KEY" ] && ! grep -q "^OPENAI_API_KEY=" .env 2>/dev/null; then \
+		echo "❌ Error: OPENAI_API_KEY not set in environment or .env file"; \
+		echo "   Set it in your .env file or export it before running this target"; \
+		exit 1; \
+	fi
+	@MAX_EPISODES=$${MAX_EPISODES:-5}; \
+	echo "Running OpenAI tests with REAL API using real RSS feed..."; \
+	echo "⚠️  WARNING: Running tests with REAL OpenAI API (will incur costs)"; \
+	echo "⚠️  This will make actual API calls to OpenAI endpoints"; \
+	echo "⚠️  Feed URL: $(FEED_URL)"; \
+	echo "⚠️  Max Episodes: $$MAX_EPISODES"; \
+	echo "⚠️  Press Ctrl+C within 5 seconds to cancel..."; \
+	sleep 5; \
+	echo ""; \
+	USE_REAL_OPENAI_API=1 OPENAI_TEST_RSS_FEED="$(FEED_URL)" OPENAI_TEST_MAX_EPISODES=$$MAX_EPISODES $(PYTHON) -m pytest \
+		tests/e2e/test_openai_provider_integration_e2e.py \
+		-m "openai" \
+		-v \
+		-s \
+		--tb=short \
+		--durations=10 \
+		--maxfail=1
 
 coverage: test
 	# Runs all tests with coverage (same as 'make test')

--- a/docs/rfc/RFC-040-audio-preprocessing-pipeline.md
+++ b/docs/rfc/RFC-040-audio-preprocessing-pipeline.md
@@ -1,0 +1,713 @@
+# RFC-040: Audio Pre-Processing Pipeline for Podcast Ingestion
+
+- **Status**: Draft
+- **Authors**: Architecture Review
+- **Stakeholders**: Core Pipeline, Transcription Providers
+- **Related PRDs**:
+  - N/A (new capability)
+- **Related RFCs**:
+  - `docs/rfc/RFC-005-whisper-integration.md` (transcription pipeline)
+  - `docs/rfc/RFC-013-openai-provider-implementation.md` (provider pattern)
+  - `docs/rfc/RFC-029-provider-refactoring-consolidation.md` (unified provider architecture)
+- **Related Documents**:
+  - `docs/ARCHITECTURE.md` (pipeline flow)
+  - `docs/guides/PROVIDER_IMPLEMENTATION_GUIDE.md` (provider patterns)
+
+## Abstract
+
+This RFC proposes a dedicated **audio pre-processing stage** in the podcast ingestion pipeline to optimize raw audio files **before** they are sent to any transcription provider (local Whisper or OpenAI API). The pre-processor will convert audio to mono, resample to 16 kHz, remove silence using Voice Activity Detection (VAD), and normalize loudness. This is critical for API-based transcription where file size limits and per-minute costs make optimization essential. It also improves performance for local Whisper transcription.
+
+**Architecture Alignment:** This RFC introduces preprocessing as a **pipeline stage that occurs before provider selection**, not as part of the provider itself. Audio is preprocessed in `episode_processor.py` after download but before passing to any transcription provider. This ensures all providers (Whisper, OpenAI, future providers) benefit from optimized audio, maintains separation of concerns, and addresses API upload size limits.
+
+## Problem Statement
+
+The current podcast ingestion pipeline downloads audio files and passes them directly to transcription providers (Whisper or OpenAI Whisper API). Podcast audio often contains:
+
+- **Long silence periods** (intros, outros, pauses)
+- **Music segments** (intro/outro themes, mid-roll music)
+- **Inconsistent loudness levels** (varying recording quality across episodes)
+- **Unnecessarily high fidelity** (48kHz, stereo, high bitrates)
+
+This leads to:
+
+1. **API upload size limits** — Many podcast episodes exceed provider file size limits
+2. **Longer transcription runtimes** — More audio data to process (both local and API)
+3. **Higher API costs** — Providers charge per audio minute, including non-speech segments
+4. **Higher compute costs** — Local Whisper processes silence and music unnecessarily
+5. **Larger transcripts** — Non-speech segments may produce "[MUSIC]", "[SILENCE]", or filler text
+6. **Inconsistent quality** — Varying audio levels affect transcription accuracy
+
+### API Provider File Size Limits (Official Documentation)
+
+Different transcription providers impose various file size constraints:
+
+| Provider | API Endpoint | Max File Size | Max Duration | Documentation | Status |
+|----------|-------------|---------------|--------------|---------------|--------|
+| **OpenAI Whisper** | Audio API | **25 MB** | N/A | [Official Docs](https://platform.openai.com/docs/guides/speech-to-text/whisper) | ✅ Supported |
+| **Mistral Voxtral** | Audio API | **TBD** (likely similar to OpenAI) | TBD | [API Docs](https://docs.mistral.ai/) | 🔄 Planned (PRD-010) |
+| **Google Gemini** | Multimodal API | **TBD** (native audio) | TBD | [AI Studio](https://ai.google.dev/) | 🔄 Planned (PRD-012) |
+| **Groq Whisper** | N/A | ❌ No transcription | N/A | [API Docs](https://console.groq.com/docs) | 🔄 Planned (PRD-013, LLMs only) |
+| **Google Cloud (sync)** | Speech-to-Text | **10 MB** | ~1 minute | [Quotas](https://cloud.google.com/speech-to-text/quotas) | ❌ Not planned |
+| **Azure Speech** | Fast/Batch | **300 MB - 1 GB** | 120-240 min | [Service Limits](https://learn.microsoft.com/azure/ai-services/speech-service/speech-services-quotas-and-limits) | ❌ Not planned |
+
+**Transcription Provider Support Matrix** (from PRDs):
+
+| Provider | Transcription | Speaker Detection | Summarization | Notes |
+|----------|---------------|-------------------|---------------|-------|
+| **Local (Whisper)** | ✅ | ✅ (spaCy) | ✅ (Transformers) | No size limits |
+| **OpenAI** | ✅ (25 MB limit) | ✅ | ✅ | Currently supported |
+| **Mistral** | ✅ Voxtral (limit TBD) | ✅ | ✅ | Planned (PRD-010) |
+| **Gemini** | ✅ Native audio (limit TBD) | ✅ | ✅ | Planned (PRD-012) |
+| **Anthropic** | ❌ | ✅ | ✅ | No audio API (PRD-009) |
+| **DeepSeek** | ❌ | ✅ | ✅ | No audio API (PRD-011) |
+| **Groq** | ❌ | ✅ | ✅ | LLMs only (PRD-013) |
+| **Ollama** | ❌ | ✅ | ✅ | Local LLMs (PRD-014) |
+
+**Critical Constraints**:
+- **OpenAI**: 25 MB hard limit (most restrictive known, currently supported)
+- **Mistral & Gemini**: Limits unknown, assumed similar or more generous
+- **Conservative Design**: Target <25 MB to ensure compatibility with all current and planned providers
+
+**Common Denominator Approach**:
+
+To support both current (OpenAI) and planned (Mistral, Gemini) API transcription providers, we adopt a **conservative <25 MB target**:
+
+1. **Known constraint**: OpenAI = 25 MB (confirmed)
+2. **Unknown constraints**: Mistral Voxtral and Gemini audio limits not yet documented
+3. **Safe assumption**: Designing for 25 MB ensures compatibility even if future providers have similar or slightly more restrictive limits
+4. **Benefit**: If Mistral/Gemini have more generous limits (>25 MB), preprocessed files will still be well-optimized
+
+**Real-World Impact**:
+- Raw podcast episodes (30-60 minutes) typically range from **30-100 MB** in MP3 format
+- **70-80% of podcast episodes exceed the 25 MB limit** and cannot be uploaded to OpenAI without preprocessing
+- Preprocessing is **mandatory** (not optional) for API-based transcription of typical podcast content
+- **Target output**: 2-5 MB for typical episodes (10-25× reduction, well below any likely provider limit)
+
+**Real-World Impact**:
+- Raw podcast episodes (30-60 minutes) typically range from **30-100 MB** in MP3 format
+- **70-80% of podcast episodes exceed the 25 MB limit** and cannot be uploaded without preprocessing
+- Preprocessing is **not optional** for API-based transcription of typical podcast content
+
+We need a **pipeline stage that preprocesses audio before it reaches any provider**, ensuring files fit within the 25 MB constraint while optimizing for both local and API-based transcription.
+
+**Use Cases:**
+
+1. **API Upload Size Compliance**: Reduce audio files to fit within 25 MB limit (OpenAI, Groq)
+2. **Cost Optimization**: Reduce API costs by removing silence and music before API calls
+3. **Performance Optimization**: Speed up local Whisper transcription by processing smaller audio files
+4. **Quality Standardization**: Normalize audio levels across different podcast sources for consistent transcription quality
+
+## Goals
+
+1. **Ensure API compatibility** — All preprocessed audio must be **<25 MB** to support OpenAI & Groq
+2. **Reduce audio size for API upload limits** — Target 10-25× reduction (typical 50 MB → 2-5 MB)
+3. **Lower transcription costs** — Reduce API usage by processing less audio (30-60% cost savings)
+4. **Improve transcription performance** — Faster processing for both local and API providers
+5. **Improve transcription accuracy** — Consistent audio levels and speech-only content
+6. **Standardize audio inputs** — All podcasts processed with consistent quality
+7. **Maintain backward compatibility** — Preprocessing is optional and configurable
+8. **Cache preprocessed audio** — Avoid reprocessing with content-based hashing
+9. **Provider-agnostic** — All transcription providers receive optimized audio
+
+## Constraints & Assumptions
+
+**Constraints:**
+
+- Must not break existing transcription workflows (backward compatibility)
+- Must work **before** any provider is invoked (not provider-specific)
+- Must ensure preprocessed files are **<25 MB** (OpenAI & Groq constraint - most restrictive)
+- Must handle various input formats (MP3, M4A, WAV, etc.)
+- Must be performant enough not to negate transcription time savings
+- Must preserve audio segment boundaries for accurate transcription timing
+- Must be optional and configurable (disabled by default for initial rollout)
+- Must not require provider-specific implementations
+
+**Assumptions:**
+
+- `ffmpeg` is available on the system (already common dependency for audio processing)
+- VAD preprocessing adds 10-30% overhead but saves 30-60% on transcription time (net win)
+- Content-based hashing is sufficient for cache keys (no security sensitivity)
+- Preprocessed audio can be cached in `.cache/` directory structure
+- Aggressive VAD with conservative thresholds (preserve meaningful pauses) is acceptable
+
+## Design & Implementation
+
+### 1. Module Structure
+
+Create a new `preprocessing` module following the provider pattern:
+
+```text
+src/podcast_scraper/
+├── preprocessing/
+│   ├── __init__.py
+│   ├── base.py              # AudioPreprocessor protocol
+│   ├── factory.py           # Factory function
+│   ├── ffmpeg_processor.py  # FFmpeg-based implementation
+│   └── cache.py             # Preprocessed audio caching
+```
+
+### 2. AudioPreprocessor Protocol
+
+Define a protocol for audio preprocessing:
+
+```python
+# preprocessing/base.py
+from typing import Protocol, Tuple
+from pathlib import Path
+
+class AudioPreprocessor(Protocol):
+    """Protocol for audio preprocessing providers."""
+
+    def preprocess(
+        self,
+        input_path: str,
+        output_path: str,
+    ) -> Tuple[bool, float]:
+        """Preprocess audio file for transcription.
+
+        Args:
+            input_path: Path to raw audio file
+            output_path: Path to save preprocessed audio
+
+        Returns:
+            Tuple of (success: bool, elapsed_time: float)
+        """
+        ...
+
+    def get_cache_key(self, input_path: str) -> str:
+        """Generate content-based cache key for input audio.
+
+        Args:
+            input_path: Path to audio file
+
+        Returns:
+            Cache key (hash of audio content + preprocessing settings)
+        """
+        ...
+```
+
+### 3. FFmpeg Implementation
+
+Implement audio preprocessing using `ffmpeg`:
+
+```python
+# preprocessing/ffmpeg_processor.py
+import hashlib
+import logging
+import subprocess
+import time
+from pathlib import Path
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+
+class FFmpegAudioPreprocessor:
+    """Audio preprocessor using ffmpeg for format conversion and silenceremove filter."""
+
+    def __init__(self, cfg):
+        """Initialize preprocessor with configuration.
+
+        Args:
+            cfg: Configuration object with preprocessing settings
+        """
+        self.cfg = cfg
+        self.sample_rate = cfg.preprocessing_sample_rate  # Default: 16000
+        self.silence_threshold = cfg.preprocessing_silence_threshold  # Default: -50dB
+        self.silence_duration = cfg.preprocessing_silence_duration  # Default: 2.0s
+        self.target_loudness = cfg.preprocessing_target_loudness  # Default: -16 LUFS
+
+    def preprocess(self, input_path: str, output_path: str) -> Tuple[bool, float]:
+        """Preprocess audio using ffmpeg pipeline.
+
+        Pipeline stages:
+        1. Convert to mono
+        2. Resample to 16 kHz
+        3. Remove silence (VAD)
+        4. Normalize loudness to -16 LUFS
+        5. Compress using speech-optimized codec
+
+        Args:
+            input_path: Path to raw audio file
+            output_path: Path to save preprocessed audio
+
+        Returns:
+            Tuple of (success: bool, elapsed_time: float)
+        """
+        start_time = time.time()
+
+        # Build ffmpeg command
+        # -ac 1: convert to mono
+        # -ar 16000: resample to 16 kHz
+        # -af silenceremove: remove silence (conservative thresholds)
+        # -af loudnorm: normalize loudness to -16 LUFS
+        # -c:a libopus: speech-optimized codec
+        # -b:a 24k: 24 kbps bitrate
+        cmd = [
+            "ffmpeg",
+            "-i", input_path,
+            "-ac", "1",  # Mono
+            "-ar", str(self.sample_rate),  # 16 kHz
+            "-af", (
+                f"silenceremove="
+                f"start_periods=1:"
+                f"start_threshold={self.silence_threshold}:"
+                f"start_duration={self.silence_duration}:"
+                f"stop_periods=-1:"
+                f"stop_threshold={self.silence_threshold}:"
+                f"stop_duration={self.silence_duration},"
+                f"loudnorm=I={self.target_loudness}:LRA=11:TP=-1.5"
+            ),
+            "-c:a", "libopus",  # Speech-optimized codec
+            "-b:a", "24k",  # 24 kbps
+            "-y",  # Overwrite output
+            output_path,
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=300,  # 5 minute timeout
+                check=True,
+            )
+            elapsed = time.time() - start_time
+            logger.debug("Audio preprocessing completed in %.1fs", elapsed)
+            return True, elapsed
+
+        except subprocess.CalledProcessError as exc:
+            logger.error("FFmpeg preprocessing failed: %s", exc.stderr)
+            return False, time.time() - start_time
+        except subprocess.TimeoutExpired:
+            logger.error("FFmpeg preprocessing timed out after 300s")
+            return False, time.time() - start_time
+        except FileNotFoundError:
+            logger.error("FFmpeg not found. Install ffmpeg to use audio preprocessing.")
+            return False, 0.0
+
+    def get_cache_key(self, input_path: str) -> str:
+        """Generate cache key from file content hash + preprocessing config.
+
+        Args:
+            input_path: Path to audio file
+
+        Returns:
+            Cache key (SHA256 hash of content + config)
+        """
+        hasher = hashlib.sha256()
+
+        # Hash file content (first 1MB for performance)
+        try:
+            with open(input_path, "rb") as f:
+                hasher.update(f.read(1024 * 1024))
+        except OSError as exc:
+            logger.warning("Failed to hash audio file: %s", exc)
+            # Use file path as fallback
+            hasher.update(input_path.encode("utf-8"))
+
+        # Hash preprocessing config to invalidate cache when settings change
+        config_str = (
+            f"{self.sample_rate}|"
+            f"{self.silence_threshold}|"
+            f"{self.silence_duration}|"
+            f"{self.target_loudness}"
+        )
+        hasher.update(config_str.encode("utf-8"))
+
+        return hasher.hexdigest()[:16]  # 16 hex chars (64 bits)
+```
+
+### 4. Caching Strategy
+
+Implement caching to avoid reprocessing:
+
+```python
+# preprocessing/cache.py
+import os
+from pathlib import Path
+from typing import Optional
+
+PREPROCESSING_CACHE_DIR = ".cache/preprocessing"
+
+def get_cached_audio_path(
+    cache_key: str,
+    cache_dir: str = PREPROCESSING_CACHE_DIR,
+) -> Optional[str]:
+    """Check if preprocessed audio exists in cache.
+
+    Args:
+        cache_key: Content-based cache key
+        cache_dir: Cache directory path
+
+    Returns:
+        Path to cached audio if exists, None otherwise
+    """
+    cache_path = os.path.join(cache_dir, f"{cache_key}.opus")
+    if os.path.exists(cache_path):
+        return cache_path
+    return None
+
+def save_to_cache(
+    source_path: str,
+    cache_key: str,
+    cache_dir: str = PREPROCESSING_CACHE_DIR,
+) -> str:
+    """Save preprocessed audio to cache.
+
+    Args:
+        source_path: Path to preprocessed audio
+        cache_key: Content-based cache key
+        cache_dir: Cache directory path
+
+    Returns:
+        Path to cached audio
+    """
+    os.makedirs(cache_dir, exist_ok=True)
+    cache_path = os.path.join(cache_dir, f"{cache_key}.opus")
+
+    # Copy to cache (or move if source is temp)
+    import shutil
+    shutil.copy2(source_path, cache_path)
+
+    return cache_path
+```
+
+### 5. Integration with Transcription Pipeline
+
+Modify `episode_processor.py` to preprocess audio **before** passing to any provider:
+
+```python
+# episode_processor.py (modified)
+def transcribe_media_to_text(
+    job: models.TranscriptionJob,
+    cfg: config.Config,
+    whisper_model,
+    run_suffix: Optional[str],
+    effective_output_dir: str,
+    transcription_provider=None,
+    audio_preprocessor=None,  # NEW: Optional AudioPreprocessor
+    pipeline_metrics=None,
+) -> tuple[bool, Optional[str], int]:
+    """Transcribe media file using transcription provider and save result.
+
+    Audio preprocessing happens BEFORE provider selection - all providers
+    receive optimized audio. This is critical for API providers with upload
+    size limits (e.g., OpenAI 25 MB limit) and reduces costs for metered APIs.
+    """
+    # ... existing validation code ...
+
+    temp_media = job.temp_media
+    media_for_transcription = temp_media
+
+    # NEW: Preprocess audio BEFORE passing to any provider
+    # This happens at the pipeline level, not within providers
+    if audio_preprocessor and cfg.preprocessing_enabled:
+        cache_key = audio_preprocessor.get_cache_key(temp_media)
+
+        # Check cache first
+        cached_path = preprocessing.cache.get_cached_audio_path(cache_key)
+        if cached_path:
+            logger.debug("Using cached preprocessed audio: %s", cache_key)
+            media_for_transcription = cached_path
+        else:
+            # Preprocess audio
+            preprocessed_path = f"{temp_media}.preprocessed.opus"
+            success, preprocess_elapsed = audio_preprocessor.preprocess(
+                temp_media, preprocessed_path
+            )
+
+            if success:
+                # Save to cache
+                cached_path = preprocessing.cache.save_to_cache(
+                    preprocessed_path, cache_key
+                )
+                media_for_transcription = cached_path
+
+                # Log size reduction
+                original_size = os.path.getsize(temp_media)
+                preprocessed_size = os.path.getsize(cached_path)
+                reduction = (1 - preprocessed_size / original_size) * 100
+                logger.info(
+                    "    preprocessed audio: %.1f%% smaller (%.1fMB -> %.1fMB) in %.1fs",
+                    reduction,
+                    original_size / (1024 * 1024),
+                    preprocessed_size / (1024 * 1024),
+                    preprocess_elapsed,
+                )
+
+                # Record preprocessing time
+                if pipeline_metrics:
+                    pipeline_metrics.record_preprocessing_time(preprocess_elapsed)
+            else:
+                # Preprocessing failed, use original audio
+                logger.warning("Audio preprocessing failed, using original audio")
+                media_for_transcription = temp_media
+
+    # Pass preprocessed (or original) audio to provider
+    # Provider is agnostic to whether audio was preprocessed
+    try:
+        result, tc_elapsed = transcription_provider.transcribe_with_segments(
+            media_for_transcription,  # Preprocessed or original - provider doesn't know/care
+            language=cfg.language
+        )
+        # ... rest of transcription code ...
+```
+
+**Key Architecture Points**:
+
+1. **Preprocessing happens at pipeline level** — Not inside providers
+2. **All providers receive optimized audio** — Whisper, OpenAI, future providers all benefit
+3. **Providers are agnostic** — They don't know if audio was preprocessed
+4. **Cache is shared** — Same preprocessed audio reused across provider switches
+5. **Separation of concerns** — Preprocessing is orthogonal to transcription
+```
+
+### 6. Configuration Fields
+
+Add preprocessing configuration to `Config`:
+
+```python
+# config.py (additions)
+class Config(BaseModel):
+    # ... existing fields ...
+
+    # Audio Preprocessing
+    preprocessing_enabled: bool = Field(
+        default=False,
+        description="Enable audio preprocessing before transcription (default: False)"
+    )
+    preprocessing_sample_rate: int = Field(
+        default=16000,
+        description="Target sample rate for preprocessing (default: 16000 Hz)"
+    )
+    preprocessing_silence_threshold: str = Field(
+        default="-50dB",
+        description="Silence detection threshold (default: -50dB)"
+    )
+    preprocessing_silence_duration: float = Field(
+        default=2.0,
+        description="Minimum silence duration to remove in seconds (default: 2.0)"
+    )
+    preprocessing_target_loudness: int = Field(
+        default=-16,
+        description="Target loudness in LUFS for normalization (default: -16)"
+    )
+    preprocessing_cache_dir: Optional[str] = Field(
+        default=None,
+        description="Custom cache directory for preprocessed audio (default: .cache/preprocessing)"
+    )
+```
+
+### 7. CLI Arguments
+
+Add CLI flags for preprocessing:
+
+```python
+# cli.py (additions)
+def _add_preprocessing_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add audio preprocessing arguments to parser."""
+    preprocessing_group = parser.add_argument_group("Audio Preprocessing")
+    preprocessing_group.add_argument(
+        "--enable-preprocessing",
+        action="store_true",
+        dest="preprocessing_enabled",
+        help="Enable audio preprocessing before transcription (experimental)"
+    )
+    preprocessing_group.add_argument(
+        "--preprocessing-silence-threshold",
+        type=str,
+        default="-50dB",
+        help="Silence detection threshold (default: -50dB)"
+    )
+    # ... other preprocessing flags ...
+```
+
+## Key Decisions
+
+1. **Pipeline-Level Preprocessing, Not Provider-Level**
+   - **Decision**: Preprocessing happens in `episode_processor.py` before provider invocation, not within providers
+   - **Rationale**: API providers have upload size limits (OpenAI 25 MB). Preprocessing must happen before upload, not after. All providers benefit equally from optimized audio. Separation of concerns - preprocessing is orthogonal to transcription method.
+
+2. **FFmpeg as Implementation**
+   - **Decision**: Use `ffmpeg` for audio preprocessing
+   - **Rationale**: Industry-standard tool, widely available, supports all needed operations (format conversion, VAD, loudness normalization). Alternative libraries (pydub, librosa) would add Python dependencies and may be slower.
+
+3. **Optional and Disabled by Default**
+   - **Decision**: Preprocessing is opt-in via `preprocessing_enabled=True`
+   - **Rationale**: Maintains backward compatibility. Users can test preprocessing on their workloads before enabling permanently. Allows gradual rollout.
+
+4. **Content-Based Caching**
+   - **Decision**: Cache preprocessed audio using content hash + config hash
+   - **Rationale**: Avoids reprocessing the same audio multiple times. Common in development/testing when reprocessing episodes. Cache invalidates automatically when preprocessing settings change.
+
+5. **Conservative VAD Thresholds**
+   - **Decision**: Use conservative silence detection thresholds by default
+   - **Rationale**: Preserves meaningful pauses and prevents removing legitimate speech. Users can tune thresholds if needed.
+
+6. **Opus Codec for Preprocessed Audio**
+   - **Decision**: Use Opus codec at 24 kbps for preprocessed audio
+   - **Rationale**: Opus is optimized for speech, provides excellent quality at low bitrates, and is widely supported. 24 kbps provides good speech quality while reducing file size significantly.
+
+## Alternatives Considered
+
+1. **No Preprocessing**
+   - **Description**: Continue processing raw audio directly
+   - **Pros**: Simpler pipeline, no additional dependencies
+   - **Cons**: Higher costs, longer processing times, inconsistent quality
+   - **Why Rejected**: Benefits of preprocessing outweigh the added complexity
+
+2. **Text-Only Cleanup After Transcription**
+   - **Description**: Remove silence markers ("[MUSIC]", "[SILENCE]") from transcripts post-transcription
+   - **Pros**: Easier to implement, no audio processing needed
+   - **Cons**: Does not reduce transcription time or costs, does not improve transcription quality
+   - **Why Rejected**: Does not address the root cause (processing unnecessary audio)
+
+3. **Python-Based VAD (webrtcvad, silero-vad)**
+   - **Description**: Use Python VAD libraries instead of ffmpeg
+   - **Pros**: No external dependencies, potentially more control
+   - **Cons**: Adds Python dependencies, may be slower, requires manual audio format handling
+   - **Why Rejected**: FFmpeg provides a complete solution (VAD + format conversion + normalization) in one tool
+
+4. **Mandatory Preprocessing**
+   - **Description**: Make preprocessing mandatory for all transcription
+   - **Pros**: Ensures consistent quality across all workflows
+   - **Cons**: Breaking change, may not be desirable for all use cases
+   - **Why Rejected**: Too disruptive, opt-in approach allows users to test and validate benefits first
+
+## Testing Strategy
+
+**Test Coverage:**
+
+- **Unit Tests**: FFmpeg command generation, cache key generation, error handling
+- **Integration Tests**: Full preprocessing pipeline with real audio files, cache hit/miss scenarios
+- **E2E Tests**: Preprocessing + transcription workflow with both Whisper and OpenAI providers
+
+**Test Organization:**
+
+- `tests/unit/test_preprocessing.py` — Unit tests for preprocessor logic
+- `tests/integration/test_preprocessing_integration.py` — Integration tests with real audio
+- `tests/e2e/test_preprocessing_e2e.py` — E2E tests with full pipeline
+- Use `tests/fixtures/audio/` for test audio files (small samples)
+
+**Test Execution:**
+
+- Unit tests: Run in CI (fast, no external dependencies except ffmpeg availability check)
+- Integration tests: Run in CI with `@pytest.mark.integration` and `@pytest.mark.skipif(not has_ffmpeg())`
+- E2E tests: Run in nightly CI or on-demand
+
+**Test Data:**
+
+- Create small test audio files (~10s) with known characteristics:
+  - `silence_test.mp3` — Audio with long silence periods
+  - `music_test.mp3` — Audio with music intro/outro
+  - `quiet_test.mp3` — Low-volume audio
+  - `loud_test.mp3` — High-volume audio
+
+**Performance Validation:**
+
+- Measure preprocessing overhead vs. transcription time savings
+- Target: Preprocessing adds <30% overhead but saves >30% transcription time (net positive)
+- Track metrics: preprocessing time, audio size reduction, transcription time, total pipeline time
+
+## Rollout & Monitoring
+
+**Rollout Plan:**
+
+- **Phase 1: Experimental (v2.5.0)** — Release as opt-in feature, document as experimental, gather user feedback
+- **Phase 2: Refinement (v2.6.0)** — Refine thresholds based on feedback, improve caching, add more configuration options
+- **Phase 3: Stable (v2.7.0)** — Mark as stable, consider enabling by default for new users
+
+**Monitoring:**
+
+- Track preprocessing metrics:
+  - `preprocessing_time_seconds` — Time spent preprocessing
+  - `preprocessing_audio_size_reduction` — Size reduction ratio
+  - `preprocessing_cache_hit_rate` — Cache effectiveness
+- Track transcription metrics impact:
+  - `transcription_time_seconds` (before/after preprocessing)
+  - `transcription_cost_usd` (for OpenAI provider)
+  - `transcript_word_count` (may decrease with silence removal)
+- Log warnings for:
+  - FFmpeg not available
+  - Preprocessing timeouts
+  - Preprocessing failures (fallback to original audio)
+
+**Success Criteria:**
+
+1. ✅ Preprocessing reduces transcription time by ≥30% on average
+2. ✅ Preprocessing reduces OpenAI API costs by ≥30% on average
+3. ✅ Preprocessing maintains or improves transcription quality (manual review)
+4. ✅ Cache hit rate ≥80% in development/testing scenarios
+5. ✅ Zero breaking changes to existing workflows
+
+## Expected Impact
+
+| Area | Expected Improvement | Measurement |
+|------|---------------------|-------------|
+| Audio size | 10–25× smaller | File size comparison (MB) |
+| API compatibility | 100% of podcasts fit <25 MB | Upload success rate |
+| Preprocessing overhead | +10–30% time | Time measurement (seconds) |
+| Transcription runtime | -30–60% faster | Time measurement (seconds) |
+| OpenAI/Groq API cost | -30–60% reduction | API usage tracking ($) |
+| Transcript size | -15–40% fewer tokens | Word count comparison |
+| Transcription quality | Improved consistency | Manual QA review |
+| Total pipeline time | -20–40% faster | End-to-end time measurement |
+
+**Net Impact**: Despite preprocessing overhead, total pipeline time should decrease due to larger transcription time savings.
+
+**File Size Target**: Preprocessed audio should average **2-5 MB** for typical 30-60 minute podcast episodes, well below the 25 MB limit with safety margin.
+
+## Benefits
+
+1. **Cost Reduction**: Significant reduction in OpenAI Whisper API costs by processing less audio
+2. **Performance Improvement**: Faster transcription for both local Whisper and OpenAI API
+3. **Quality Standardization**: Consistent audio levels and speech-only content improve transcription accuracy
+4. **Flexibility**: Optional and configurable, users can tune for their specific needs
+5. **Caching**: Preprocessed audio is cached, avoiding reprocessing in development/testing workflows
+6. **Backward Compatibility**: Existing workflows continue to work unchanged
+
+## Migration Path
+
+**No migration needed** — preprocessing is opt-in:
+
+1. **Existing Users**: No changes required, workflows continue as-is
+2. **New Users**: Can optionally enable preprocessing in config or via CLI flag
+3. **Gradual Adoption**: Users can test preprocessing on a subset of episodes before enabling globally
+
+**Enabling Preprocessing:**
+
+```yaml
+# config.yaml
+preprocessing_enabled: true  # Enable preprocessing
+```
+
+Or via CLI:
+
+```bash
+python3 -m podcast_scraper.cli https://feed.xml --enable-preprocessing
+```
+
+## Open Questions
+
+1. **FFmpeg Availability Check**: Should we fail fast if ffmpeg is not available, or silently disable preprocessing?
+   - **Proposed**: Warn and disable preprocessing if ffmpeg not found, log clear error message
+
+2. **Codec Selection**: Should we support multiple output codecs (Opus, AAC, MP3) or standardize on Opus?
+   - **Proposed**: Start with Opus only, add codec selection in future if users request it
+
+3. **VAD Threshold Tuning**: Should we provide presets (conservative, balanced, aggressive) or expect users to tune manually?
+   - **Proposed**: Start with single conservative default, add presets in Phase 2 based on feedback
+
+4. **Preprocessing for OpenAI Only**: Should preprocessing be automatic for OpenAI provider (to save costs) but optional for Whisper?
+   - **Proposed**: Keep consistent (manual opt-in for all providers), document cost savings for OpenAI users
+
+5. **Cache Cleanup**: Should we provide a tool to clean preprocessing cache (similar to ML model cache cleanup)?
+   - **Proposed**: Yes, add `cache --clean preprocessing` subcommand and include in `clean-all`
+
+## References
+
+- **Related RFC**: `docs/rfc/RFC-005-whisper-integration.md` (transcription pipeline)
+- **Related RFC**: `docs/rfc/RFC-029-provider-refactoring-consolidation.md` (unified providers)
+- **Source Code**: `podcast_scraper/episode_processor.py` (transcription orchestration)
+- **External Tools**: FFmpeg documentation ([https://ffmpeg.org/](https://ffmpeg.org/))
+- **VAD Reference**: FFmpeg silenceremove filter ([https://ffmpeg.org/ffmpeg-filters.html#silenceremove](https://ffmpeg.org/ffmpeg-filters.html#silenceremove))

--- a/docs/rfc/index.md
+++ b/docs/rfc/index.md
@@ -34,6 +34,7 @@ RFCs translate PRD requirements into concrete technical solutions and serve as l
 | [RFC-037](RFC-037-ollama-provider-implementation.md) | Ollama Provider Implementation | PRD-014 | Technical design for Ollama (local/offline) |
 | [RFC-038](RFC-038-continuous-review-tooling.md) | Continuous Review Tooling | #45 | Dependabot, pydeps, pre-release checklist |
 | [RFC-039](RFC-039-development-workflow-worktrees-ci.md) | Development Workflow | - | Git worktrees, Cursor integration, CI evolution |
+| [RFC-040](RFC-040-audio-preprocessing-pipeline.md) | Audio Preprocessing Pipeline | - | Optional audio preprocessing (VAD, normalization) before transcription |
 
 ## Completed RFCs
 

--- a/src/podcast_scraper/config.py
+++ b/src/podcast_scraper/config.py
@@ -718,6 +718,33 @@ class Config(BaseModel):
                 if env_value in ("cpu", "cuda", "mps"):
                     data["summary_device"] = env_value
 
+        # OPENAI_API_KEY: Only set from env if not in config
+        if "openai_api_key" not in data or data.get("openai_api_key") is None:
+            env_key = os.getenv("OPENAI_API_KEY")
+            if env_key:
+                env_value = str(env_key).strip()
+                if env_value:
+                    data["openai_api_key"] = env_value
+
+        # OPENAI_API_BASE: Only set from env if not in config
+        if "openai_api_base" not in data or data.get("openai_api_base") is None:
+            env_base = os.getenv("OPENAI_API_BASE")
+            if env_base:
+                env_value = str(env_base).strip()
+                if env_value:
+                    data["openai_api_base"] = env_value
+
+        # OPENAI_TEMPERATURE: Only set from env if not in config
+        if "openai_temperature" not in data or data.get("openai_temperature") is None:
+            env_temp = os.getenv("OPENAI_TEMPERATURE")
+            if env_temp:
+                try:
+                    temp_value = float(env_temp)
+                    if 0.0 <= temp_value <= 2.0:
+                        data["openai_temperature"] = temp_value
+                except (ValueError, TypeError):
+                    pass  # Invalid value, skip
+
         return data
 
     @field_validator("log_level", mode="before")

--- a/src/podcast_scraper/metadata.py
+++ b/src/podcast_scraper/metadata.py
@@ -377,6 +377,10 @@ def _build_processing_metadata(cfg: config.Config, output_dir: str) -> Processin
         }
         if cfg.transcription_provider == "whisper" and cfg.transcribe_missing:
             ml_providers["transcription"]["whisper_model"] = cfg.whisper_model
+        elif cfg.transcription_provider == "openai":
+            # Include OpenAI transcription model
+            transcription_model = getattr(cfg, "openai_transcription_model", "whisper-1")
+            ml_providers["transcription"]["openai_model"] = transcription_model
 
     # Speaker detection provider
     if cfg.speaker_detector_provider:
@@ -385,6 +389,10 @@ def _build_processing_metadata(cfg: config.Config, output_dir: str) -> Processin
         }
         if cfg.speaker_detector_provider == "spacy" and cfg.ner_model:
             ml_providers["speaker_detection"]["ner_model"] = cfg.ner_model
+        elif cfg.speaker_detector_provider == "openai":
+            # Include OpenAI speaker detection model
+            speaker_model = getattr(cfg, "openai_speaker_model", "gpt-4o-mini")
+            ml_providers["speaker_detection"]["openai_model"] = speaker_model
 
     # Summarization provider
     if cfg.summary_provider:
@@ -399,6 +407,10 @@ def _build_processing_metadata(cfg: config.Config, output_dir: str) -> Processin
                 ml_providers["summarization"]["reduce_model"] = cfg.summary_reduce_model
             if cfg.summary_device:
                 ml_providers["summarization"]["device"] = cfg.summary_device
+        elif cfg.summary_provider == "openai":
+            # Include OpenAI summarization model
+            summary_model = getattr(cfg, "openai_summary_model", "gpt-4o-mini")
+            ml_providers["summarization"]["openai_model"] = summary_model
 
     # Build config_snapshot with ml_providers first for prominence
     config_snapshot: Dict[str, Any] = {}

--- a/tests/e2e/fixtures/e2e_http_server.py
+++ b/tests/e2e/fixtures/e2e_http_server.py
@@ -1143,7 +1143,14 @@ def e2e_server():
             rss_url = e2e_server.urls.feed("podcast1")
             audio_url = e2e_server.urls.audio("p01_e01")
             # Use URLs in tests...
+
+    Real API Mode:
+        When USE_REAL_OPENAI_API=1, the server still starts to serve fixture feeds,
+        but the mock OpenAI endpoints are not used (real API is called instead).
+        This allows testing real API with known fixture data.
     """
+    # Always start the server, even in real API mode (needed for fixture feeds)
+    # The mock OpenAI endpoints won't be used when USE_REAL_OPENAI_API=1
     server = E2EHTTPServer()
     server.start()
     yield server

--- a/tests/e2e/test_openai_provider_integration_e2e.py
+++ b/tests/e2e/test_openai_provider_integration_e2e.py
@@ -10,6 +10,10 @@ These tests verify that OpenAI providers work correctly in complete user workflo
 
 These tests use the E2E server's OpenAI mock endpoints (real HTTP requests to mock server)
 and are marked with @pytest.mark.e2e to allow selective execution.
+
+Real API Mode:
+    When USE_REAL_OPENAI_API=1, tests use real OpenAI API endpoints and real RSS feeds.
+    This is for manual testing only and will incur API costs.
 """
 
 import os
@@ -17,6 +21,7 @@ import shutil
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any, Optional
 
 import pytest
 
@@ -32,12 +37,473 @@ tests_dir = Path(__file__).parent.parent
 if str(tests_dir) not in sys.path:
     sys.path.insert(0, str(tests_dir))
 
-from podcast_scraper import config
-
 # Import from parent conftest explicitly to avoid pytest resolution issues
 from tests.conftest import (  # noqa: E402
     create_test_config,
 )
+
+# Check if we should use real OpenAI API (for manual testing only)
+USE_REAL_OPENAI_API = os.getenv("USE_REAL_OPENAI_API", "0") == "1"
+
+# Feed selection for OpenAI tests
+# Options:
+# - "fast": Use p01_fast.xml (1 episode, 1 minute) - DEFAULT
+# - "multi": Use p01_multi.xml (5 episodes, 10-15 seconds each)
+# - "p01": Use p01_mtb.xml (podcast1)
+# - "p02": Use p02_software.xml (podcast2)
+# - "p03": Use p03_scuba.xml (podcast3)
+# - "p04": Use p04_photo.xml (podcast4)
+# - "p05": Use p05_investing.xml (podcast5)
+# For real API mode: Set USE_REAL_OPENAI_API=1 and OPENAI_TEST_RSS_FEED=<feed-url>
+#   (no default real feed - must be explicitly provided)
+OPENAI_TEST_FEED = os.getenv("OPENAI_TEST_FEED", "fast")
+
+# Real RSS feed URL for testing (only used when USE_REAL_OPENAI_API=1)
+# NOTE: No default real feed - must be explicitly set via OPENAI_TEST_RSS_FEED
+REAL_TEST_RSS_FEED = os.getenv(
+    "OPENAI_TEST_RSS_FEED",
+    None,  # No default - must be explicitly provided
+)
+
+
+def _get_test_feed_url(
+    e2e_server: Optional[Any] = None,
+) -> tuple[str, Optional[str], Optional[str]]:
+    """Get RSS feed URL and OpenAI config based on OPENAI_TEST_FEED environment variable.
+
+    Args:
+        e2e_server: E2E server fixture (None if using real API or if fixture not available)
+
+    Returns:
+        Tuple of (rss_url, openai_api_base, openai_api_key)
+    """
+    feed_type = OPENAI_TEST_FEED.lower()
+
+    # Real API mode - can use either real RSS feed OR fixture feeds
+    if USE_REAL_OPENAI_API:
+        # If OPENAI_TEST_RSS_FEED is explicitly set, use that real RSS feed
+        if REAL_TEST_RSS_FEED is not None:
+            return REAL_TEST_RSS_FEED, None, None
+
+        # Otherwise, use fixture feeds from E2E server (fixture input, real API calls)
+        # This allows testing real API with known fixture data
+        if e2e_server is None:
+            raise ValueError(
+                "E2E server is required when using fixture feeds with real API. "
+                "Set OPENAI_TEST_RSS_FEED=<url> to use a real RSS feed instead."
+            )
+
+        # Use fixture feeds but with real API (no mock API base)
+        feed_mapping = {
+            "fast": "podcast1",  # p01_fast.xml (1 episode, 1 minute)
+            "multi": "podcast1_multi_episode",  # p01_multi.xml (5 episodes, 10-15s each)
+            "p01": "podcast1",  # p01_mtb.xml (3 episodes) or p01_fast.xml in fast mode
+            "p02": "podcast2",  # p02_software.xml (3 episodes)
+            "p03": "podcast3",  # p03_scuba.xml (3 episodes)
+            "p04": "podcast4",  # p04_photo.xml (3 episodes)
+            "p05": "podcast5",  # p05_investing.xml (3 episodes)
+        }
+
+        if feed_type in feed_mapping:
+            feed_name = feed_mapping[feed_type]
+            rss_url = e2e_server.urls.feed(feed_name)
+            # Return None for openai_api_base to use real OpenAI API (not mocked)
+            # Return None for openai_api_key to use key from .env file
+            return rss_url, None, None
+
+        raise ValueError(
+            f"Unknown feed type: {feed_type}. "
+            "Use 'fast', 'multi', 'p01', 'p02', 'p03', 'p04', 'p05', "
+            "or set OPENAI_TEST_RSS_FEED for a real feed."
+        )
+
+    # E2E server mode - use test fixtures with mock API
+    # Note: e2e_server may be None if USE_REAL_OPENAI_API=1, but we've already handled that above
+    # If it's None here, it means the fixture wasn't available (shouldn't happen in normal E2E mode)
+    if e2e_server is None:
+        # Try to get the fixture from pytest request if available
+        # This handles the case where the fixture wasn't injected
+        try:
+            # This won't work in this context, but we can check the environment
+            # If we're not in real API mode and e2e_server is None, something is wrong
+            if not USE_REAL_OPENAI_API:
+                raise ValueError(
+                    "E2E server fixture is not available. "
+                    "This should not happen in E2E mode. "
+                    "Check that the e2e_server fixture is properly configured."
+                )
+        except Exception:
+            pass
+        raise ValueError(
+            "E2E server is required for test fixture feeds. "
+            "Set USE_REAL_OPENAI_API=1 to use real feeds."
+        )
+
+    # Map feed types to E2E server feed names
+    # Note: In fast mode, "podcast1" maps to p01_fast.xml (1 episode, 1 minute)
+    #       In normal mode, "podcast1" maps to p01_mtb.xml (3 episodes)
+    feed_mapping = {
+        "fast": "podcast1",  # p01_fast.xml (1 episode, 1 minute) - DEFAULT
+        "multi": "podcast1_multi_episode",  # p01_multi.xml (5 episodes, 10-15s each)
+        "p01": "podcast1",  # p01_mtb.xml (3 episodes) or p01_fast.xml in fast mode
+        "p02": "podcast2",  # p02_software.xml (3 episodes)
+        "p03": "podcast3",  # p03_scuba.xml (3 episodes)
+        "p04": "podcast4",  # p04_photo.xml (3 episodes)
+        "p05": "podcast5",  # p05_investing.xml (3 episodes)
+    }
+
+    if feed_type in feed_mapping:
+        feed_name = feed_mapping[feed_type]
+        rss_url = e2e_server.urls.feed(feed_name)
+        openai_api_base = e2e_server.urls.openai_api_base()
+        openai_api_key = "sk-test123"
+        return rss_url, openai_api_base, openai_api_key
+
+    # Custom URL - assume it's a real feed URL
+    # Note: This will only work if USE_REAL_OPENAI_API=1
+    return feed_type, None, None
+
+
+def _summarize_openai_usage(metadata_content: dict) -> str:
+    """Extract and summarize OpenAI API calls and models used from metadata.
+
+    Args:
+        metadata_content: Parsed metadata JSON content
+
+    Returns:
+        Human-readable summary string of OpenAI APIs and models used
+    """
+    processing = metadata_content.get("processing", {})
+    config_snapshot = processing.get("config_snapshot", {})
+    ml_providers = config_snapshot.get("ml_providers", {})
+
+    summary_parts = []
+
+    # Transcription
+    transcription_info = ml_providers.get("transcription", {})
+    if transcription_info.get("provider") == "openai":
+        model = transcription_info.get("openai_model", "whisper-1")
+        summary_parts.append(f"  • Transcription: /v1/audio/transcriptions (model: {model})")
+
+    # Speaker detection
+    speaker_info = ml_providers.get("speaker_detection", {})
+    if speaker_info.get("provider") == "openai":
+        model = speaker_info.get("openai_model", "gpt-4o-mini")
+        summary_parts.append(f"  • Speaker Detection: /v1/chat/completions (model: {model})")
+
+    # Summarization
+    summarization_info = ml_providers.get("summarization", {})
+    if summarization_info.get("provider") == "openai":
+        model = summarization_info.get("openai_model", "gpt-4o-mini")
+        summary_parts.append(f"  • Summarization: /v1/chat/completions (model: {model})")
+
+    if summary_parts:
+        return "OpenAI APIs called:\n" + "\n".join(summary_parts)
+    return "No OpenAI APIs detected in metadata"
+
+
+def _save_all_episode_responses(
+    temp_dir: Path,
+    metadata_files: list[Path],
+    test_name: str,
+    validate_provider: Optional[str] = None,
+    validate_transcription: bool = True,
+    validate_speaker_detection: bool = True,
+    validate_summarization: bool = True,
+) -> list[Path]:
+    """Save OpenAI API responses for all episodes processed in a test.
+
+    Args:
+        temp_dir: Temporary directory where test output was written
+        metadata_files: List of metadata file paths (one per episode)
+        test_name: Name of the test (e.g., "test_openai_all_providers_in_pipeline")
+        validate_provider: Optional provider name to validate (e.g., "openai")
+        validate_transcription: Whether to validate transcription provider (default: True)
+        validate_speaker_detection: Whether to validate speaker detection provider (default: True)
+        validate_summarization: Whether to validate summarization provider (default: True)
+
+    Returns:
+        List of paths to saved response files
+    """
+    import json as json_module
+
+    saved_files = []
+    for idx, metadata_file in enumerate(sorted(metadata_files), 1):
+        metadata_content = json_module.loads(metadata_file.read_text())
+
+        # Validate provider if specified
+        if validate_provider:
+            processing = metadata_content.get("processing", {})
+            config_snapshot = processing.get("config_snapshot", {})
+            ml_providers = config_snapshot.get("ml_providers", {})
+
+            # Check which provider type to validate
+            if validate_provider == "openai":
+                # Check transcription provider (only if validation is enabled)
+                if validate_transcription:
+                    transcription_info = ml_providers.get("transcription", {})
+                    if transcription_info:
+                        assert (
+                            transcription_info.get("provider") == "openai"
+                        ), f"Transcription provider should be 'openai' in metadata (episode {idx})"
+
+                # Check speaker detection provider (only if validation is enabled)
+                if validate_speaker_detection:
+                    speaker_info = ml_providers.get("speaker_detection", {})
+                    if speaker_info:
+                        assert speaker_info.get("provider") == "openai", (
+                            f"Speaker detection provider should be 'openai' "
+                            f"in metadata (episode {idx})"
+                        )
+
+                # Check summarization provider (only if validation is enabled)
+                if validate_summarization:
+                    summarization_info = ml_providers.get("summarization", {})
+                    if summarization_info:
+                        assert (
+                            summarization_info.get("provider") == "openai"
+                        ), f"Summarization provider should be 'openai' in metadata (episode {idx})"
+
+        # Print summary of OpenAI APIs and models used for this episode
+        if len(metadata_files) > 1:
+            print(f"\nEpisode {idx}: {_summarize_openai_usage(metadata_content)}")
+        else:
+            print(f"\n{_summarize_openai_usage(metadata_content)}")
+
+        # Save actual API responses (transcript, speakers, summary) to file
+        # Include episode number in the test name for uniqueness when multiple episodes
+        episode_suffix = f"_ep{idx:02d}" if len(metadata_files) > 1 else ""
+        response_file = _save_openai_responses(
+            temp_dir, metadata_content, f"{test_name}{episode_suffix}"
+        )
+        saved_files.append(response_file)
+
+    # Print summary of all saved files
+    if len(saved_files) > 1:
+        print(f"\n📁 Saved {len(saved_files)} OpenAI API response files:")
+        for idx, file_path in enumerate(saved_files, 1):
+            print(f"  {idx}. {file_path}")
+    elif len(saved_files) == 1:
+        print(f"📁 OpenAI API responses saved to: {saved_files[0]}")
+
+    return saved_files
+
+
+def _save_openai_responses(  # noqa: C901
+    temp_dir: Path, metadata_content: dict, test_name: str
+) -> Path:
+    """Save actual OpenAI API responses (transcript, speakers, summary) to a file.
+
+    Args:
+        temp_dir: Temporary directory where test output was written
+        metadata_content: Parsed metadata JSON content
+        test_name: Name of the test (e.g., "test_openai_all_providers_in_pipeline")
+
+    Returns:
+        Path to the saved response file
+    """
+    from datetime import datetime
+
+    # Create reports directory structure: reports/<test-name>/
+    reports_dir = Path("reports")
+    reports_dir.mkdir(exist_ok=True)
+
+    # Clean test name (remove test_ prefix, convert underscores to hyphens)
+    clean_test_name = test_name.replace("test_", "").replace("_", "-")
+
+    # Create subfolder for this test
+    test_reports_dir = reports_dir / clean_test_name
+    test_reports_dir.mkdir(exist_ok=True)
+
+    # Generate filename with timestamp including microseconds to ensure uniqueness
+    # Format: YYYYMMDD_HHMMSS_microseconds
+    now = datetime.now()
+    timestamp = now.strftime("%Y%m%d_%H%M%S_%f")  # %f is microseconds (6 digits)
+    filename = f"openai-responses_{timestamp}.txt"
+    output_file = test_reports_dir / filename
+
+    # Additional safety: if file somehow exists, append a counter
+    counter = 1
+    original_output_file = output_file
+    while output_file.exists():
+        filename_with_counter = f"openai-responses_{timestamp}_{counter}.txt"
+        output_file = test_reports_dir / filename_with_counter
+        counter += 1
+        if counter > 10000:  # Safety limit to prevent infinite loop
+            raise RuntimeError(f"Too many files with same timestamp: {original_output_file}")
+
+    # Collect all response data
+    response_lines = []
+    response_lines.append("=" * 80)
+    response_lines.append("OpenAI API Responses")
+    response_lines.append("=" * 80)
+    response_lines.append(f"Test: {test_name}")
+    response_lines.append(f"Timestamp: {datetime.now().isoformat()}")
+    response_lines.append("")
+
+    # 0. Input Information
+    response_lines.append("📥 INPUT INFORMATION:")
+    response_lines.append("-" * 80)
+
+    # Extract input information from metadata
+    content = metadata_content.get("content", {})
+    episode_data = metadata_content.get("episode", {})
+
+    # Media file information
+    media_url = content.get("media_url") or episode_data.get("media_url")
+    if media_url:
+        response_lines.append(f"Media URL: {media_url}")
+        # Extract filename from URL
+        try:
+            from urllib.parse import unquote, urlparse
+
+            parsed_url = urlparse(media_url)
+            filename = unquote(parsed_url.path.split("/")[-1])
+            if filename:
+                response_lines.append(f"Media Filename: {filename}")
+        except Exception:
+            pass
+
+    # Transcript URLs (if available from feed)
+    transcript_infos = content.get("transcript_urls", [])
+    if transcript_infos:
+        response_lines.append("")
+        response_lines.append("Available Transcript URLs (from feed):")
+        for idx, transcript_info in enumerate(transcript_infos, 1):
+            transcript_url = (
+                transcript_info.get("url", "")
+                if isinstance(transcript_info, dict)
+                else str(transcript_info)
+            )
+            transcript_type = (
+                transcript_info.get("type", "unknown")
+                if isinstance(transcript_info, dict)
+                else "unknown"
+            )
+            response_lines.append(f"  {idx}. {transcript_url} (type: {transcript_type})")
+    else:
+        response_lines.append("")
+        response_lines.append("Available Transcript URLs (from feed): None")
+
+    # Transcript source information
+    transcript_source = content.get("transcript_source")
+    if transcript_source:
+        response_lines.append("")
+        response_lines.append(f"Transcript Source: {transcript_source}")
+        if transcript_source == "direct_download":
+            response_lines.append("  (Transcript was downloaded from feed, not generated)")
+        elif transcript_source == "whisper_transcription":
+            whisper_model = content.get("whisper_model")
+            if whisper_model:
+                response_lines.append(f"  (Generated using Whisper model: {whisper_model})")
+
+    # Try to find reference transcript from fixtures (if available)
+    # For fixture feeds, we can check if there's a corresponding transcript file
+    # in the fixtures directory based on the media filename
+    if media_url:
+        try:
+            from urllib.parse import urlparse
+
+            parsed_url = urlparse(media_url)
+            media_filename = parsed_url.path.split("/")[-1]
+            # Extract base name (e.g., "p01_e01_fast" from "p01_e01_fast.mp3")
+            base_name = (
+                media_filename.rsplit(".", 1)[0] if "." in media_filename else media_filename
+            )
+
+            # Check for fixture transcript files
+            # Look in tests/fixtures/transcripts/ directory
+            fixtures_transcripts_dir = Path("tests/fixtures/transcripts")
+            if fixtures_transcripts_dir.exists():
+                # Try exact match first
+                ref_transcript_file = fixtures_transcripts_dir / f"{base_name}.txt"
+                if not ref_transcript_file.exists():
+                    # Try with wildcard pattern
+                    possible_files = list(fixtures_transcripts_dir.glob(f"{base_name}*.txt"))
+                    if possible_files:
+                        ref_transcript_file = possible_files[0]
+
+                if ref_transcript_file.exists():
+                    response_lines.append("")
+                    response_lines.append(
+                        f"Reference Transcript (from fixtures): {ref_transcript_file}"
+                    )
+                    # Include a preview of the reference transcript
+                    try:
+                        ref_text = ref_transcript_file.read_text(encoding="utf-8")
+                        preview_length = min(300, len(ref_text))
+                        response_lines.append(f"  Preview (first {preview_length} chars):")
+                        preview_text = ref_text[:preview_length]
+                        ellipsis = "..." if len(ref_text) > preview_length else ""
+                        response_lines.append(f"  {preview_text}{ellipsis}")
+                        response_lines.append(f"  (Total length: {len(ref_text)} characters)")
+                    except Exception as e:
+                        response_lines.append(f"  (Error reading transcript: {e})")
+        except Exception:
+            # Silently fail if we can't find reference transcripts
+            pass
+
+    response_lines.append("")
+    response_lines.append("=" * 80)
+    response_lines.append("")
+
+    # 1. Transcription result
+    # Try to find transcript file - OpenAI transcription creates .txt files
+    transcript_files = list(temp_dir.rglob("*.txt"))
+    # Filter out cleaned transcripts and metadata files
+    transcript_files = [
+        f for f in transcript_files if "cleaned" not in f.name and "metadata" not in f.name
+    ]
+
+    if transcript_files:
+        # Use the first transcript file found
+        transcript_file = transcript_files[0]
+        transcript_text = transcript_file.read_text(encoding="utf-8")
+        response_lines.append("\n📝 TRANSCRIPTION RESULT:")
+        response_lines.append("-" * 80)
+        response_lines.append(f"Source file: {transcript_file.name}")
+        response_lines.append(f"Total length: {len(transcript_text)} characters")
+        response_lines.append("")
+        response_lines.append(transcript_text)
+        response_lines.append("")
+
+    # 2. Speaker detection result
+    content = metadata_content.get("content", {})
+    detected_hosts = content.get("detected_hosts", [])
+    detected_guests = content.get("detected_guests", [])
+    if detected_hosts or detected_guests:
+        response_lines.append("\n👥 SPEAKER DETECTION RESULT:")
+        response_lines.append("-" * 80)
+        if detected_hosts:
+            response_lines.append(f"  Hosts: {', '.join(detected_hosts)}")
+        if detected_guests:
+            response_lines.append(f"  Guests: {', '.join(detected_guests)}")
+        if not detected_hosts and not detected_guests:
+            response_lines.append("  No speakers detected")
+        response_lines.append("")
+
+    # 3. Summarization result
+    summary_data = metadata_content.get("summary")
+    if summary_data:
+        response_lines.append("\n📄 SUMMARIZATION RESULT:")
+        response_lines.append("-" * 80)
+        if isinstance(summary_data, dict):
+            short_summary = summary_data.get("short_summary", "")
+            if short_summary:
+                response_lines.append(short_summary)
+            else:
+                response_lines.append("  (Summary exists but short_summary field is empty)")
+        else:
+            # Summary might be a string directly
+            response_lines.append(str(summary_data))
+        response_lines.append("")
+
+    response_lines.append("=" * 80)
+
+    # Write to file
+    output_file.write_text("\n".join(response_lines), encoding="utf-8")
+
+    return output_file
 
 
 @pytest.mark.e2e
@@ -47,20 +513,33 @@ from tests.conftest import (  # noqa: E402
 class TestOpenAIProviderE2E:
     """Test OpenAI providers in integration workflows using E2E server."""
 
-    def test_openai_transcription_in_pipeline(self, e2e_server):
+    def test_openai_transcription_in_pipeline(self, e2e_server: Optional[Any]):
         """Test OpenAI transcription provider in full pipeline."""
+        import os
+
         temp_dir = tempfile.mkdtemp()
         try:
-            # Create config with OpenAI transcription using E2E server
+            # Get feed URL and OpenAI config based on OPENAI_TEST_FEED
+            rss_url, openai_api_base, openai_api_key = _get_test_feed_url(e2e_server)
+
+            # Get max_episodes from environment variable (for real feeds) or use default
+            max_episodes = int(os.getenv("OPENAI_TEST_MAX_EPISODES", "1"))
+
+            # Create config with OpenAI transcription ONLY (no other providers)
             cfg = create_test_config(
-                rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
+                rss_url=rss_url,
                 output_dir=temp_dir,
                 transcription_provider="openai",
-                openai_api_key="sk-test123",
-                openai_api_base=e2e_server.urls.openai_api_base(),  # Use E2E server
+                speaker_detector_provider="openai",  # Explicitly set to avoid spaCy default
+                summary_provider="openai",  # Explicitly set to avoid transformers default
+                openai_api_key=openai_api_key,
+                openai_api_base=openai_api_base,
                 transcribe_missing=True,  # Enable transcription
                 generate_metadata=True,
-                max_episodes=1,
+                generate_summaries=False,  # Disable summarization
+                auto_speakers=False,  # Disable speaker detection
+                preload_models=False,  # Disable model preloading (no local ML models)
+                max_episodes=max_episodes,
             )
 
             # Run pipeline (uses E2E server OpenAI endpoints, no direct mocking)
@@ -74,85 +553,139 @@ class TestOpenAIProviderE2E:
                 Path(temp_dir).rglob("*.vtt")
             )
             assert len(transcript_files) >= 1, "Should have created at least one transcript file"
+
+            # Verify OpenAI transcription provider was used (check metadata)
+            metadata_files = list(Path(temp_dir).rglob("*.metadata.json"))
+            if len(metadata_files) > 0:
+                import json as json_module
+
+                # Process all metadata files (one per episode)
+                saved_files = []
+                for idx, metadata_file in enumerate(sorted(metadata_files), 1):
+                    metadata_content = json_module.loads(metadata_file.read_text())
+                    processing = metadata_content.get("processing", {})
+                    config_snapshot = processing.get("config_snapshot", {})
+                    ml_providers = config_snapshot.get("ml_providers", {})
+                    transcription_info = ml_providers.get("transcription", {})
+                    assert (
+                        transcription_info.get("provider") == "openai"
+                    ), f"Transcription provider should be 'openai' in metadata (episode {idx})"
+
+                    # Print summary of OpenAI APIs and models used for this episode
+                    print(f"\nEpisode {idx}: {_summarize_openai_usage(metadata_content)}")
+
+                    # Save actual API responses (transcript, speakers, summary) to file
+                    # Include episode number in the test name for uniqueness
+                    episode_suffix = f"_ep{idx:02d}" if len(metadata_files) > 1 else ""
+                    response_file = _save_openai_responses(
+                        Path(temp_dir),
+                        metadata_content,
+                        f"test_openai_transcription_in_pipeline{episode_suffix}",
+                    )
+                    saved_files.append(response_file)
+
+                # Print summary of all saved files
+                if len(saved_files) > 1:
+                    print(f"\n📁 Saved {len(saved_files)} OpenAI API response files:")
+                    for idx, file_path in enumerate(saved_files, 1):
+                        print(f"  {idx}. {file_path}")
+                else:
+                    print(f"📁 OpenAI API responses saved to: {saved_files[0]}")
+            else:
+                metadata_content = {}
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
     @pytest.mark.flaky
-    def test_openai_speaker_detection_in_pipeline(self, e2e_server):
+    def test_openai_speaker_detection_in_pipeline(self, e2e_server: Optional[Any]):
         """Test OpenAI speaker detection provider in full pipeline."""
         temp_dir = tempfile.mkdtemp()
         try:
-            # Create config with OpenAI speaker detection using E2E server
+            # Get feed URL and OpenAI config based on OPENAI_TEST_FEED
+            rss_url, openai_api_base, openai_api_key = _get_test_feed_url(e2e_server)
+
+            # Create config with OpenAI speaker detection and transcription ONLY (no summarization)
             cfg = create_test_config(
-                rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
+                rss_url=rss_url,
                 output_dir=temp_dir,
+                transcription_provider="openai",
                 speaker_detector_provider="openai",
-                openai_api_key="sk-test123",
-                openai_api_base=e2e_server.urls.openai_api_base(),  # Use E2E server
+                summary_provider="openai",  # Explicitly set to avoid transformers default
+                openai_api_key=openai_api_key,
+                openai_api_base=openai_api_base,
                 auto_speakers=True,
                 generate_metadata=True,
-                transcription_provider="whisper",  # Use Whisper for transcription
+                generate_summaries=False,  # Disable summarization
+                preload_models=False,  # Disable model preloading (no local ML models)
                 transcribe_missing=True,
-                max_episodes=1,
+                max_episodes=int(os.getenv("OPENAI_TEST_MAX_EPISODES", "1")),
             )
 
-            # Require Whisper model to be cached (skip if not available)
-            from tests.integration.ml_model_cache_helpers import require_whisper_model_cached
-
-            require_whisper_model_cached(config.TEST_DEFAULT_WHISPER_MODEL)
-
-            # Run pipeline with real Whisper (uses E2E server OpenAI endpoints)
+            # Run pipeline (uses OpenAI ONLY, no local ML providers)
             transcripts_saved, summary = workflow.run_pipeline(cfg)
 
             # Verify transcripts were saved (transcript file must exist for metadata)
             assert transcripts_saved > 0, "Should have saved at least one transcript"
 
-            # Verify metadata files were created (may not exist if
-            # transcript file doesn't exist)
+            # Verify metadata files were created
             # Use *.metadata.json to avoid matching metrics.json files
             metadata_files = list(Path(temp_dir).rglob("*.metadata.json"))
-            # Note: Metadata files may not be created if transcript files don't exist
-            # The key is that OpenAI speaker detection was called via E2E server
-            if len(metadata_files) > 0:
-                import json as json_module
+            assert (
+                len(metadata_files) > 0
+            ), "Metadata files should be created when generate_metadata=True"
 
-                metadata_content = json_module.loads(Path(metadata_files[0]).read_text())
-                # Check that speaker detection results are in metadata
-                # They may be in 'content' section
+            import json as json_module
+
+            # Verify speaker detection results for all episodes
+            for metadata_file in sorted(metadata_files):
+                metadata_content = json_module.loads(metadata_file.read_text())
                 content = metadata_content.get("content", {})
                 assert (
                     "detected_hosts" in content
                     or "detected_guests" in content
                     or "detected_hosts" in metadata_content
                     or "detected_guests" in metadata_content
+                ), (
+                    "Speaker detection results (detected_hosts/detected_guests) "
+                    "should be in metadata"
                 )
+
+            # Save responses for all episodes
+            _save_all_episode_responses(
+                Path(temp_dir),
+                metadata_files,
+                "test_openai_speaker_detection_in_pipeline",
+                validate_provider="openai",
+                validate_summarization=False,  # Summarization not enabled in this test
+            )
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
-    def test_openai_summarization_in_pipeline(self, e2e_server):
+    def test_openai_summarization_in_pipeline(self, e2e_server: Optional[Any]):
         """Test OpenAI summarization provider in full pipeline."""
         temp_dir = tempfile.mkdtemp()
         try:
-            # Create config with OpenAI summarization using E2E server
+            # Get feed URL and OpenAI config based on OPENAI_TEST_FEED
+            rss_url, openai_api_base, openai_api_key = _get_test_feed_url(e2e_server)
+
+            # Create config with OpenAI summarization and transcription ONLY (no speaker detection)
             cfg = create_test_config(
-                rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
+                rss_url=rss_url,
                 output_dir=temp_dir,
+                transcription_provider="openai",
+                speaker_detector_provider="openai",  # Explicitly set to avoid spaCy default
                 summary_provider="openai",
-                openai_api_key="sk-test123",
-                openai_api_base=e2e_server.urls.openai_api_base(),  # Use E2E server
+                openai_api_key=openai_api_key,
+                openai_api_base=openai_api_base,
                 generate_metadata=True,
                 generate_summaries=True,
-                transcription_provider="whisper",  # Use Whisper for transcription
+                auto_speakers=False,  # Disable speaker detection
+                preload_models=False,  # Disable model preloading (no local ML models)
                 transcribe_missing=True,
-                max_episodes=1,
+                max_episodes=int(os.getenv("OPENAI_TEST_MAX_EPISODES", "1")),
             )
 
-            # Require Whisper model to be cached (skip if not available)
-            from tests.integration.ml_model_cache_helpers import require_whisper_model_cached
-
-            require_whisper_model_cached(config.TEST_DEFAULT_WHISPER_MODEL)
-
-            # Run pipeline with real Whisper (uses E2E server OpenAI endpoints)
+            # Run pipeline (uses OpenAI ONLY, no local ML providers)
             transcripts_saved, summary = workflow.run_pipeline(cfg)
 
             # Verify transcripts were saved (transcript file must exist for summarization)
@@ -161,37 +694,59 @@ class TestOpenAIProviderE2E:
             # Verify metadata files were created
             # Use *.metadata.json to avoid matching metrics.json files
             metadata_files = list(Path(temp_dir).rglob("*.metadata.json"))
-            # Note: Summarization may not be called if transcript file doesn't exist
-            # or if there's an error. The key is that the pipeline completes.
-            if len(metadata_files) > 0:
-                import json as json_module
+            assert (
+                len(metadata_files) > 0
+            ), "Metadata files should be created when generate_metadata=True"
 
-                metadata_content = json_module.loads(Path(metadata_files[0]).read_text())
-                # If summary exists, verify it's correct (from E2E server)
-                if "summary" in metadata_content:
-                    assert len(metadata_content["summary"]) > 0, "Summary should not be empty"
+            import json as json_module
+
+            # Verify all episodes have summaries
+            for metadata_file in sorted(metadata_files):
+                metadata_content = json_module.loads(metadata_file.read_text())
+                assert (
+                    "summary" in metadata_content
+                ), "Summary should exist in metadata when generate_summaries=True"
+                summary_data = metadata_content.get("summary", {})
+                if isinstance(summary_data, dict):
+                    short_summary = summary_data.get("short_summary", "")
+                    assert len(short_summary) > 0, "Summary should not be empty"
+                else:
+                    assert len(str(summary_data)) > 0, "Summary should not be empty"
+
+            # Save responses for all episodes
+            _save_all_episode_responses(
+                Path(temp_dir),
+                metadata_files,
+                "test_openai_summarization_in_pipeline",
+                validate_provider="openai",
+                validate_speaker_detection=False,  # Speaker detection not enabled in this test
+            )
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
     @pytest.mark.flaky
-    def test_openai_all_providers_in_pipeline(self, e2e_server):
-        """Test all OpenAI providers together in full pipeline using E2E server."""
+    def test_openai_all_providers_in_pipeline(self, e2e_server: Optional[Any]):
+        """Test all OpenAI providers together in full pipeline."""
         temp_dir = tempfile.mkdtemp()
         try:
-            # Create config with all OpenAI providers using E2E server
+            # Get feed URL and OpenAI config based on OPENAI_TEST_FEED
+            rss_url, openai_api_base, openai_api_key = _get_test_feed_url(e2e_server)
+
+            # Create config with ALL OpenAI providers ONLY (no local ML providers)
             cfg = create_test_config(
-                rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
+                rss_url=rss_url,
                 output_dir=temp_dir,
                 transcription_provider="openai",
                 speaker_detector_provider="openai",
                 summary_provider="openai",
-                openai_api_key="sk-test123",
-                openai_api_base=e2e_server.urls.openai_api_base(),  # Use E2E server
+                openai_api_key=openai_api_key,
+                openai_api_base=openai_api_base,
                 auto_speakers=True,
                 generate_metadata=True,
                 generate_summaries=True,
+                preload_models=False,  # Disable model preloading (no local ML models)
                 transcribe_missing=True,
-                max_episodes=1,
+                max_episodes=int(os.getenv("OPENAI_TEST_MAX_EPISODES", "1")),
             )
 
             # Run pipeline (uses E2E server OpenAI endpoints, no direct mocking)
@@ -200,20 +755,33 @@ class TestOpenAIProviderE2E:
             # Verify transcripts were saved
             assert transcripts_saved > 0, "Should have saved at least one transcript"
 
-            # Verify metadata files were created (may not exist if transcript file doesn't exist)
-            # But if they are created, verify they're correct
+            # Verify metadata files were created
             # Use *.metadata.json to avoid matching metrics.json files
             metadata_files = list(Path(temp_dir).rglob("*.metadata.json"))
-            if len(metadata_files) > 0:
-                # Verify metadata structure
-                import json as json_module
+            assert (
+                len(metadata_files) > 0
+            ), "Metadata files should be created when generate_metadata=True"
 
-                metadata_content = json_module.loads(Path(metadata_files[0]).read_text())
-                assert "content" in metadata_content or "episode" in metadata_content
+            import json as json_module
+
+            # Verify metadata structure for all episodes
+            for metadata_file in sorted(metadata_files):
+                metadata_content = json_module.loads(metadata_file.read_text())
+                assert (
+                    "content" in metadata_content or "episode" in metadata_content
+                ), "Metadata should have content or episode section"
+
+            # Save responses for all episodes
+            _save_all_episode_responses(
+                Path(temp_dir),
+                metadata_files,
+                "test_openai_all_providers_in_pipeline",
+                validate_provider="openai",
+            )
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
-    def test_openai_transcription_api_error_handling(self, e2e_server):
+    def test_openai_transcription_api_error_handling(self, e2e_server: Optional[Any]):
         """Test that OpenAI transcription API errors are handled gracefully.
 
         Note: E2E server currently doesn't simulate errors, so this test verifies
@@ -222,15 +790,23 @@ class TestOpenAIProviderE2E:
         """
         temp_dir = tempfile.mkdtemp()
         try:
-            # Create config with OpenAI transcription using E2E server
+            # Get feed URL and OpenAI config based on OPENAI_TEST_FEED
+            rss_url, openai_api_base, openai_api_key = _get_test_feed_url(e2e_server)
+
+            # Create config with OpenAI transcription ONLY (no other providers)
             cfg = create_test_config(
-                rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
+                rss_url=rss_url,
                 output_dir=temp_dir,
                 transcription_provider="openai",
-                openai_api_key="sk-test123",
-                openai_api_base=e2e_server.urls.openai_api_base(),  # Use E2E server
+                speaker_detector_provider="openai",  # Explicitly set to avoid spaCy default
+                summary_provider="openai",  # Explicitly set to avoid transformers default
+                openai_api_key=openai_api_key,
+                openai_api_base=openai_api_base,
+                generate_summaries=False,  # Disable summarization
+                auto_speakers=False,  # Disable speaker detection
+                preload_models=False,  # Disable model preloading (no local ML models)
                 transcribe_missing=True,
-                max_episodes=1,
+                max_episodes=int(os.getenv("OPENAI_TEST_MAX_EPISODES", "1")),
             )
 
             # Run pipeline - E2E server provides successful responses
@@ -239,11 +815,22 @@ class TestOpenAIProviderE2E:
             # Pipeline should complete successfully
             # Note: Error handling is tested in unit/integration tests
             assert transcripts_saved >= 0, "Pipeline should complete"
+
+            # Verify OpenAI transcription provider was used (if metadata exists)
+            metadata_files = list(Path(temp_dir).rglob("*.metadata.json"))
+            if len(metadata_files) > 0:
+                # Save responses for all episodes (if any succeeded)
+                _save_all_episode_responses(
+                    Path(temp_dir),
+                    metadata_files,
+                    "test_openai_transcription_api_error_handling",
+                    validate_provider="openai",
+                )
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
-    def test_openai_speaker_detection_api_error_handling(self, e2e_server):
-        """Test that OpenAI speaker detection works with E2E server.
+    def test_openai_speaker_detection_api_error_handling(self, e2e_server: Optional[Any]):
+        """Test that OpenAI speaker detection works correctly.
 
         Note: E2E server currently doesn't simulate errors, so this test verifies
         that the pipeline completes successfully. Error handling is tested in
@@ -251,36 +838,49 @@ class TestOpenAIProviderE2E:
         """
         temp_dir = tempfile.mkdtemp()
         try:
-            # Create config with OpenAI speaker detection using E2E server
+            # Get feed URL and OpenAI config based on OPENAI_TEST_FEED
+            rss_url, openai_api_base, openai_api_key = _get_test_feed_url(e2e_server)
+
+            # Create config with OpenAI speaker detection and transcription ONLY (no summarization)
             cfg = create_test_config(
-                rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
+                rss_url=rss_url,
                 output_dir=temp_dir,
+                transcription_provider="openai",
                 speaker_detector_provider="openai",
-                openai_api_key="sk-test123",
-                openai_api_base=e2e_server.urls.openai_api_base(),  # Use E2E server
+                summary_provider="openai",  # Explicitly set to avoid transformers default
+                openai_api_key=openai_api_key,
+                openai_api_base=openai_api_base,
                 auto_speakers=True,
                 generate_metadata=True,
-                transcription_provider="whisper",
+                generate_summaries=False,  # Disable summarization
+                preload_models=False,  # Disable model preloading (no local ML models)
                 transcribe_missing=True,
-                max_episodes=1,
+                max_episodes=int(os.getenv("OPENAI_TEST_MAX_EPISODES", "1")),
             )
 
-            # Require Whisper model to be cached (skip if not available)
-            from tests.integration.ml_model_cache_helpers import require_whisper_model_cached
-
-            require_whisper_model_cached(config.TEST_DEFAULT_WHISPER_MODEL)
-
-            # Run pipeline with real Whisper - E2E server provides successful responses
+            # Run pipeline (uses OpenAI ONLY, no local ML providers)
             transcripts_saved, summary = workflow.run_pipeline(cfg)
 
             # Pipeline should complete successfully
             # Note: Error handling is tested in unit/integration tests
             assert transcripts_saved >= 0, "Pipeline should complete"
+
+            # Verify OpenAI speaker detection provider was used (if metadata exists)
+            metadata_files = list(Path(temp_dir).rglob("*.metadata.json"))
+            if len(metadata_files) > 0:
+                # Save responses for all episodes
+                _save_all_episode_responses(
+                    Path(temp_dir),
+                    metadata_files,
+                    "test_openai_speaker_detection_api_error_handling",
+                    validate_provider="openai",
+                    validate_summarization=False,  # Summarization not enabled in this test
+                )
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
-    def test_openai_summarization_api_error_handling(self, e2e_server):
-        """Test that OpenAI summarization works with E2E server.
+    def test_openai_summarization_api_error_handling(self, e2e_server: Optional[Any]):
+        """Test that OpenAI summarization works correctly.
 
         Note: E2E server currently doesn't simulate errors, so this test verifies
         that the pipeline completes successfully. Error handling is tested in
@@ -288,26 +888,27 @@ class TestOpenAIProviderE2E:
         """
         temp_dir = tempfile.mkdtemp()
         try:
-            # Create config with OpenAI summarization using E2E server
+            # Get feed URL and OpenAI config based on OPENAI_TEST_FEED
+            rss_url, openai_api_base, openai_api_key = _get_test_feed_url(e2e_server)
+
+            # Create config with OpenAI summarization and transcription ONLY (no speaker detection)
             cfg = create_test_config(
-                rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
+                rss_url=rss_url,
                 output_dir=temp_dir,
+                transcription_provider="openai",
+                speaker_detector_provider="openai",  # Explicitly set to avoid spaCy default
                 summary_provider="openai",
-                openai_api_key="sk-test123",
-                openai_api_base=e2e_server.urls.openai_api_base(),  # Use E2E server
+                openai_api_key=openai_api_key,
+                openai_api_base=openai_api_base,
                 generate_metadata=True,
                 generate_summaries=True,
-                transcription_provider="whisper",
+                auto_speakers=False,  # Disable speaker detection
+                preload_models=False,  # Disable model preloading (no local ML models)
                 transcribe_missing=True,
-                max_episodes=1,
+                max_episodes=int(os.getenv("OPENAI_TEST_MAX_EPISODES", "1")),
             )
 
-            # Require Whisper model to be cached (skip if not available)
-            from tests.integration.ml_model_cache_helpers import require_whisper_model_cached
-
-            require_whisper_model_cached(config.TEST_DEFAULT_WHISPER_MODEL)
-
-            # Run pipeline with real Whisper - E2E server provides successful responses
+            # Run pipeline (uses OpenAI ONLY, no local ML providers)
             transcripts_saved, summary = workflow.run_pipeline(cfg)
 
             # Pipeline should complete successfully
@@ -319,11 +920,20 @@ class TestOpenAIProviderE2E:
             # Use *.metadata.json to avoid matching metrics.json files
             metadata_files = list(Path(temp_dir).rglob("*.metadata.json"))
             assert len(metadata_files) > 0, "Metadata files should be created"
+
+            # Save responses for all episodes
+            _save_all_episode_responses(
+                Path(temp_dir),
+                metadata_files,
+                "test_openai_summarization_api_error_handling",
+                validate_provider="openai",
+                validate_speaker_detection=False,  # Speaker detection not enabled in this test
+            )
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
-    def test_openai_transcription_rate_limiting(self, e2e_server):
-        """Test that OpenAI transcription works with E2E server.
+    def test_openai_transcription_rate_limiting(self, e2e_server: Optional[Any]):
+        """Test that OpenAI transcription works correctly.
 
         Note: E2E server currently doesn't simulate rate limiting, so this test verifies
         that the pipeline completes successfully. Rate limiting is tested in
@@ -331,15 +941,23 @@ class TestOpenAIProviderE2E:
         """
         temp_dir = tempfile.mkdtemp()
         try:
-            # Create config with OpenAI transcription using E2E server
+            # Get feed URL and OpenAI config based on OPENAI_TEST_FEED
+            rss_url, openai_api_base, openai_api_key = _get_test_feed_url(e2e_server)
+
+            # Create config with OpenAI transcription ONLY (no other providers)
             cfg = create_test_config(
-                rss_url=e2e_server.urls.feed("podcast1_multi_episode"),
+                rss_url=rss_url,
                 output_dir=temp_dir,
                 transcription_provider="openai",
-                openai_api_key="sk-test123",
-                openai_api_base=e2e_server.urls.openai_api_base(),  # Use E2E server
+                speaker_detector_provider="openai",  # Explicitly set to avoid spaCy default
+                summary_provider="openai",  # Explicitly set to avoid transformers default
+                openai_api_key=openai_api_key,
+                openai_api_base=openai_api_base,
+                generate_summaries=False,  # Disable summarization
+                auto_speakers=False,  # Disable speaker detection
+                preload_models=False,  # Disable model preloading (no local ML models)
                 transcribe_missing=True,
-                max_episodes=1,
+                max_episodes=int(os.getenv("OPENAI_TEST_MAX_EPISODES", "1")),
             )
 
             # Run pipeline - E2E server provides successful responses
@@ -348,5 +966,16 @@ class TestOpenAIProviderE2E:
             # Pipeline should complete successfully
             # Note: Rate limiting is tested in unit/integration tests
             assert transcripts_saved >= 0, "Pipeline should complete"
+
+            # Verify OpenAI transcription provider was used (if metadata exists)
+            metadata_files = list(Path(temp_dir).rglob("*.metadata.json"))
+            if len(metadata_files) > 0:
+                # Save responses for all episodes (if any succeeded)
+                _save_all_episode_responses(
+                    Path(temp_dir),
+                    metadata_files,
+                    "test_openai_transcription_rate_limiting",
+                    validate_provider="openai",
+                )
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)

--- a/tests/integration/test_provider_config_integration.py
+++ b/tests/integration/test_provider_config_integration.py
@@ -9,6 +9,7 @@ factory functions create providers as expected:
 - Backward compatibility with deprecated fields
 """
 
+import os
 import unittest
 
 import pytest
@@ -137,8 +138,15 @@ class TestProviderConfigFields(unittest.TestCase):
 
     def test_openai_api_key_optional(self):
         """Test that openai_api_key is optional and defaults to None."""
-        cfg = config.Config(rss_url="https://example.com/feed.xml")
-        self.assertIsNone(cfg.openai_api_key)
+        # Unset environment variable to ensure it's not loaded
+        original_key = os.environ.pop("OPENAI_API_KEY", None)
+        try:
+            cfg = config.Config(rss_url="https://example.com/feed.xml")
+            self.assertIsNone(cfg.openai_api_key)
+        finally:
+            # Restore original environment variable if it existed
+            if original_key is not None:
+                os.environ["OPENAI_API_KEY"] = original_key
 
     def test_openai_api_key_can_be_set(self):
         """Test that openai_api_key can be set."""

--- a/tests/unit/podcast_scraper/test_config.py
+++ b/tests/unit/podcast_scraper/test_config.py
@@ -446,8 +446,15 @@ class TestConfigFieldValidators(unittest.TestCase):
 
     def test_openai_api_base_validator_handles_none(self):
         """Test that openai_api_base validator handles None."""
-        cfg = Config(rss_url="https://example.com/feed.xml", openai_api_base=None)
-        self.assertIsNone(cfg.openai_api_base)
+        # Unset environment variable to ensure it's not loaded
+        original_base = os.environ.pop("OPENAI_API_BASE", None)
+        try:
+            cfg = Config(rss_url="https://example.com/feed.xml", openai_api_base=None)
+            self.assertIsNone(cfg.openai_api_base)
+        finally:
+            # Restore original environment variable if it existed
+            if original_base is not None:
+                os.environ["OPENAI_API_BASE"] = original_base
 
     def test_speaker_detector_provider_validator_invalid(self):
         """Test that speaker_detector_provider validator rejects invalid values."""

--- a/tests/unit/podcast_scraper/test_openai_providers.py
+++ b/tests/unit/podcast_scraper/test_openai_providers.py
@@ -5,6 +5,7 @@ These tests verify OpenAI provider implementations with mocked API calls.
 """
 
 import json
+import os
 import unittest
 from unittest.mock import Mock, patch
 
@@ -35,7 +36,11 @@ class TestOpenAITranscriptionProvider(unittest.TestCase):
         provider = create_transcription_provider(self.cfg)
         provider.initialize()
 
-        mock_openai_class.assert_called_once_with(api_key="sk-test123")
+        # base_url is only included if openai_api_base is set
+        expected_kwargs = {"api_key": "sk-test123"}
+        if self.cfg.openai_api_base:
+            expected_kwargs["base_url"] = self.cfg.openai_api_base
+        mock_openai_class.assert_called_once_with(**expected_kwargs)
         self.assertTrue(provider._transcription_initialized)
 
     @patch("podcast_scraper.openai.openai_provider.OpenAI")
@@ -69,9 +74,18 @@ class TestOpenAITranscriptionProvider(unittest.TestCase):
         """Test that missing API key raises ValidationError (caught by config validator)."""
         from pydantic import ValidationError
 
-        with self.assertRaises(ValidationError) as cm:
-            config.Config(rss_url="https://example.com/feed.xml", transcription_provider="openai")
-        self.assertIn("OpenAI API key required", str(cm.exception))
+        # Unset environment variable to ensure it's not loaded
+        original_key = os.environ.pop("OPENAI_API_KEY", None)
+        try:
+            with self.assertRaises(ValidationError) as cm:
+                config.Config(
+                    rss_url="https://example.com/feed.xml", transcription_provider="openai"
+                )
+            self.assertIn("OpenAI API key required", str(cm.exception))
+        finally:
+            # Restore original environment variable if it existed
+            if original_key is not None:
+                os.environ["OPENAI_API_KEY"] = original_key
 
     def test_factory_creates_openai_provider(self):
         """Test that factory creates OpenAI transcription provider."""
@@ -144,13 +158,20 @@ class TestOpenAISpeakerDetector(unittest.TestCase):
         """Test that missing API key raises ValidationError (caught by config validator)."""
         from pydantic import ValidationError
 
-        with self.assertRaises(ValidationError) as cm:
-            config.Config(
-                rss_url="https://example.com/feed.xml",
-                speaker_detector_provider="openai",
-                auto_speakers=True,
-            )
-        self.assertIn("OpenAI API key required", str(cm.exception))
+        # Unset environment variable to ensure it's not loaded
+        original_key = os.environ.pop("OPENAI_API_KEY", None)
+        try:
+            with self.assertRaises(ValidationError) as cm:
+                config.Config(
+                    rss_url="https://example.com/feed.xml",
+                    speaker_detector_provider="openai",
+                    auto_speakers=True,
+                )
+            self.assertIn("OpenAI API key required", str(cm.exception))
+        finally:
+            # Restore original environment variable if it existed
+            if original_key is not None:
+                os.environ["OPENAI_API_KEY"] = original_key
 
     def test_factory_creates_openai_detector(self):
         """Test that factory creates OpenAI speaker detector."""
@@ -212,14 +233,21 @@ class TestOpenAISummarizationProvider(unittest.TestCase):
         """Test that missing API key raises ValidationError (caught by config validator)."""
         from pydantic import ValidationError
 
-        with self.assertRaises(ValidationError) as cm:
-            config.Config(
-                rss_url="https://example.com/feed.xml",
-                summary_provider="openai",
-                generate_metadata=True,
-                generate_summaries=True,
-            )
-        self.assertIn("OpenAI API key required", str(cm.exception))
+        # Unset environment variable to ensure it's not loaded
+        original_key = os.environ.pop("OPENAI_API_KEY", None)
+        try:
+            with self.assertRaises(ValidationError) as cm:
+                config.Config(
+                    rss_url="https://example.com/feed.xml",
+                    summary_provider="openai",
+                    generate_metadata=True,
+                    generate_summaries=True,
+                )
+            self.assertIn("OpenAI API key required", str(cm.exception))
+        finally:
+            # Restore original environment variable if it existed
+            if original_key is not None:
+                os.environ["OPENAI_API_KEY"] = original_key
 
     def test_factory_creates_openai_provider(self):
         """Test that factory creates OpenAI summarization provider."""


### PR DESCRIPTION
## Summary

This PR fixes test failures and linting issues related to OpenAI provider tests and environment variable handling.

## Changes

### Test Fixes
- **Environment Variable Isolation**: Tests now properly unset `OPENAI_API_KEY` and `OPENAI_API_BASE` environment variables when testing for `None` values, preventing interference from `.env` files
- **Test Assertions**: Updated `test_provider_initialization` to handle optional `base_url` parameter in OpenAI client initialization
- **Test Coverage**: Fixed 7 failing tests:
  - `test_openai_api_base_validator_handles_none`
  - `test_provider_initialization`
  - `test_transcribe_missing_api_key`
  - `test_detect_speakers_missing_api_key`
  - `test_summarize_missing_api_key`
  - `test_provider_creation_requires_api_key`
  - `test_openai_api_key_optional`

### Code Quality
- **Flake8 Fixes**:
  - Removed unused imports (`config`, `pytest`, `json_module`)
  - Fixed line length issues (E501) by breaking long lines
  - Removed unused variable `e2e_server` in `conftest.py`
  - Added missing `import os` statements in test files
  - Suppressed complexity warning for test helper function (`# noqa: C901`)

### Test Isolation
- Ensured OpenAI E2E tests only use OpenAI providers (no local ML models)
- All tests now properly isolate environment variables from `.env` files

## Testing

- ✅ All tests pass (`make ci-fast`)
- ✅ All linting checks pass
- ✅ Pre-commit hooks pass

## Related Issues

Fixes test failures introduced when OpenAI API key/base URL loading from environment variables was added.