### PR TITLE
chore: placeholder PR for post-#565 issue links

### DIFF
--- a/docs/wip/wip-post-pr565-issue-closure-placeholder.md
+++ b/docs/wip/wip-post-pr565-issue-closure-placeholder.md
@@ -1,0 +1,19 @@
+# Post-PR #565 issue closure (placeholder)
+
+This note supports a **small housekeeping pull request** whose only purpose is
+to give GitHub a mergeable branch where you can attach **remaining issues**
+that were shipped in **#565** but were not linked (or not closed) before that PR
+merged.
+
+## How to use the placeholder PR
+
+1. Open the PR titled like **chore: placeholder PR for post-#565 issue links**.
+2. In the description (or follow-up commits), add lines such as `Fixes #NNN` or
+   `Closes #NNN` for each issue that should close when this PR merges.
+3. Merge when you are done linking; the code change in the PR is intentionally
+   minimal (this doc only).
+
+## After merge
+
+You may delete this file in a later cleanup PR, or keep it as a short pointer in
+history. Prefer removing it once all intended issues are closed.


### PR DESCRIPTION
## Purpose

Housekeeping PR only: **#565** is merged; GitHub does not let you attach more issues to it after the fact.

Use this PR to add `Fixes #NNN` / `Closes #NNN` (in the description below or in follow-up commits) for any issues that shipped in #565 but were never linked.

See `docs/wip/wip-post-pr565-issue-closure-placeholder.md` for short instructions.

## Your links (edit this section)

<!-- Example: Fixes #123 Closes #456 -->



Made with [Cursor](https://cursor.com)