### PR TITLE
Mega-bundle pipeline modes + corpus layout + JSON truncation fix (#643, #644, #645)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,78 @@
 - **`.metrics/rule-adherence.jsonl`**: append at milestones and before commit/push (see `.cursorrules`) — rules/skills/subagents self-audit **only**; no retrospective fields.
 - **Rule 18** (session review): same closing **cadence** often as the last metrics line, but **separate** — brief reflection; promote durable lessons into guides or `.cursor/rules` (not JSONL).
 
+## Auto-load guides by file path (do not wait for the trigger phrase)
+
+Load the relevant guide **before** editing, even when the user did not say
+"load ai coding guidelines". The guide sets the rules; deciding without it
+causes preventable CI breakage.
+
+- **Editing `tests/unit/**`** → read `docs/guides/UNIT_TESTING_GUIDE.md`
+  (especially *Pyproject extras: what unit tests may depend on*).
+  `tests/unit/` must not depend on any non-`[dev]` extra (`[ml]`, `[llm]`,
+  `[server]`, `[compare]`); mock the SDK module symbol with `@patch(…)` or a
+  file-scoped autouse fixture instead. Never use `pytest.importorskip()` to
+  sidestep the rule. If a test truly needs the real SDK, it belongs in
+  `tests/integration/`.
+- **Editing `tests/integration/**` or `tests/e2e/**`** → read
+  `docs/guides/TESTING_GUIDE.md` and the relevant section of
+  `docs/architecture/TESTING_STRATEGY.md`.
+- **Adding a new provider / provider method / provider test** → read the
+  two rules above plus the existing test file for the provider you're
+  modifying (follow the established SDK-mock pattern).
+- **Editing `config/profiles/*.yaml`** → see *Profile completeness* below.
+- **Editing `web/gi-kg-viewer/**`** → already covered by the GI/KG rule
+  above (E2E_SURFACE_MAP → specs → UXS).
+
+## Profile completeness (config/profiles/\*.yaml)
+
+Never ship a profile default that references an enum value
+(`llm_pipeline_mode`, `gi_insight_source`, `kg_extraction_source`,
+`summary_provider`, …) without verifying a **live** code path reads it.
+
+Procedure before committing a profile change:
+
+1. Find the field's `Literal[...]` declaration in `src/podcast_scraper/config.py`.
+2. Grep the symbol and the literal strings in `src/` (`grep -rn
+   "llm_pipeline_mode" src/`). Confirm every value in the `Literal` has a
+   dispatch arm that actually does something different.
+3. Trace to the stage that consumes it end-to-end. If the value is
+   accepted by `Config` but no downstream dispatcher switches on it,
+   **the profile is lying**: either wire the dispatch or drop the profile
+   default to a value that is already live.
+
+The `#643 Phase 3C` near-miss (shipping `llm_pipeline_mode: mega_bundled`
+while the dispatch was deferred) is the canonical example — with no wiring
+the new mode would have been *worse* than staged (extra LLM call + no cost
+savings from GIL/KG skip).
+
+## Half-wired features are worse than no feature
+
+Generalises profile completeness to all config / flag / enum additions:
+
+- Adding a new `Literal[...]` value, a new `Config` field, a new CLI flag,
+  or a new method on a provider is only complete when **every code path
+  the user could hit actually does the different thing**. "Method exists
+  but pipeline still calls the old one" is a regression, not a stub.
+- If a full end-to-end wiring is genuinely out of scope, do **not** change
+  profile defaults, do **not** publicise the flag in docs as available, and
+  do **not** add the `Literal` value. Ship the interior pieces as private /
+  unreachable until the dispatch is wired.
+- "Works in unit tests but not through the real pipeline" is the signature
+  failure mode. A wiring test that calls the top-level entrypoint and
+  asserts the downstream stage *skipped its LLM call* is the correct guard
+  (see `tests/unit/podcast_scraper/workflow/test_prefilled_extraction_wiring.py`).
+
+## Resuming from compaction: re-confirm deferred items
+
+When a conversation summary carries over a todo tagged "deferred", "risky",
+or "follow-up", do **not** silently act on it — also do **not** silently
+keep it deferred if it would break the diff you are about to ship.
+Re-state the item and ask: *"Summary says X is deferred. Does that still
+apply, or do we need to do it now before pushing?"* The Phase 3C miss came
+from carrying over a pre-compaction "defer to follow-up" tag without
+re-asking; the profile change it was paired with turned into a lie.
+
 ## COMPLETE GUIDE FILE SET (LOAD ALL WHEN REQUESTED)
 
 **When the user asks to "load ai coding guidelines" or "load coding guidelines", you MUST load ALL of these files:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,30 @@ apply, or do we need to do it now before pushing?"* The Phase 3C miss came
 from carrying over a pre-compaction "defer to follow-up" tag without
 re-asking; the profile change it was paired with turned into a lie.
 
+## Final validation before push: real episodes, not just unit tests
+
+Mocked unit tests prove the dispatch routes correctly; they do **not**
+prove the feature works against real provider responses, real transcripts,
+or the real end-to-end pipeline. Before pushing any change that touches
+a production pipeline stage (summarization dispatch, GI/KG extraction,
+transcription preprocessing, audio pipeline, any new `llm_pipeline_mode`
+value, any profile default), the last step before commit is:
+
+1. **Run one real episode end-to-end** with the changed code path, using
+   the real provider API keys available in `.env`. There is no "I don't
+   have keys" — check `.env` first.
+2. **Measure the claim numerically.** If the change is "fewer LLM calls",
+   count them. If it's "cheaper transcription", measure file size and $.
+   If it's "better KG", count nodes. Unit tests don't measure claims.
+3. **Inspect one artifact by eye.** Open the produced `gi.json` /
+   `kg.json` / `metadata.json` / cleaned audio and confirm it looks sane.
+4. **Only then push.** The test plan checkbox in a PR body is a
+   post-merge reminder, not a replacement for pre-push validation.
+
+For work in `scripts/validate/validate_phase3c.py` style: keep it as a
+committed reusable harness so the next change in the same stage has a
+ready comparison baseline.
+
 ## COMPLETE GUIDE FILE SET (LOAD ALL WHEN REQUESTED)
 
 **When the user asks to "load ai coding guidelines" or "load coding guidelines", you MUST load ALL of these files:**

--- a/config/examples/config.example.yaml
+++ b/config/examples/config.example.yaml
@@ -95,7 +95,7 @@ metadata_format: json  # json or yaml (json recommended for database ingestion)
 
 # Semantic corpus search (RFC-061 / PRD-021): FAISS index over GIL, summaries, transcripts
 # vector_search: false  # Default off. When true, pipeline runs embed-and-index after finalize
-# vector_backend: faiss  # Phase 1: faiss only; qdrant deferred (RFC-061 Phase 2)
+# vector_backend: faiss  # Only value accepted today; qdrant reserved for RFC-070 (re-added to Literal when wired)
 # vector_index_path: null  # Optional; relative → under output_dir. Default: search/ → <output_dir>/search/
 # vector_embedding_model: minilm-l6  # Registry alias or full sentence-transformers id (see ModelRegistry)
 # vector_index_types: null  # Optional list: insight, quote, summary, transcript, kg_topic, kg_entity (default: all)

--- a/config/profiles/cloud_balanced.yaml
+++ b/config/profiles/cloud_balanced.yaml
@@ -37,6 +37,17 @@ summary_provider: gemini
 gemini_summary_model: gemini-2.5-flash-lite
 preprocessing_enabled: true
 
+# Pipeline mode — extraction_bundled (#643): summary/bullets use the provider's
+# native summary prompt (staged), insights + topics + entities collapse into a
+# single extraction call. Halves cloud calls for GIL+KG+NER without betting on
+# tier-1 mega-bundle fidelity. Works for all 6 cloud providers; swap to
+# mega_bundled on Anthropic or DeepSeek if you need max cost savings.
+llm_pipeline_mode: extraction_bundled
+
+# Output token floor for cloud LLM structured JSON (#645). Prevents truncated
+# JSON (Gemini returned empty strings on long transcripts below ~650 tokens).
+cloud_llm_structured_min_output_tokens: 4096
+
 # Grounded Insights
 generate_gi: true
 gi_insight_source: provider

--- a/config/profiles/cloud_balanced.yaml
+++ b/config/profiles/cloud_balanced.yaml
@@ -37,12 +37,16 @@ summary_provider: gemini
 gemini_summary_model: gemini-2.5-flash-lite
 preprocessing_enabled: true
 
-# Pipeline mode — extraction_bundled (#643): summary/bullets use the provider's
-# native summary prompt (staged), insights + topics + entities collapse into a
-# single extraction call. Halves cloud calls for GIL+KG+NER without betting on
-# tier-1 mega-bundle fidelity. Works for all 6 cloud providers; swap to
-# mega_bundled on Anthropic or DeepSeek if you need max cost savings.
-llm_pipeline_mode: extraction_bundled
+# Pipeline mode — mega_bundled (#646 real-episode validation):
+# 1 LLM call returns summary + bullets + insights + topics + entities.
+# Gemini flash-lite mega_bundled measured on real investor-podcast traffic
+# (scripts/validate/validate_phase3c.py, 2026-04-21):
+#   $0.00127/ep medium (~45min audio), 17.8 s, 12 insights / 10 topics / 15 entities.
+# vs extraction_bundled ($0.00265/ep, 2 calls) same artifact counts → 52 % cheaper.
+# vs staged ($0.00445/ep, 3 calls) → 72 % cheaper.
+# Gemini may occasionally return transient 503 UNAVAILABLE — retry_with_metrics
+# handles this with backoff but it can add a few seconds on a bad minute.
+llm_pipeline_mode: mega_bundled
 
 # Output token floor for cloud LLM structured JSON (#645). Prevents truncated
 # JSON (Gemini returned empty strings on long transcripts below ~650 tokens).

--- a/config/profiles/cloud_quality.yaml
+++ b/config/profiles/cloud_quality.yaml
@@ -31,16 +31,21 @@ speaker_detector_provider: spacy
 ner_model: en_core_web_trf
 auto_speakers: true
 
-# Summarization — DeepSeek for quality
-summary_provider: deepseek
-deepseek_summary_model: deepseek-chat
+# Summarization — Anthropic haiku-4.5 for tier-1 mega-bundle (#646 validation).
+# Real-episode test (scripts/validate/validate_phase3c.py, 2026-04-21):
+# 1 LLM call / ep, 12 insights / 10 topics / 7+ entities, ~15 s, entity F1 = 1.000.
+# DeepSeek deepseek-chat is a validated tier-2 alternative (~10× cheaper, ~50 s,
+# 12 / 10 / 8–15 artifacts) IF deepseek_timeout ≥ 300 — switch to:
+#   summary_provider: deepseek
+#   deepseek_summary_model: deepseek-chat
+#   deepseek_timeout: 600
+# for high-volume corpus building where latency > quality. See
+# docs/guides/AI_PROVIDER_COMPARISON_GUIDE.md for the full tradeoff.
+summary_provider: anthropic
+anthropic_summary_model: claude-haiku-4-5
 
 # Pipeline mode — mega_bundled (#643): one call returns
-# title + summary + bullets + insights + topics + entities. DeepSeek is tier-2
-# for mega-bundle (entity F1 ≈ 0.88 vs Anthropic haiku-4.5 tier-1 at 1.000),
-# but the ~6× cost savings vs three standalone calls outweighs the entity gap
-# for most quality-tier users. Swap to Anthropic haiku-4.5 + mega_bundled if
-# NER fidelity matters most. See docs/guides/AI_PROVIDER_COMPARISON_GUIDE.md.
+# title + summary + bullets + insights + topics + entities.
 llm_pipeline_mode: mega_bundled
 
 # Output token floor for cloud LLM structured JSON (#645). Default 4096 is

--- a/config/profiles/cloud_quality.yaml
+++ b/config/profiles/cloud_quality.yaml
@@ -35,6 +35,19 @@ auto_speakers: true
 summary_provider: deepseek
 deepseek_summary_model: deepseek-chat
 
+# Pipeline mode — mega_bundled (#643): one call returns
+# title + summary + bullets + insights + topics + entities. DeepSeek is tier-2
+# for mega-bundle (entity F1 ≈ 0.88 vs Anthropic haiku-4.5 tier-1 at 1.000),
+# but the ~6× cost savings vs three standalone calls outweighs the entity gap
+# for most quality-tier users. Swap to Anthropic haiku-4.5 + mega_bundled if
+# NER fidelity matters most. See docs/guides/AI_PROVIDER_COMPARISON_GUIDE.md.
+llm_pipeline_mode: mega_bundled
+
+# Output token floor for cloud LLM structured JSON (#645). Default 4096 is
+# enough for mega-bundle on full-length transcripts; raise if you see
+# truncated JSON in logs.
+cloud_llm_structured_min_output_tokens: 4096
+
 # Grounded Insights — uses summary_provider (DeepSeek) for insight + evidence.
 # Best single-provider GI in the 7-LLM matrix is Gemini at 80%, but switching
 # here would split summary and GI across providers. Per-stage provider routing

--- a/docs/guides/AI_PROVIDER_COMPARISON_GUIDE.md
+++ b/docs/guides/AI_PROVIDER_COMPARISON_GUIDE.md
@@ -54,6 +54,39 @@ params:
 
 ---
 
+## LLM pipeline modes (`llm_pipeline_mode`)
+
+Four end-to-end pipelines produce the `{title, summary, bullets}` artifact **plus**
+insights / topics / entities that feed the knowledge graph:
+
+| Mode | API calls | Best for | Tier-1 providers |
+| --- | --- | --- | --- |
+| `staged` (default) | 3–4 (summary + GIL + KG/NER) | Local/Ollama; when bullets/summary quality must be tuned independently | All |
+| `bundled` | 1 summary + 2 extraction | Compact cloud runs where summary+bullets fit one call | Anthropic, Ollama |
+| `extraction_bundled` | 1 summary + 1 extraction | Balanced cloud — summary stays in a provider-tuned prompt, extraction collapses into one call | All cloud providers |
+| `mega_bundled` | 1 | Quality-first cloud, tier-1 providers only — single call returns everything | Anthropic (tier 1), DeepSeek (tier 2) |
+
+Research pointers (#632 mega-bundle experiment):
+
+- **Anthropic `claude-haiku-4-5` mega-bundled** — summary length within 74 % of
+  silver, KG topic coverage 81 % (beats standalone 71 %), entity F1 = 1.000.
+  Saves ~⅔ of extraction cost vs three calls. Use for `cloud_quality`.
+- **DeepSeek `deepseek-chat` mega-bundled** — tier 2: summary 73 %, KG 71 %
+  (baseline), entity F1 ≈ 0.88. ~6× cheaper than separate calls.
+- **OpenAI / Gemini / Mistral / Grok** — not tier-1 for mega-bundle (KG or
+  entity quality regresses). Use `extraction_bundled` to still collapse the
+  GIL+KG+NER trio into one JSON call while keeping the provider's native
+  summary prompt for paragraph/bullets.
+
+Set the mode in your profile:
+
+```yaml
+llm_pipeline_mode: "mega_bundled"        # or: "extraction_bundled", "bundled", "staged"
+cloud_llm_structured_min_output_tokens: 4096  # floor for JSON responses (#645)
+```
+
+---
+
 ## Full reference — v2 matrix details
 
 The two picks above cover most deployments. Everything below is the detailed reference for

--- a/docs/guides/AI_PROVIDER_COMPARISON_GUIDE.md
+++ b/docs/guides/AI_PROVIDER_COMPARISON_GUIDE.md
@@ -66,17 +66,33 @@ insights / topics / entities that feed the knowledge graph:
 | `extraction_bundled` | 1 summary + 1 extraction | Balanced cloud — summary stays in a provider-tuned prompt, extraction collapses into one call | All cloud providers |
 | `mega_bundled` | 1 | Quality-first cloud, tier-1 providers only — single call returns everything | Anthropic (tier 1), DeepSeek (tier 2) |
 
-Research pointers (#632 mega-bundle experiment):
+### Real-episode validation (2026-04-21, #646)
 
-- **Anthropic `claude-haiku-4-5` mega-bundled** — summary length within 74 % of
-  silver, KG topic coverage 81 % (beats standalone 71 %), entity F1 = 1.000.
-  Saves ~⅔ of extraction cost vs three calls. Use for `cloud_quality`.
-- **DeepSeek `deepseek-chat` mega-bundled** — tier 2: summary 73 %, KG 71 %
-  (baseline), entity F1 ≈ 0.88. ~6× cheaper than separate calls.
-- **OpenAI / Gemini / Mistral / Grok** — not tier-1 for mega-bundle (KG or
-  entity quality regresses). Use `extraction_bundled` to still collapse the
-  GIL+KG+NER trio into one JSON call while keeping the provider's native
-  summary prompt for paragraph/bullets.
+All 6 cloud providers tested end-to-end via `scripts/validate/validate_phase3c.py`
+on two real investor-podcast transcripts (7.8 KB short ~8 min, 47 KB medium ~45 min).
+Every provider passes the call-count / prefilled-propagation / artifact-count gates
+in `mega_bundled` mode — **the #632 "tier-1/tier-2 only" claim did not hold on
+real production traffic.**
+
+Medium transcript (~45 min, representative of production audio):
+
+| Provider | Model | Calls | Cost $ | Time | Ins / Top / Ent | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| **Gemini** | flash-lite | 1 | **0.00127** | 17.8 s | 12 / 10 / 15 | Cost/latency winner; default for `cloud_balanced`. Occasional 503 UNAVAILABLE (retried). |
+| **Mistral** | small-latest | 1 | 0.00201 | **8.6 s** | 12 / 10 / 14 | Fastest of all providers. |
+| **OpenAI** | gpt-4o-mini | 1 | 0.00153 | 23.9 s | 12 / 10 / 15 | Reliable mid-cost. |
+| **DeepSeek** | deepseek-chat | 1 | 0.00223 | 56.2 s | 12 / 10 / 15 | Slowest; needs `deepseek_timeout ≥ 300` (default 600 s in #646). |
+| **Anthropic** | haiku-4.5 | 1 | 0.01530 | 16.3 s | 12 / 10 / 15 | Most specific entity names ("Salomon Brothers", "Duke University"); default for `cloud_quality`. |
+| **Grok** | grok-3-mini | 1 | 0.03346 | 43.4 s | 12 / 10 / 13 | 25× more expensive than Gemini with no quality edge. Not recommended for volume. |
+
+Baseline comparison on Gemini (medium transcript): **staged** = 3 calls, $0.00445, 13.5 s; **bundled** = 3 calls, $0.00438, 11.2 s; **extraction_bundled** = 2 calls, $0.00265, 9.7 s; **mega_bundled** = 1 call, $0.00127, 17.8 s. Mega-bundled = 72 % cheaper than staged for the same artifact counts.
+
+**Profile defaults after validation:**
+
+- `cloud_balanced` → **Gemini flash-lite mega_bundled** (cheapest, same quality as extraction_bundled, simpler pipeline).
+- `cloud_quality` → **Anthropic haiku-4.5 mega_bundled** (entity F1 = 1.000 per #632, most specific entity names, 15 s latency).
+
+**Quality caveat:** entity F1 numbers from #632 (Anthropic 1.000 vs DeepSeek 0.88) were on fixture transcripts. Real-episode artifact counts are now comparable across all 6 providers; differences are subtler (name specificity, edge-case entity capture). Re-score with the eval harness if entity fidelity is critical.
 
 Set the mode in your profile:
 

--- a/docs/wip/PLAN_NEXT_SESSION.md
+++ b/docs/wip/PLAN_NEXT_SESSION.md
@@ -22,3 +22,28 @@
    - Insight cluster integration in viewer
    - Cluster browse, quote search, topic-insight matrix in UI
    - Separate TypeScript/Vue work
+
+## Follow-ups noted during #646 / Phase 3C validation (not yet scheduled)
+
+- **Real-episode end-to-end validation for single-feed corpus layout
+  (#644).** 4 unit tests in
+  `tests/unit/podcast_scraper/test_service_single_feed_corpus_layout.py`
+  confirm `single_feed_uses_corpus_layout=True` wraps `output_dir` with
+  `feeds/<slug>/run_*/`, but no real scraper run has exercised it. Same
+  class of gap as #643 Phase 3C. Work: scrape one RSS feed with and
+  without the flag, diff the on-disk trees, confirm single-feed output
+  matches multi-feed shape exactly. Add an integration test that runs the
+  scraper in dry-run against a mocked RSS to assert directory layout.
+  Blast radius: silent divergence between single- and multi-feed corpora
+  (the original bug this flag was supposed to fix).
+- **Real-episode end-to-end validation for audio preprocessing profile
+  wiring (#634/#642).** Research itself was validated against real fixtures
+  (`data/eval/runs/_bitrate_sweep/`, `_silence_sweep/`) and profile
+  resolution has 8 unit tests, but no real scraped episode was ever run
+  end-to-end with `speech_optimal_v1` to confirm the downstream ffmpeg
+  call actually uses 32 kbps + -30dB/0.5s. Same class of gap as #643
+  Phase 3C (wiring-not-validated). Work: hook logging on preprocessing
+  stage, run one real episode through `cloud_balanced`, confirm ffmpeg
+  args + file-size reduction + WER within 1 % of reference, add an
+  integration test to prevent regression. Blast radius of ignoring:
+  silent cost regression, no crash.

--- a/scripts/eval/megabundle_experiment.py
+++ b/scripts/eval/megabundle_experiment.py
@@ -1,0 +1,631 @@
+"""Mega-bundle experiment: single LLM call for summary + GI + KG (#632).
+
+Tests whether one structured JSON call can produce all extraction outputs
+(title, summary, bullets, insights, topics, entities) without unacceptable
+quality degradation vs three standalone calls.
+
+Silver references (curated_5feeds_benchmark_v2):
+  - Summary paragraph: data/eval/references/silver/silver_sonnet46_benchmark_v2_paragraph
+  - GI insights (n=12): data/eval/references/silver/silver_sonnet46_gi_benchmark_v2
+  - KG topics + entities: data/eval/references/silver/silver_sonnet46_kg_benchmark_v2
+
+Scoring per field:
+  - Summary paragraph: ROUGE-L F1 vs silver paragraph
+  - GI insights: embedding coverage @ 0.65 threshold vs silver insight texts
+  - KG topics: embedding coverage @ 0.65 threshold vs silver topic labels
+  - KG entities: set F1 on normalized entity names
+
+Success criteria (from #632 / MEGA_BUNDLE_EXPERIMENT_PLAN.md):
+  Summary:    gpt-4o-mini standalone 0.469 -> acceptable >= 0.440
+  GI (n=12):  82% coverage -> acceptable >= 75%
+  KG topics:  71% coverage -> acceptable >= 65%
+  Entities:   1.000 F1 -> acceptable >= 0.900
+
+Keys (autoresearch convention; falls back to production env var):
+  AUTORESEARCH_EXPERIMENT_OPENAI_API_KEY   | OPENAI_API_KEY
+  AUTORESEARCH_EXPERIMENT_GEMINI_API_KEY   | GEMINI_API_KEY
+  AUTORESEARCH_EXPERIMENT_ANTHROPIC_API_KEY| ANTHROPIC_API_KEY
+
+Usage:
+    export AUTORESEARCH_EXPERIMENT_OPENAI_API_KEY=sk-...
+    python scripts/eval/megabundle_experiment.py \\
+        --transcripts-dir data/eval/materialized/curated_5feeds_benchmark_v2 \\
+        --silver-dir data/eval/references/silver \\
+        --episodes p01_e03,p02_e03,p03_e03,p04_e03,p05_e03 \\
+        --provider openai \\
+        --model gpt-4o-mini
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RESULTS_DIR = _REPO_ROOT / "data" / "eval" / "runs" / "_megabundle"
+
+# Success criteria per field (baselines from v2 held-out eval on same 5 eps).
+SUMMARY_BASELINE = 0.469  # gpt-4o-mini standalone paragraph, v2 held-out
+SUMMARY_ACCEPTABLE = 0.440  # <6% drop
+BULLETS_BASELINE = 0.396  # gpt-4o-mini standalone bullets, v2 held-out
+BULLETS_ACCEPTABLE = 0.370  # <6% drop
+GI_BASELINE_PCT = 82.0
+GI_ACCEPTABLE_PCT = 75.0
+KG_TOPIC_BASELINE_PCT = 71.0
+KG_TOPIC_ACCEPTABLE_PCT = 65.0
+ENTITY_ACCEPTABLE_F1 = 0.900
+
+EMBED_THRESHOLD = 0.65
+
+
+def _resolve_key(provider: str) -> Optional[str]:
+    mapping = {
+        "openai": ("AUTORESEARCH_EXPERIMENT_OPENAI_API_KEY", "OPENAI_API_KEY"),
+        "gemini": ("AUTORESEARCH_EXPERIMENT_GEMINI_API_KEY", "GEMINI_API_KEY"),
+        "anthropic": ("AUTORESEARCH_EXPERIMENT_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"),
+        "deepseek": ("AUTORESEARCH_EXPERIMENT_DEEPSEEK_API_KEY", "DEEPSEEK_API_KEY"),
+        "mistral": ("AUTORESEARCH_EXPERIMENT_MISTRAL_API_KEY", "MISTRAL_API_KEY"),
+        "grok": ("AUTORESEARCH_EXPERIMENT_GROK_API_KEY", "GROK_API_KEY"),
+    }
+    ar, prod = mapping[provider]
+    return os.environ.get(ar) or os.environ.get(prod)
+
+
+_OPENAI_COMPATIBLE_BASE_URLS: Dict[str, str] = {
+    "deepseek": "https://api.deepseek.com",
+    "grok": "https://api.x.ai/v1",
+}
+
+
+# ---------------------------------------------------------------------------
+# Prompt
+# ---------------------------------------------------------------------------
+
+
+def build_megabundle_prompt(transcript: str) -> Tuple[str, str]:
+    """Return (system_prompt, user_prompt) for the mega-bundle call."""
+    system = (
+        "You are a podcast content analyzer. Given a podcast episode transcript, "
+        "produce a SINGLE JSON object with exactly the fields specified below. "
+        "Output valid JSON only — no commentary, no code fences."
+    )
+    user = (
+        "From the transcript below, extract the following fields into one JSON "
+        "object:\n\n"
+        '  "title": string — concise episode title (10-15 words).\n'
+        '  "summary": string — 4-6 paragraph prose summary, covering main '
+        "arguments, guests, and conclusions.\n"
+        '  "bullets": array of 4-6 strings — key takeaways as standalone sentences.\n'
+        '  "insights": array of EXACTLY 12 objects, each '
+        '{"text": string, "insight_type": "claim"|"fact"|"opinion"}. '
+        "Insights must be grounded factual claims or strong opinions from the "
+        "transcript, not summaries or filler.\n"
+        '  "topics": array of EXACTLY 10 strings — distinct 2-8 word noun phrases '
+        "capturing the episode's subject matter. Noun phrases only "
+        "(e.g. 'passive index investing', NOT 'passive investing is better'). "
+        "Topics must be unique.\n"
+        '  "entities": array of up to 15 objects, each '
+        '{"name": string, "kind": "person"|"org"|"place", '
+        '"role": "host"|"guest"|"mentioned"}. '
+        'Use "host"/"guest" only when the transcript clearly identifies the '
+        'person as such; otherwise use "mentioned".\n\n'
+        "Transcript:\n"
+        "---\n"
+        f"{transcript}\n"
+        "---\n\n"
+        "Output ONLY the JSON object."
+    )
+    return system, user
+
+
+# ---------------------------------------------------------------------------
+# Provider call
+# ---------------------------------------------------------------------------
+
+
+def call_megabundle(
+    provider: str, model: str, api_key: str, transcript: str
+) -> Tuple[Dict[str, Any], float, Optional[float]]:
+    """Returns (parsed_json, wall_s, estimated_cost_usd_or_None)."""
+    system, user = build_megabundle_prompt(transcript)
+    t0 = time.time()
+    if provider == "openai":
+        from openai import OpenAI
+
+        client = OpenAI(api_key=api_key)
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            response_format={"type": "json_object"},
+            temperature=0.0,
+        )
+        text = resp.choices[0].message.content or "{}"
+        # gpt-4o-mini pricing approx: $0.15/1M input, $0.60/1M output
+        usage = resp.usage
+        cost = None
+        if usage:
+            cost = (
+                usage.prompt_tokens / 1_000_000 * 0.15 + usage.completion_tokens / 1_000_000 * 0.60
+            )
+    elif provider == "anthropic":
+        import anthropic
+
+        client = anthropic.Anthropic(api_key=api_key)
+        resp = client.messages.create(
+            model=model,
+            max_tokens=8192,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+            temperature=0.0,
+        )
+        text = resp.content[0].text if resp.content else "{}"
+        # claude-haiku-4-5 pricing approx: $1/1M input, $5/1M output
+        cost = None
+        if hasattr(resp, "usage"):
+            cost = (
+                resp.usage.input_tokens / 1_000_000 * 1.0
+                + resp.usage.output_tokens / 1_000_000 * 5.0
+            )
+    elif provider == "gemini":
+        import google.genai as genai
+
+        client = genai.Client(api_key=api_key)
+        resp = client.models.generate_content(
+            model=model,
+            contents=f"{system}\n\n{user}",
+            config={
+                "response_mime_type": "application/json",
+                "temperature": 0.0,
+                "max_output_tokens": 16384,
+            },
+        )
+        text = resp.text or "{}"
+        # gemini-2.5-flash-lite pricing very approx
+        cost = None
+    elif provider in ("deepseek", "grok", "mistral"):
+        # OpenAI-compatible chat endpoint (DeepSeek/Grok via base_url swap;
+        # Mistral via its SDK).
+        if provider == "mistral":
+            from mistralai import Mistral
+
+            m_client = Mistral(api_key=api_key)
+            resp = m_client.chat.complete(
+                model=model,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                response_format={"type": "json_object"},
+                temperature=0.0,
+            )
+            text = resp.choices[0].message.content or "{}"
+            cost = None  # Mistral cost derivation TBD
+        else:
+            from openai import OpenAI
+
+            client = OpenAI(api_key=api_key, base_url=_OPENAI_COMPATIBLE_BASE_URLS[provider])
+            kwargs: Dict[str, Any] = {
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                "temperature": 0.0,
+            }
+            if provider == "deepseek":
+                kwargs["response_format"] = {"type": "json_object"}
+            resp = client.chat.completions.create(**kwargs)
+            text = resp.choices[0].message.content or "{}"
+            cost = None
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+    dt = time.time() - t0
+
+    # Parse JSON; strip code fences if present.
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Provider returned non-JSON: {e}\n---\n{text[:500]}") from e
+    return parsed, round(dt, 1), round(cost, 6) if cost is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Silver loaders
+# ---------------------------------------------------------------------------
+
+
+def load_silver_paragraph(silver_dir: Path, episode_id: str) -> Optional[str]:
+    """Load silver paragraph summary. Silver uses key 'summary_final'."""
+    pred_path = silver_dir / "silver_sonnet46_benchmark_v2_paragraph" / "predictions.jsonl"
+    if not pred_path.exists():
+        return None
+    for line in pred_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if row.get("episode_id") == episode_id:
+            out = row.get("output") or {}
+            if isinstance(out, dict):
+                return out.get("summary_final") or out.get("summary") or out.get("paragraph") or ""
+            if isinstance(out, str):
+                return out
+    return None
+
+
+def _load_silver_bullets_row(silver_dir: Path, episode_id: str) -> Optional[Dict[str, Any]]:
+    """Return the decoded {title, bullets, ...} dict from the bullets silver row,
+    or None. The bullets silver stores a JSON STRING at output.summary_final."""
+    path = silver_dir / "silver_sonnet46_benchmark_v2_bullets" / "predictions.jsonl"
+    if not path.exists():
+        return None
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if row.get("episode_id") == episode_id:
+            out = row.get("output") or {}
+            nested = out.get("summary_final")
+            if isinstance(nested, str):
+                try:
+                    return json.loads(nested)
+                except json.JSONDecodeError:
+                    return None
+            if isinstance(nested, dict):
+                return nested
+    return None
+
+
+def load_silver_bullets(silver_dir: Path, episode_id: str) -> List[str]:
+    inner = _load_silver_bullets_row(silver_dir, episode_id)
+    if not inner:
+        return []
+    return [str(b).strip() for b in (inner.get("bullets") or []) if b]
+
+
+def load_silver_title(silver_dir: Path, episode_id: str) -> str:
+    inner = _load_silver_bullets_row(silver_dir, episode_id)
+    if not inner:
+        return ""
+    return str(inner.get("title") or "").strip()
+
+
+def load_silver_gi_insights(silver_dir: Path, episode_id: str) -> List[str]:
+    path = silver_dir / "silver_sonnet46_gi_benchmark_v2" / "predictions.jsonl"
+    if not path.exists():
+        return []
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if row.get("episode_id") == episode_id:
+            insights = (row.get("output") or {}).get("insights") or []
+            return [str(ins.get("text", "")).strip() for ins in insights if ins.get("text")]
+    return []
+
+
+def load_silver_kg(silver_dir: Path, episode_id: str) -> Tuple[List[str], List[str]]:
+    """Return (topic_labels, entity_names)."""
+    path = silver_dir / "silver_sonnet46_kg_benchmark_v2" / "predictions.jsonl"
+    if not path.exists():
+        return [], []
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if row.get("episode_id") == episode_id:
+            out = row.get("output") or {}
+            topics = [
+                str(t.get("label", t) if isinstance(t, dict) else t).strip()
+                for t in (out.get("topics") or [])
+            ]
+            entities = [
+                str(e.get("name", e) if isinstance(e, dict) else e).strip()
+                for e in (out.get("entities") or [])
+            ]
+            return [t for t in topics if t], [e for e in entities if e]
+    return [], []
+
+
+# ---------------------------------------------------------------------------
+# Scorers
+# ---------------------------------------------------------------------------
+
+
+def rouge_l_f1(hypothesis: str, reference: str) -> float:
+    """Word-level ROUGE-L F1 using LCS."""
+    hyp = hypothesis.lower().split()
+    ref = reference.lower().split()
+    if not hyp or not ref:
+        return 0.0
+    # LCS length
+    dp = [[0] * (len(ref) + 1) for _ in range(len(hyp) + 1)]
+    for i, h in enumerate(hyp, 1):
+        for j, r in enumerate(ref, 1):
+            if h == r:
+                dp[i][j] = dp[i - 1][j - 1] + 1
+            else:
+                dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+    lcs = dp[len(hyp)][len(ref)]
+    if lcs == 0:
+        return 0.0
+    p = lcs / len(hyp)
+    r = lcs / len(ref)
+    return 2 * p * r / (p + r)
+
+
+def entity_set_f1(hyp_names: List[str], ref_names: List[str]) -> float:
+    def norm(s: str) -> str:
+        return " ".join(s.strip().lower().split())
+
+    hyp = {norm(n) for n in hyp_names if n}
+    ref = {norm(n) for n in ref_names if n}
+    if not ref and not hyp:
+        return 1.0
+    if not ref or not hyp:
+        return 0.0
+    tp = len(hyp & ref)
+    if tp == 0:
+        return 0.0
+    p = tp / len(hyp)
+    r = tp / len(ref)
+    return 2 * p * r / (p + r)
+
+
+def embedding_coverage(
+    hyp_texts: List[str], ref_texts: List[str], threshold: float = EMBED_THRESHOLD
+) -> Tuple[float, int, int]:
+    """Fraction of refs matched by at least one hyp above cosine threshold.
+
+    Returns (coverage_pct, matched_count, ref_count).
+    """
+    if not ref_texts:
+        return 0.0, 0, 0
+    if not hyp_texts:
+        return 0.0, 0, len(ref_texts)
+    from sentence_transformers import SentenceTransformer, util
+
+    model = SentenceTransformer("all-MiniLM-L6-v2")
+    hyp_emb = model.encode(hyp_texts, convert_to_tensor=True, show_progress_bar=False)
+    ref_emb = model.encode(ref_texts, convert_to_tensor=True, show_progress_bar=False)
+    sim = util.cos_sim(ref_emb, hyp_emb)  # (n_ref, n_hyp)
+    matched = 0
+    for i in range(len(ref_texts)):
+        if sim[i].max().item() >= threshold:
+            matched += 1
+    return matched / len(ref_texts) * 100.0, matched, len(ref_texts)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Mega-bundle experiment (#632)")
+    parser.add_argument("--transcripts-dir", required=True)
+    parser.add_argument("--silver-dir", required=True, help="Root dir for silver references")
+    parser.add_argument("--episodes", required=True)
+    parser.add_argument(
+        "--provider",
+        required=True,
+        choices=["openai", "anthropic", "gemini", "deepseek", "mistral", "grok"],
+    )
+    parser.add_argument("--model", required=True)
+    args = parser.parse_args()
+
+    key = _resolve_key(args.provider)
+    if not key:
+        sys.exit(f"No API key for {args.provider}")
+
+    transcripts_dir = Path(args.transcripts_dir)
+    silver_dir = Path(args.silver_dir)
+    episodes = [e.strip() for e in args.episodes.split(",") if e.strip()]
+
+    print(f"Provider/Model: {args.provider}/{args.model}")
+    print(f"Episodes:       {episodes}\n", flush=True)
+
+    results: List[Dict[str, Any]] = []
+    total_cost = 0.0
+
+    for ep in episodes:
+        tpath = transcripts_dir / f"{ep}.txt"
+        if not tpath.exists():
+            print(f"  {ep}: SKIP (no transcript)", flush=True)
+            continue
+        transcript = tpath.read_text(encoding="utf-8")
+        # Cap transcript input to avoid going over context (rough 25k-char cap).
+        transcript = transcript[:25000]
+
+        ref_para = load_silver_paragraph(silver_dir, ep) or ""
+        ref_bullets = load_silver_bullets(silver_dir, ep)
+        ref_title = load_silver_title(silver_dir, ep)
+        ref_insights = load_silver_gi_insights(silver_dir, ep)
+        ref_topics, ref_entities = load_silver_kg(silver_dir, ep)
+
+        print(
+            f"  {ep}: transcript={len(transcript)} chars, "
+            f"refs: para={len(ref_para)} chars, bullets={len(ref_bullets)}, "
+            f"gi={len(ref_insights)}, kg={len(ref_topics)} topics + {len(ref_entities)} ents",
+            flush=True,
+        )
+        print(f"  {ep}: calling {args.provider}/{args.model}...", flush=True)
+        try:
+            parsed, wall_s, cost = call_megabundle(args.provider, args.model, key, transcript)
+        except Exception as e:
+            print(f"  {ep}: FAIL ({type(e).__name__}: {e})", flush=True)
+            continue
+        if cost:
+            total_cost += cost
+
+        # Extract fields (defensive on missing keys)
+        hyp_summary = str(parsed.get("summary", "")).strip()
+        hyp_bullets = parsed.get("bullets") or []
+        hyp_insights = [
+            str((i or {}).get("text", i) if isinstance(i, dict) else i).strip()
+            for i in (parsed.get("insights") or [])
+        ]
+        hyp_topics = [str(t).strip() for t in (parsed.get("topics") or [])]
+        hyp_entities = [
+            str((e or {}).get("name", e) if isinstance(e, dict) else e).strip()
+            for e in (parsed.get("entities") or [])
+        ]
+        hyp_insights = [x for x in hyp_insights if x]
+        hyp_topics = [x for x in hyp_topics if x]
+        hyp_entities = [x for x in hyp_entities if x]
+
+        # Score
+        hyp_title = str(parsed.get("title", "")).strip()
+        title_rouge = rouge_l_f1(hyp_title, ref_title) if ref_title and hyp_title else None
+        summ_rouge = rouge_l_f1(hyp_summary, ref_para) if ref_para else None
+        # Bullets: ROUGE-L on joined-newline strings (matches v2 bullets scoring).
+        if ref_bullets and hyp_bullets:
+            bul_rouge = rouge_l_f1(
+                "\n".join(str(b) for b in hyp_bullets),
+                "\n".join(str(b) for b in ref_bullets),
+            )
+        else:
+            bul_rouge = None
+        gi_cov, gi_hit, gi_total = embedding_coverage(hyp_insights, ref_insights)
+        kg_cov, kg_hit, kg_total = embedding_coverage(hyp_topics, ref_topics)
+        ent_f1 = entity_set_f1(hyp_entities, ref_entities)
+
+        row = {
+            "episode": ep,
+            "provider": args.provider,
+            "model": args.model,
+            "wall_s": wall_s,
+            "cost_usd": cost,
+            "counts": {
+                "bullets": len(hyp_bullets),
+                "insights": len(hyp_insights),
+                "topics": len(hyp_topics),
+                "entities": len(hyp_entities),
+            },
+            "scores": {
+                "title_rouge_l": round(title_rouge, 4) if title_rouge is not None else None,
+                "summary_rouge_l": round(summ_rouge, 4) if summ_rouge is not None else None,
+                "bullets_rouge_l": round(bul_rouge, 4) if bul_rouge is not None else None,
+                "gi_coverage_pct": round(gi_cov, 1),
+                "gi_matched": f"{gi_hit}/{gi_total}",
+                "kg_topic_coverage_pct": round(kg_cov, 1),
+                "kg_topic_matched": f"{kg_hit}/{kg_total}",
+                "entity_f1": round(ent_f1, 3),
+            },
+            "outputs": {
+                "title": parsed.get("title", ""),
+                "summary": hyp_summary,
+                "bullets": hyp_bullets,
+                "insights": hyp_insights,
+                "topics": hyp_topics,
+                "entities": hyp_entities,
+            },
+        }
+        results.append(row)
+
+        def _fmt(v: Optional[float], spec: str = ".3f") -> str:
+            return format(v, spec) if v is not None else "—"
+
+        print(
+            f"  {ep}: title={_fmt(title_rouge)} summary={_fmt(summ_rouge)} "
+            f"bullets={_fmt(bul_rouge)} gi={gi_cov:.1f}% kg_topics={kg_cov:.1f}% "
+            f"ent={ent_f1:.3f} wall={wall_s}s cost=${cost or 0:.4f}",
+            flush=True,
+        )
+
+    # Summary table
+    print("\n" + "=" * 70)
+    print("SUMMARY vs success criteria")
+    print("=" * 70)
+    titles = [
+        r["scores"]["title_rouge_l"] for r in results if r["scores"]["title_rouge_l"] is not None
+    ]
+    summ = [
+        r["scores"]["summary_rouge_l"]
+        for r in results
+        if r["scores"]["summary_rouge_l"] is not None
+    ]
+    buls = [
+        r["scores"]["bullets_rouge_l"]
+        for r in results
+        if r["scores"]["bullets_rouge_l"] is not None
+    ]
+    gis = [r["scores"]["gi_coverage_pct"] for r in results]
+    kgs = [r["scores"]["kg_topic_coverage_pct"] for r in results]
+    ents = [r["scores"]["entity_f1"] for r in results]
+
+    if titles:
+        tm = statistics.mean(titles)
+        # Titles are short strings; ROUGE-L baseline noise band is wide. Report
+        # without a pass/fail verdict — interpret in context.
+        print(f"  Title (ROUGE-L):    avg {tm:.3f}  (short-string ROUGE-L — compare relative)")
+    if summ:
+        sm = statistics.mean(summ)
+        verdict = "PASS" if sm >= SUMMARY_ACCEPTABLE else "BORDERLINE" if sm >= 0.420 else "FAIL"
+        print(
+            f"  Summary (ROUGE-L):  avg {sm:.3f}  "
+            f"(bar {SUMMARY_ACCEPTABLE}; baseline {SUMMARY_BASELINE}) -> {verdict}"
+        )
+    if buls:
+        bm = statistics.mean(buls)
+        verdict = "PASS" if bm >= BULLETS_ACCEPTABLE else "FAIL"
+        print(
+            f"  Bullets (ROUGE-L):  avg {bm:.3f}  "
+            f"(bar {BULLETS_ACCEPTABLE}; baseline {BULLETS_BASELINE}) -> {verdict}"
+        )
+    if gis:
+        gm = statistics.mean(gis)
+        verdict = "PASS" if gm >= GI_ACCEPTABLE_PCT else "FAIL"
+        print(
+            f"  GI coverage:        avg {gm:.1f}%  "
+            f"(bar {GI_ACCEPTABLE_PCT}%; baseline {GI_BASELINE_PCT}%) -> {verdict}"
+        )
+    if kgs:
+        km = statistics.mean(kgs)
+        verdict = "PASS" if km >= KG_TOPIC_ACCEPTABLE_PCT else "FAIL"
+        print(
+            f"  KG topic coverage:  avg {km:.1f}%  "
+            f"(bar {KG_TOPIC_ACCEPTABLE_PCT}%; baseline {KG_TOPIC_BASELINE_PCT}%) -> {verdict}"
+        )
+    if ents:
+        em = statistics.mean(ents)
+        verdict = "PASS" if em >= ENTITY_ACCEPTABLE_F1 else "FAIL"
+        print(f"  Entity F1:          avg {em:.3f}  " f"(bar {ENTITY_ACCEPTABLE_F1}) -> {verdict}")
+    print(f"\nTotal API cost (est.): ${total_cost:.4f}")
+
+    # Write
+    _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    out = _RESULTS_DIR / f"megabundle_{args.provider}_{args.model}_{ts}.json"
+    out.write_text(
+        json.dumps(
+            {
+                "provider": args.provider,
+                "model": args.model,
+                "episodes": episodes,
+                "total_cost_usd": round(total_cost, 6),
+                "results": results,
+            },
+            indent=2,
+        )
+    )
+    print(f"Results: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tools/migrate_single_feed_to_corpus.py
+++ b/scripts/tools/migrate_single_feed_to_corpus.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Migrate a legacy single-feed output_dir to the unified corpus layout (#644).
+
+Legacy shape:
+    <output_dir>/
+    ├── run_<id1>/
+    ├── run_<id2>/
+    └── ...
+
+Target shape (matches multi-feed corpus):
+    <output_dir>/
+    └── feeds/
+        └── <feed_slug>/
+            ├── run_<id1>/
+            ├── run_<id2>/
+            └── ...
+
+The feed slug is deterministically derived from the RSS URL using the same
+``feed_workspace_dirname`` function the multi-feed pipeline uses, so a future
+multi-feed run against the same output_dir will land under the same sub-dir.
+
+Usage:
+    python scripts/tools/migrate_single_feed_to_corpus.py \\
+        --output-dir /path/to/existing/single-feed/corpus \\
+        --rss-url https://feeds.example.com/podcast.xml \\
+        [--dry-run]
+
+Safe to re-run: idempotent (detects already-migrated corpora and exits clean).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from podcast_scraper.utils.filesystem import feed_workspace_dirname  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+_RUN_DIR_RE = re.compile(r"^run_\d{8}-\d{6}_[a-f0-9]+$")
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--output-dir", required=True, help="Legacy single-feed output_dir")
+    parser.add_argument("--rss-url", required=True, help="RSS URL that was used for the runs")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned moves without executing them",
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir).resolve()
+    if not output_dir.is_dir():
+        logger.error("Output dir does not exist: %s", output_dir)
+        return 2
+
+    # Idempotency check: if feeds/<slug>/ already exists AND there are no
+    # legacy run_* siblings at the top, this is already migrated.
+    slug = feed_workspace_dirname(args.rss_url)
+    target_dir = output_dir / "feeds" / slug
+    top_run_dirs = [p for p in output_dir.iterdir() if p.is_dir() and _RUN_DIR_RE.match(p.name)]
+    if not top_run_dirs:
+        logger.info(
+            "No legacy run_* dirs at top of %s — nothing to migrate. " "(feeds/%s exists: %s)",
+            output_dir,
+            slug,
+            target_dir.exists(),
+        )
+        return 0
+
+    logger.info("Output dir:   %s", output_dir)
+    logger.info("RSS URL:      %s", args.rss_url)
+    logger.info("Target slug:  %s", slug)
+    logger.info("Target dir:   %s", target_dir)
+    logger.info("Run dirs to move: %d", len(top_run_dirs))
+    for p in top_run_dirs:
+        logger.info("  - %s", p.name)
+
+    if args.dry_run:
+        logger.info("--dry-run: no changes made.")
+        return 0
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for p in top_run_dirs:
+        dest = target_dir / p.name
+        if dest.exists():
+            logger.warning("Destination already exists, skipping: %s", dest)
+            continue
+        logger.info("Moving %s -> %s", p, dest)
+        shutil.move(str(p), str(dest))
+
+    logger.info(
+        "Migration complete. Set single_feed_uses_corpus_layout: true in your "
+        "profile or CLI for future runs against this output_dir."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate/validate_layout_644.py
+++ b/scripts/validate/validate_layout_644.py
@@ -1,0 +1,257 @@
+"""Real-episode end-to-end validation for #644 single-feed corpus layout.
+
+Runs the actual scraper against a real RSS feed three ways and diffs the
+on-disk tree to prove that ``single_feed_uses_corpus_layout=True`` produces
+the same shape as a multi-feed run.
+
+Three runs, all with ``max_episodes=1``, ``transcribe_missing=False`` so we
+exercise the scrape + directory-layout path without burning $ on cloud
+transcription:
+
+  1. Single feed, flag OFF — current default: ``<root>/run_*/``
+  2. Single feed, flag ON  — expected: ``<root>/feeds/<slug>/run_*/``
+  3. Multi feed (2 feeds)  — authoritative shape: ``<root>/feeds/<slug>/run_*/``
+
+Pass gates:
+  - Run 1 emits ``<root>/run_*/`` (no ``feeds/`` segment at top level)
+  - Run 2 emits ``<root>/feeds/<slug>/run_*/`` exactly
+  - Run 3 emits ``<root>/feeds/<slug1>/run_*/`` and ``<root>/feeds/<slug2>/run_*/``
+  - Run 2's feed dir structure under ``feeds/<slug>/`` matches Run 3's exactly
+    (same subdirs, same file categories)
+
+Usage::
+
+    .venv/bin/python scripts/validate/validate_layout_644.py
+
+Exit code 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+WORK_DIR = _REPO_ROOT / ".test_outputs" / "_validate_layout_644"
+
+# Real, well-known podcast RSS feeds with short episodes. Both are stable and
+# publicly available; used only for layout exercise (no content is evaluated).
+FEED_A = "https://feeds.99percentinvisible.org/99percentinvisible"
+FEED_B = "https://feeds.feedburner.com/planetmoneypodcast"
+
+
+def _run_scrape(output_dir: Path, rss_urls: List[str], flag: bool) -> subprocess.CompletedProcess:
+    """Invoke the CLI scraper with minimal work — one episode, no LLM, no transcription.
+
+    ``single_feed_uses_corpus_layout`` has no CLI flag (RFC-follow-up noted),
+    so we write a temp YAML config when flag=True.
+    """
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # generate_summaries defaults to False; no --no flag exists. Skip it.
+    args: List[str] = [
+        str(_REPO_ROOT / ".venv" / "bin" / "python"),
+        "-m",
+        "podcast_scraper.cli",
+        "--output-dir",
+        str(output_dir),
+        "--max-episodes",
+        "1",
+        "--no-transcribe-missing",
+        "--no-generate-metadata",
+        "--no-auto-speakers",
+    ]
+
+    # First URL goes as positional (populates args.rss → cfg.rss_url).
+    # Extras use --rss (args.rss_extra → cfg.rss_urls via collect_feed_urls).
+    args.append(rss_urls[0])
+    for url in rss_urls[1:]:
+        args.extend(["--rss", url])
+
+    if flag:
+        cfg_path = output_dir / "_validate_cfg.yaml"
+        cfg_path.write_text("single_feed_uses_corpus_layout: true\n")
+        args = args[:3] + ["--config", str(cfg_path)] + args[3:]
+
+    return subprocess.run(args, capture_output=True, text=True, timeout=300)
+
+
+def _top_level_dirs(root: Path) -> Set[str]:
+    if not root.exists():
+        return set()
+    return {p.name for p in root.iterdir() if p.is_dir()}
+
+
+def _feed_slugs_under(root: Path) -> List[str]:
+    feeds_dir = root / "feeds"
+    if not feeds_dir.exists():
+        return []
+    return sorted(p.name for p in feeds_dir.iterdir() if p.is_dir())
+
+
+def _shape_under_feed(feed_dir: Path) -> Dict[str, List[str]]:
+    """Return the set of subdirs and top-level files under a single feed dir,
+    normalising run_* → run_<REDACTED> so runs with different timestamps
+    compare equal."""
+    out: Dict[str, List[str]] = {"subdirs": [], "files": []}
+    if not feed_dir.exists():
+        return out
+    for p in feed_dir.iterdir():
+        name = p.name
+        if p.is_dir():
+            if name.startswith("run_"):
+                name = "run_<TS>"
+            out["subdirs"].append(name)
+        else:
+            out["files"].append(name)
+    out["subdirs"].sort()
+    out["files"].sort()
+    return out
+
+
+def _describe_tree(root: Path, max_depth: int = 4) -> str:
+    """Return a short description of a directory tree for human + test inspection."""
+    lines: List[str] = []
+
+    def walk(p: Path, depth: int) -> None:
+        if depth > max_depth:
+            return
+        rel = p.relative_to(root) if p != root else Path(".")
+        indent = "  " * depth
+        lines.append(f"{indent}{rel}")
+        if p.is_dir():
+            for child in sorted(p.iterdir()):
+                walk(child, depth + 1)
+
+    walk(root, 0)
+    return "\n".join(lines[:120])
+
+
+def _check_singlefeed_flag_off(work_dir: Path) -> Tuple[bool, str]:
+    """Expect: <root>/run_*/ at top level, NO feeds/."""
+    top = _top_level_dirs(work_dir)
+    has_run = any(n.startswith("run_") for n in top)
+    has_feeds = "feeds" in top
+    if has_run and not has_feeds:
+        return True, "OK: top-level run_* dir, no feeds/"
+    return False, f"FAIL: top-level dirs = {sorted(top)} (want run_*, not feeds/)"
+
+
+def _check_singlefeed_flag_on(work_dir: Path) -> Tuple[bool, str]:
+    """Expect: <root>/feeds/<slug>/run_*/ — no run_* at root."""
+    top = _top_level_dirs(work_dir)
+    has_top_run = any(n.startswith("run_") for n in top)
+    has_feeds = "feeds" in top
+    slugs = _feed_slugs_under(work_dir)
+    if has_feeds and not has_top_run and len(slugs) == 1:
+        feed_dir = work_dir / "feeds" / slugs[0]
+        has_run_inside = any(p.name.startswith("run_") for p in feed_dir.iterdir())
+        if has_run_inside:
+            return True, f"OK: feeds/{slugs[0]}/run_* (no top-level run_*)"
+        return False, f"FAIL: feeds/{slugs[0]}/ has no run_* subdir"
+    return (
+        False,
+        f"FAIL: top={sorted(top)}, slugs={slugs} (want feeds/<one slug>/ with run_*)",
+    )
+
+
+def _check_multifeed(work_dir: Path) -> Tuple[bool, str]:
+    """Expect: <root>/feeds/<slug1>/run_*/ and <root>/feeds/<slug2>/run_*/."""
+    slugs = _feed_slugs_under(work_dir)
+    if len(slugs) < 2:
+        return False, f"FAIL: multi-feed expected ≥2 slugs, got {slugs}"
+    for s in slugs:
+        if not any(p.name.startswith("run_") for p in (work_dir / "feeds" / s).iterdir()):
+            return False, f"FAIL: feeds/{s}/ has no run_*"
+    return True, f"OK: {len(slugs)} feeds, each with run_*"
+
+
+def _compare_feed_shapes(singlefeed_on_dir: Path, multifeed_dir: Path) -> Tuple[bool, str]:
+    """Compare the per-feed structure between single-feed-with-flag and multi-feed."""
+    sf_slugs = _feed_slugs_under(singlefeed_on_dir)
+    mf_slugs = _feed_slugs_under(multifeed_dir)
+    if not sf_slugs or not mf_slugs:
+        return False, f"FAIL: missing slugs (single={sf_slugs}, multi={mf_slugs})"
+    sf_shape = _shape_under_feed(singlefeed_on_dir / "feeds" / sf_slugs[0])
+    mf_shape = _shape_under_feed(multifeed_dir / "feeds" / mf_slugs[0])
+    if sf_shape == mf_shape:
+        return True, f"OK: feed-dir shapes match ({sf_shape['subdirs']})"
+    return (
+        False,
+        f"FAIL: shape mismatch\n  single: {sf_shape}\n  multi:  {mf_shape}",
+    )
+
+
+def main() -> int:
+    if WORK_DIR.exists():
+        shutil.rmtree(WORK_DIR)
+    WORK_DIR.mkdir(parents=True)
+
+    report: Dict[str, object] = {}
+    all_pass = True
+
+    # --- Run 1: single feed, flag OFF ---
+    print("\n[1/3] Single feed, flag OFF …", flush=True)
+    out1 = WORK_DIR / "singlefeed_off"
+    p1 = _run_scrape(out1, [FEED_A], flag=False)
+    ok1, msg1 = _check_singlefeed_flag_off(out1)
+    print(f"  exit={p1.returncode}  {msg1}")
+    report["run1"] = {
+        "exit": p1.returncode,
+        "ok": ok1,
+        "msg": msg1,
+        "tree": _describe_tree(out1),
+        "stderr": p1.stderr[-800:],
+    }
+    all_pass &= ok1 and p1.returncode == 0
+
+    # --- Run 2: single feed, flag ON ---
+    print("\n[2/3] Single feed, flag ON …", flush=True)
+    out2 = WORK_DIR / "singlefeed_on"
+    p2 = _run_scrape(out2, [FEED_A], flag=True)
+    ok2, msg2 = _check_singlefeed_flag_on(out2)
+    print(f"  exit={p2.returncode}  {msg2}")
+    report["run2"] = {"exit": p2.returncode, "ok": ok2, "msg": msg2, "tree": _describe_tree(out2)}
+    all_pass &= ok2 and p2.returncode == 0
+
+    # --- Run 3: multi feed (authoritative shape) ---
+    print("\n[3/3] Multi feed (2 feeds) …", flush=True)
+    out3 = WORK_DIR / "multifeed"
+    p3 = _run_scrape(out3, [FEED_A, FEED_B], flag=False)
+    ok3, msg3 = _check_multifeed(out3)
+    print(f"  exit={p3.returncode}  {msg3}")
+    report["run3"] = {"exit": p3.returncode, "ok": ok3, "msg": msg3, "tree": _describe_tree(out3)}
+    all_pass &= ok3 and p3.returncode == 0
+
+    # --- Structural comparison: single-feed-on should equal multi-feed shape ---
+    if ok2 and ok3:
+        print("\n[compare] feed-dir shapes (single-flag-on vs multi-feed) …")
+        ok4, msg4 = _compare_feed_shapes(out2, out3)
+        print(f"  {msg4}")
+        report["shape_compare"] = {"ok": ok4, "msg": msg4}
+        all_pass &= ok4
+
+    WORK_DIR.joinpath("report.json").write_text(json.dumps(report, indent=2, default=str))
+
+    print()
+    if all_pass:
+        print("LAYOUT GATES: PASS")
+    else:
+        print("LAYOUT GATES: FAIL — see report.json")
+        for run in ("run1", "run2", "run3"):
+            if run in report and not report[run]["ok"]:  # type: ignore[index]
+                rep = report[run]
+                print(f"\n--- {run} stderr tail ---")
+                # stderr was captured in subprocess but not stored; re-describe tree
+                print(rep.get("tree", ""))  # type: ignore[union-attr]
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate/validate_phase3c.py
+++ b/scripts/validate/validate_phase3c.py
@@ -1,0 +1,520 @@
+"""Real-episode end-to-end validation for #643 Phase 3C dispatch wiring.
+
+Drives the actual ``_generate_episode_summary`` → ``gi.build_artifact`` →
+``kg.build_artifact`` code path with real cloud providers, against real
+transcripts (copied from an existing corpus). Verifies the claim that
+``extraction_bundled`` drops one LLM call vs staged and ``mega_bundled``
+drops two.
+
+Usage::
+
+    .venv/bin/python scripts/validate/validate_phase3c.py
+
+Reads transcripts from ``.test_outputs/_validate_phase3c/transcripts/``
+(expects ``short.txt`` and ``medium.txt``). Output JSON +
+stdout-rendered table go to ``.test_outputs/_validate_phase3c/results/``.
+
+Exit code: 0 if all gates pass, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+# Load .env for API keys.
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(_REPO_ROOT / ".env")
+except ImportError:
+    pass
+
+from podcast_scraper import config as config_mod  # noqa: E402
+from podcast_scraper.gi.pipeline import build_artifact as gi_build_artifact  # noqa: E402
+from podcast_scraper.kg.pipeline import build_artifact as kg_build_artifact  # noqa: E402
+from podcast_scraper.summarization.factory import (  # noqa: E402
+    create_summarization_provider,
+)
+from podcast_scraper.workflow import metrics as metrics_mod  # noqa: E402
+from podcast_scraper.workflow.metadata_generation import _generate_episode_summary  # noqa: E402
+
+RESULTS_DIR = _REPO_ROOT / ".test_outputs" / "_validate_phase3c" / "results"
+TRANSCRIPTS_DIR = _REPO_ROOT / ".test_outputs" / "_validate_phase3c" / "transcripts"
+
+# Pricing (USD per 1M tokens). Keep conservative / in line with provider docs.
+PRICING = {
+    "anthropic": {"input": 1.00, "output": 5.00},  # claude-haiku-4-5
+    "gemini": {"input": 0.10, "output": 0.40},  # gemini-2.5-flash-lite (approx)
+    "deepseek": {"input": 0.28, "output": 0.42},  # deepseek-chat
+    "openai": {"input": 0.15, "output": 0.60},  # gpt-4o-mini
+    "mistral": {"input": 0.20, "output": 0.60},  # mistral-small
+    "grok": {"input": 3.00, "output": 15.00},  # grok-4 / grok-3 approx
+}
+
+
+@dataclass
+class RunResult:
+    transcript: str
+    mode: str
+    provider: str
+    model: str
+    call_counts: Dict[str, int] = field(default_factory=dict)
+    tokens: Dict[str, int] = field(default_factory=dict)
+    elapsed: Dict[str, float] = field(default_factory=dict)
+    artifact_counts: Dict[str, int] = field(default_factory=dict)
+    prefilled_present: bool = False
+    usd_cost: float = 0.0
+    errors: List[str] = field(default_factory=list)
+
+
+def _build_cfg(provider: str, mode: str, output_dir: str) -> config_mod.Config:
+    cfg_dict: Dict[str, Any] = {
+        "rss_url": "https://example.com/validation.rss",
+        "output_dir": output_dir,
+        "transcribe_missing": False,
+        "auto_speakers": False,
+        "generate_summaries": True,
+        "generate_gi": True,
+        "generate_kg": True,
+        "generate_metadata": True,
+        "gi_insight_source": "provider",
+        "kg_extraction_source": "provider",
+        "gi_require_grounding": False,  # skip QA+NLI to isolate dispatch cost
+        "summary_provider": provider,
+        "llm_pipeline_mode": mode,
+        "cloud_llm_structured_min_output_tokens": 4096,
+        "gi_max_insights": 12,
+        "kg_max_topics": 10,
+        "kg_max_entities": 15,
+        # Needed by the factory / provider __init__.
+        "anthropic_api_key": os.environ.get("ANTHROPIC_API_KEY"),
+        "openai_api_key": os.environ.get("OPENAI_API_KEY"),
+        "gemini_api_key": os.environ.get("GEMINI_API_KEY"),
+        "deepseek_api_key": os.environ.get("DEEPSEEK_API_KEY"),
+        "mistral_api_key": os.environ.get("MISTRAL_API_KEY"),
+        "grok_api_key": os.environ.get("GROK_API_KEY"),
+    }
+    if provider == "anthropic":
+        cfg_dict["anthropic_summary_model"] = "claude-haiku-4-5"
+    elif provider == "gemini":
+        cfg_dict["gemini_summary_model"] = "gemini-2.5-flash-lite"
+    elif provider == "deepseek":
+        cfg_dict["deepseek_summary_model"] = "deepseek-chat"
+    elif provider == "openai":
+        cfg_dict["openai_summary_model"] = "gpt-4o-mini"
+    elif provider == "mistral":
+        cfg_dict["mistral_summary_model"] = "mistral-small-latest"
+    elif provider == "grok":
+        cfg_dict["grok_summary_model"] = "grok-3-mini"
+    return config_mod.Config.model_validate(cfg_dict)
+
+
+def _instrument(provider: Any) -> Tuple[Dict[str, int], Dict[str, int]]:
+    """Wrap provider methods to count invocations and track tokens."""
+    counts = {
+        "summarize": 0,
+        "summarize_bundled": 0,
+        "summarize_mega_bundled": 0,
+        "summarize_extraction_bundled": 0,
+        "generate_insights": 0,
+        "extract_kg_graph": 0,
+        "extract_kg_from_summary_bullets": 0,
+        "total": 0,
+    }
+    tokens = {"input": 0, "output": 0}
+
+    # Also hook the underlying HTTP client so we also capture token totals
+    # regardless of which provider-facing method is called. Providers vary:
+    # anthropic → client.messages.create; openai-compat → client.chat.completions.create;
+    # gemini → client.models.generate_content.
+    client = getattr(provider, "client", None)
+    if client is not None:
+        if hasattr(client, "messages") and hasattr(client.messages, "create"):
+            orig = client.messages.create
+
+            def wrapped_anth(*a: Any, **kw: Any) -> Any:
+                r = orig(*a, **kw)
+                u = getattr(r, "usage", None)
+                if u is not None:
+                    tokens["input"] += int(getattr(u, "input_tokens", 0) or 0)
+                    tokens["output"] += int(getattr(u, "output_tokens", 0) or 0)
+                return r
+
+            client.messages.create = wrapped_anth
+        if hasattr(client, "chat") and hasattr(getattr(client, "chat", None), "completions"):
+            orig_oc = client.chat.completions.create
+
+            def wrapped_oc(*a: Any, **kw: Any) -> Any:
+                r = orig_oc(*a, **kw)
+                u = getattr(r, "usage", None)
+                if u is not None:
+                    tokens["input"] += int(getattr(u, "prompt_tokens", 0) or 0)
+                    tokens["output"] += int(getattr(u, "completion_tokens", 0) or 0)
+                return r
+
+            client.chat.completions.create = wrapped_oc
+        # Mistral SDK uses chat.complete (no 's') — same usage field shape as OpenAI.
+        if hasattr(client, "chat") and hasattr(getattr(client, "chat", None), "complete"):
+            orig_mc = client.chat.complete
+
+            def wrapped_mc(*a: Any, **kw: Any) -> Any:
+                r = orig_mc(*a, **kw)
+                u = getattr(r, "usage", None)
+                if u is not None:
+                    tokens["input"] += int(getattr(u, "prompt_tokens", 0) or 0)
+                    tokens["output"] += int(getattr(u, "completion_tokens", 0) or 0)
+                return r
+
+            client.chat.complete = wrapped_mc
+        if hasattr(client, "models") and hasattr(
+            getattr(client, "models", None), "generate_content"
+        ):
+            orig_g = client.models.generate_content
+
+            def wrapped_g(*a: Any, **kw: Any) -> Any:
+                r = orig_g(*a, **kw)
+                u = getattr(r, "usage_metadata", None)
+                if u is not None:
+                    tokens["input"] += int(getattr(u, "prompt_token_count", 0) or 0)
+                    tokens["output"] += int(getattr(u, "candidates_token_count", 0) or 0)
+                return r
+
+            client.models.generate_content = wrapped_g
+
+    # Method-level counters (how many times each provider method was called).
+    for name in list(counts.keys()):
+        if name == "total":
+            continue
+        orig_m = getattr(provider, name, None)
+        if not callable(orig_m):
+            continue
+
+        def make_wrapper(orig_fn: Callable[..., Any], key: str) -> Callable[..., Any]:
+            def wrapper(*a: Any, **kw: Any) -> Any:
+                counts[key] += 1
+                counts["total"] += 1
+                return orig_fn(*a, **kw)
+
+            return wrapper
+
+        setattr(provider, name, make_wrapper(orig_m, name))
+
+    return counts, tokens
+
+
+def _count_nodes(payload: Dict[str, Any], node_type: str) -> int:
+    return sum(1 for n in payload.get("nodes", []) if n.get("type") == node_type)
+
+
+def run_one(transcript_path: Path, mode: str, provider_name: str) -> RunResult:
+    work_dir = RESULTS_DIR.parent / "runs" / f"{transcript_path.stem}__{mode}__{provider_name}"
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    local_transcript = work_dir / "transcript.txt"
+    local_transcript.write_text(transcript_path.read_text(encoding="utf-8"))
+
+    cfg = _build_cfg(provider_name, mode, str(work_dir))
+    provider = create_summarization_provider(cfg)
+    if hasattr(provider, "initialize"):
+        provider.initialize()
+    counts, tokens = _instrument(provider)
+
+    model = getattr(provider, "summary_model", "?")
+    result = RunResult(
+        transcript=transcript_path.name,
+        mode=mode,
+        provider=provider_name,
+        model=str(model),
+    )
+
+    pipeline_metrics = metrics_mod.Metrics()
+
+    try:
+        # --- Summary stage (dispatch happens here) ---
+        t0 = time.time()
+        summary_meta, _cm = _generate_episode_summary(
+            transcript_file_path="transcript.txt",
+            output_dir=str(work_dir),
+            cfg=cfg,
+            episode_idx=0,
+            summary_provider=provider,
+            pipeline_metrics=pipeline_metrics,
+        )
+        result.elapsed["summary"] = time.time() - t0
+        result.prefilled_present = bool(
+            summary_meta and getattr(summary_meta, "prefilled_extraction", None)
+        )
+
+        transcript_text = local_transcript.read_text(encoding="utf-8")
+
+        # --- GI stage ---
+        prefilled_insights: Optional[List[Dict[str, Any]]] = None
+        if result.prefilled_present and summary_meta is not None:
+            pe = summary_meta.prefilled_extraction or {}
+            if pe.get("insights"):
+                prefilled_insights = pe["insights"]
+
+        t1 = time.time()
+        gi_payload = gi_build_artifact(
+            "ep_validation",
+            transcript_text,
+            podcast_id="feed_validation",
+            episode_title="Validation Episode",
+            cfg=cfg,
+            insight_provider=provider,
+            summary_provider=provider,
+            pipeline_metrics=pipeline_metrics,
+            prefilled_insights=prefilled_insights,
+        )
+        result.elapsed["gi"] = time.time() - t1
+
+        # --- KG stage ---
+        prefilled_partial: Optional[Dict[str, Any]] = None
+        if result.prefilled_present and summary_meta is not None:
+            pe = summary_meta.prefilled_extraction or {}
+            if pe.get("topics") or pe.get("entities"):
+                prefilled_partial = {
+                    "topics": pe.get("topics") or [],
+                    "entities": pe.get("entities") or [],
+                }
+
+        t2 = time.time()
+        kg_payload = kg_build_artifact(
+            "ep_validation",
+            transcript_text,
+            podcast_id="feed_validation",
+            episode_title="Validation Episode",
+            cfg=cfg,
+            kg_extraction_provider=provider,
+            pipeline_metrics=pipeline_metrics,
+            prefilled_partial=prefilled_partial,
+        )
+        result.elapsed["kg"] = time.time() - t2
+
+        # Artifact counts
+        result.artifact_counts["bullets"] = len(getattr(summary_meta, "bullets", []) or [])
+        result.artifact_counts["gi_insights"] = _count_nodes(gi_payload, "Insight")
+        result.artifact_counts["kg_topics"] = _count_nodes(kg_payload, "Topic")
+        result.artifact_counts["kg_entities"] = _count_nodes(kg_payload, "Entity")
+
+        # Persist artifacts for inspection
+        (work_dir / "gi.json").write_text(json.dumps(gi_payload, indent=2))
+        (work_dir / "kg.json").write_text(json.dumps(kg_payload, indent=2))
+        if summary_meta is not None:
+            (work_dir / "summary.json").write_text(
+                json.dumps(summary_meta.model_dump(mode="json"), indent=2)
+            )
+    except Exception as exc:  # noqa: BLE001
+        result.errors.append(f"{type(exc).__name__}: {exc}")
+
+    result.call_counts = counts
+    result.tokens = tokens
+    pricing = PRICING.get(provider_name, {"input": 0.0, "output": 0.0})
+    result.usd_cost = (
+        tokens["input"] * pricing["input"] / 1_000_000
+        + tokens["output"] * pricing["output"] / 1_000_000
+    )
+    return result
+
+
+def _print_table(results: List[RunResult]) -> None:
+    hdr = (
+        f"{'transcript':<12} {'mode':<22} {'provider':<10} "
+        f"{'calls':<6} {'in_tok':<8} {'out_tok':<8} {'cost_$':<8} "
+        f"{'bullets':<8} {'ins':<5} {'top':<5} {'ent':<5} "
+        f"{'pref':<5} {'t_sum':<7} {'t_gi':<7} {'t_kg':<7} {'err'}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    for r in results:
+        err = "-" if not r.errors else r.errors[0][:30]
+        print(
+            f"{r.transcript[:11]:<12} "
+            f"{r.mode:<22} {r.provider:<10} "
+            f"{r.call_counts.get('total', 0):<6} "
+            f"{r.tokens.get('input', 0):<8} "
+            f"{r.tokens.get('output', 0):<8} "
+            f"{r.usd_cost:<8.5f} "
+            f"{r.artifact_counts.get('bullets', 0):<8} "
+            f"{r.artifact_counts.get('gi_insights', 0):<5} "
+            f"{r.artifact_counts.get('kg_topics', 0):<5} "
+            f"{r.artifact_counts.get('kg_entities', 0):<5} "
+            f"{'Y' if r.prefilled_present else 'N':<5} "
+            f"{r.elapsed.get('summary', 0):<7.2f} "
+            f"{r.elapsed.get('gi', 0):<7.2f} "
+            f"{r.elapsed.get('kg', 0):<7.2f} "
+            f"{err}"
+        )
+
+
+def _check_gates(results: List[RunResult]) -> Tuple[bool, List[str]]:
+    """Apply per-mode gates from the validation plan."""
+    failures: List[str] = []
+    # Bucket by (transcript, mode, provider).
+    for r in results:
+        tag = f"{r.transcript}/{r.mode}/{r.provider}"
+        if r.errors:
+            failures.append(f"{tag}: run errored: {r.errors[0]}")
+            continue
+        if r.mode == "staged":
+            # Expect summarize + generate_insights + extract_kg_graph = 3 calls.
+            if r.call_counts.get("total", 0) < 3:
+                failures.append(
+                    f"{tag}: staged expected ≥3 LLM calls, got {r.call_counts.get('total', 0)}"
+                )
+        elif r.mode == "bundled":
+            # Expect summarize_bundled + generate_insights + extract_kg_graph = 3 calls.
+            if r.call_counts.get("summarize_bundled", 0) != 1:
+                failures.append(
+                    f"{tag}: bundled expected 1 summarize_bundled call, "
+                    f"got {r.call_counts.get('summarize_bundled', 0)}"
+                )
+        elif r.mode == "extraction_bundled":
+            # Expect 1 extraction_bundled + 1 staged summarize = 2 total provider method calls.
+            # GIL + KG must NOT hit the provider.
+            if r.call_counts.get("summarize_extraction_bundled", 0) != 1:
+                failures.append(
+                    f"{tag}: extraction_bundled expected 1 extraction call, "
+                    f"got {r.call_counts.get('summarize_extraction_bundled', 0)}"
+                )
+            if r.call_counts.get("generate_insights", 0) != 0:
+                failures.append(
+                    f"{tag}: extraction_bundled GIL should skip provider, "
+                    f"got {r.call_counts.get('generate_insights', 0)} generate_insights calls"
+                )
+            if (
+                r.call_counts.get("extract_kg_graph", 0)
+                + r.call_counts.get("extract_kg_from_summary_bullets", 0)
+                != 0
+            ):
+                failures.append(
+                    f"{tag}: extraction_bundled KG should skip provider, got "
+                    f"{r.call_counts.get('extract_kg_graph', 0)} extract_kg_graph + "
+                    f"{r.call_counts.get('extract_kg_from_summary_bullets', 0)} bullet-derived"
+                )
+            if not r.prefilled_present:
+                failures.append(f"{tag}: extraction_bundled missing prefilled_extraction")
+        elif r.mode == "mega_bundled":
+            # Expect ONE call total: summarize_mega_bundled. GIL + KG skipped.
+            if r.call_counts.get("summarize_mega_bundled", 0) != 1:
+                failures.append(
+                    f"{tag}: mega_bundled expected 1 mega call, "
+                    f"got {r.call_counts.get('summarize_mega_bundled', 0)}"
+                )
+            if r.call_counts.get("generate_insights", 0) != 0:
+                failures.append(
+                    f"{tag}: mega_bundled GIL should skip provider, "
+                    f"got {r.call_counts.get('generate_insights', 0)} generate_insights calls"
+                )
+            if (
+                r.call_counts.get("extract_kg_graph", 0)
+                + r.call_counts.get("extract_kg_from_summary_bullets", 0)
+                != 0
+            ):
+                failures.append(
+                    f"{tag}: mega_bundled KG should skip provider, got "
+                    f"{r.call_counts.get('extract_kg_graph', 0)} extract_kg_graph + "
+                    f"{r.call_counts.get('extract_kg_from_summary_bullets', 0)} bullet-derived"
+                )
+            if not r.prefilled_present:
+                failures.append(f"{tag}: mega_bundled missing prefilled_extraction")
+            if r.call_counts.get("total", 0) != 1:
+                failures.append(
+                    f"{tag}: mega_bundled expected total=1, got {r.call_counts.get('total', 0)}"
+                )
+
+        # Artifact presence gates.
+        if r.artifact_counts.get("gi_insights", 0) < 1:
+            failures.append(f"{tag}: GI produced 0 insights")
+        if r.artifact_counts.get("kg_topics", 0) < 1:
+            failures.append(f"{tag}: KG produced 0 topics")
+        if r.artifact_counts.get("kg_entities", 0) < 1:
+            failures.append(f"{tag}: KG produced 0 entities")
+        if r.artifact_counts.get("bullets", 0) < 1:
+            failures.append(f"{tag}: summary produced 0 bullets")
+
+    return (len(failures) == 0, failures)
+
+
+def main() -> int:
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    transcripts = [
+        TRANSCRIPTS_DIR / "short.txt",
+        TRANSCRIPTS_DIR / "medium.txt",
+    ]
+    for t in transcripts:
+        if not t.exists():
+            print(f"FATAL: missing transcript {t}", file=sys.stderr)
+            return 2
+
+    matrix: List[Tuple[Path, str, str]] = []
+    for t in transcripts:
+        matrix.extend(
+            [
+                # Gemini baselines (staged vs bundled vs extraction vs mega).
+                (t, "staged", "gemini"),
+                (t, "bundled", "gemini"),
+                (t, "extraction_bundled", "gemini"),
+                (t, "mega_bundled", "gemini"),
+                # All other providers in mega_bundled — #632 claimed only
+                # Anthropic/DeepSeek were tier-capable; #646 real-episode retest
+                # showed all 6 work on production traffic.
+                (t, "mega_bundled", "anthropic"),
+                (t, "mega_bundled", "deepseek"),
+                (t, "mega_bundled", "openai"),
+                (t, "mega_bundled", "mistral"),
+                (t, "mega_bundled", "grok"),
+            ]
+        )
+
+    results: List[RunResult] = []
+    for t, mode, provider_name in matrix:
+        print(f"\n[run] {t.name} / {mode} / {provider_name} …", flush=True)
+        r = run_one(t, mode, provider_name)
+        results.append(r)
+        print(
+            f"  total_calls={r.call_counts.get('total', 0)} "
+            f"tokens={r.tokens.get('input', 0)}/{r.tokens.get('output', 0)} "
+            f"cost=${r.usd_cost:.5f} "
+            f"ins={r.artifact_counts.get('gi_insights', 0)} "
+            f"top={r.artifact_counts.get('kg_topics', 0)} "
+            f"ent={r.artifact_counts.get('kg_entities', 0)} "
+            f"err={r.errors[0] if r.errors else '-'}"
+        )
+
+    print()
+    print("=" * 140)
+    _print_table(results)
+    print("=" * 140)
+
+    passed, failures = _check_gates(results)
+    (RESULTS_DIR / "results.json").write_text(json.dumps([asdict(r) for r in results], indent=2))
+    (RESULTS_DIR / "gates.json").write_text(
+        json.dumps({"passed": passed, "failures": failures}, indent=2)
+    )
+
+    print()
+    if passed:
+        print("GATES: PASS")
+    else:
+        print(f"GATES: FAIL ({len(failures)} failures)")
+        for f in failures:
+            print(f"  - {f}")
+
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/podcast_scraper/cli.py
+++ b/src/podcast_scraper/cli.py
@@ -510,6 +510,23 @@ def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--single-feed-uses-corpus-layout",
+        dest="single_feed_uses_corpus_layout",
+        action="store_true",
+        default=False,
+        help=(
+            "Opt-in single-feed corpus layout (#644): wrap output as "
+            "<output-dir>/feeds/<slug>/run_<id>/ so single-feed runs match "
+            "the multi-feed shape. Default: off (legacy <output-dir>/run_<id>/)."
+        ),
+    )
+    parser.add_argument(
+        "--no-single-feed-uses-corpus-layout",
+        dest="single_feed_uses_corpus_layout",
+        action="store_false",
+        help="Disable single-feed corpus layout (default).",
+    )
+    parser.add_argument(
         "--max-episodes", type=int, default=None, help="Maximum number of episodes to process"
     )
     parser.add_argument(
@@ -3379,6 +3396,7 @@ def _build_config(args: argparse.Namespace) -> config.Config:  # noqa: C901
         "generate_gi": getattr(args, "generate_gi", False),
         "generate_kg": getattr(args, "generate_kg", False),
         "kg_extraction_source": getattr(args, "kg_extraction_source", None) or "summary_bullets",
+        "single_feed_uses_corpus_layout": getattr(args, "single_feed_uses_corpus_layout", False),
         "kg_max_topics": (
             config_constants.DEFAULT_SUMMARY_BULLETS_DOWNSTREAM_MAX
             if getattr(args, "kg_max_topics", None) is None

--- a/src/podcast_scraper/cli.py
+++ b/src/podcast_scraper/cli.py
@@ -3324,8 +3324,24 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         print(f"podcast_scraper {__version__}")
         raise SystemExit(0)
 
-    if initial_args.config:
-        args = _load_and_merge_config(parser, initial_args.config, argv)
+    # Resolve --profile NAME to its YAML path and route through
+    # _load_and_merge_config — same path as --config. Without this, argparse
+    # defaults (e.g. --summary-provider's default "transformers") silently
+    # override profile values, and users of cloud_balanced/cloud_quality got
+    # 13 wrong fields (#646 real-episode audit).
+    effective_config_path: Optional[str] = initial_args.config
+    if not effective_config_path and getattr(initial_args, "profile", None):
+        profile_name = str(initial_args.profile).strip()
+        from pathlib import Path as _P
+
+        candidate = (
+            _P(__file__).resolve().parents[2] / "config" / "profiles" / f"{profile_name}.yaml"
+        )
+        if candidate.is_file():
+            effective_config_path = str(candidate)
+
+    if effective_config_path:
+        args = _load_and_merge_config(parser, effective_config_path, argv)
     else:
         args = parser.parse_args(argv)
 
@@ -3695,6 +3711,21 @@ def _build_config(args: argparse.Namespace) -> config.Config:  # noqa: C901
     # Inject profile if set via --profile CLI flag (#593)
     if profile:
         payload["profile"] = profile
+
+    # Fields that have no argparse flag but can be set by --config YAML via
+    # parser.set_defaults. Include only when non-None so Config's own default
+    # stands otherwise (#646 profile-completeness audit).
+    for _field in (
+        "llm_pipeline_mode",
+        "cloud_llm_structured_min_output_tokens",
+        "deepseek_timeout",
+        "audio_preprocessing_profile",
+        "ml_preprocessing_profile",
+    ):
+        _v = getattr(args, _field, None)
+        if _v is not None:
+            payload[_field] = _v
+
     # Pydantic's model_validate returns the correct type, but mypy needs help
     return cast(config.Config, config.Config.model_validate(payload))
 

--- a/src/podcast_scraper/cli.py
+++ b/src/podcast_scraper/cli.py
@@ -1242,9 +1242,12 @@ def _add_metadata_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--vector-backend",
-        choices=["faiss", "qdrant"],
+        choices=["faiss"],
         default=None,
-        help="Vector index backend (default: faiss). qdrant is not implemented in Phase 1.",
+        help=(
+            "Vector index backend (default: faiss). "
+            "qdrant is reserved for RFC-070 and not yet wired."
+        ),
     )
     parser.add_argument(
         "--vector-index-path",

--- a/src/podcast_scraper/config.py
+++ b/src/podcast_scraper/config.py
@@ -3952,6 +3952,36 @@ class Config(BaseModel):
         return self
 
     @model_validator(mode="after")
+    def _apply_single_feed_corpus_layout(self) -> "Config":
+        """Wrap single-feed ``output_dir`` under ``feeds/<slug>/`` when the opt-in
+        flag is set (#644). Runs on every Config construction (CLI, YAML,
+        programmatic) so the wrapping is consistent across all entry points.
+        Idempotent: skips wrapping when ``output_dir`` already contains a
+        ``feeds/<slug>/`` segment."""
+        if not self.single_feed_uses_corpus_layout:
+            return self
+        # Multi-feed path wraps per-feed elsewhere; don't double-wrap.
+        if self.rss_urls and len(self.rss_urls) >= 2:
+            return self
+        if not isinstance(self.rss_url, str) or not self.rss_url:
+            return self
+        if not isinstance(self.output_dir, str) or not self.output_dir:
+            return self
+        # Idempotency check: skip if output_dir already looks wrapped.
+        if "/feeds/rss_" in self.output_dir or self.output_dir.rstrip("/").endswith(
+            tuple(f"/feeds/{s}" for s in ("",))
+        ):
+            return self
+        from .utils.filesystem import corpus_feed_output_dir
+
+        wrapped = corpus_feed_output_dir(self.output_dir, self.rss_url)
+        # Assign via object.__setattr__ because model_validator(after) runs
+        # before the model becomes fully "frozen" for mutation but pydantic v2
+        # still routes direct assignment through validation — this bypasses it.
+        object.__setattr__(self, "output_dir", wrapped)
+        return self
+
+    @model_validator(mode="after")
     def _validate_openai_provider_requirements(self) -> "Config":
         """Validate that OpenAI API key is provided when OpenAI providers are selected."""
         openai_providers_used = []

--- a/src/podcast_scraper/config.py
+++ b/src/podcast_scraper/config.py
@@ -1529,6 +1529,17 @@ class Config(BaseModel):
         alias="deepseek_max_tokens",
         description="Max tokens for DeepSeek generation (None = model default)",
     )
+    deepseek_timeout: int = Field(
+        default=600,
+        alias="deepseek_timeout",
+        ge=30,
+        description=(
+            "HTTP read timeout in seconds for DeepSeek API calls (default: 600 = 10min). "
+            "DeepSeek mega-bundle / large JSON responses can exceed the default 120s "
+            "generic HTTP timeout, so DeepSeek follows Grok's pattern of a per-provider "
+            "override (#646 real-episode validation)."
+        ),
+    )
     # DeepSeek Prompt Configuration (following OpenAI pattern)
     deepseek_summary_system_prompt: str = Field(
         default="deepseek/summarization/system_bullets_v1",
@@ -1957,10 +1968,13 @@ class Config(BaseModel):
         alias="vector_embedding_model",
         description="Sentence-transformers model id for semantic corpus embeddings (GitHub #484).",
     )
-    vector_backend: Literal["faiss", "qdrant"] = Field(
+    vector_backend: Literal["faiss"] = Field(
         default="faiss",
         alias="vector_backend",
-        description=("Vector index backend. Shipped: faiss only; qdrant deferred (RFC-070)."),
+        description=(
+            "Vector index backend. Currently faiss only. qdrant is reserved for a future "
+            "platform-mode release (RFC-070) — will be re-added to this Literal once wired."
+        ),
     )
     vector_index_types: Optional[
         List[Literal["insight", "quote", "summary", "transcript", "kg_topic", "kg_entity"]]

--- a/src/podcast_scraper/config.py
+++ b/src/podcast_scraper/config.py
@@ -2321,14 +2321,20 @@ class Config(BaseModel):
             "'hybrid' (pattern-based + conditional LLM when needed)."
         ),
     )
-    llm_pipeline_mode: Literal["staged", "bundled"] = Field(
+    llm_pipeline_mode: Literal["staged", "bundled", "mega_bundled", "extraction_bundled"] = Field(
         default="staged",
         alias="llm_pipeline_mode",
         description=(
-            "LLM transcript pipeline for cleaning + summary + bullets (Issue #477). "
-            "'staged' = separate semantic clean and summarize calls (default). "
-            "'bundled' = one structured completion when the summary provider implements "
-            "summarize_bundled (OpenAI/Anthropic/Gemini); falls back to staged on failure."
+            "LLM transcript pipeline (Issue #477, extended by #643). "
+            "'staged' = separate clean, summarize, GI, KG calls (default). "
+            "'bundled' = one structured completion for clean+summary+bullets "
+            "(Issue #477). "
+            "'mega_bundled' = one call for summary+bullets+insights+topics+entities. "
+            "Validated on Anthropic Claude Haiku 4.5 (#632, #643). Falls back "
+            "to 'staged' on parser failure. "
+            "'extraction_bundled' = two calls: summary standalone + "
+            "insights/topics/entities bundled. Viable on OpenAI, Gemini where "
+            "mega_bundled compresses the summary (#643)."
         ),
     )
     llm_bundled_max_output_tokens: int = Field(
@@ -2338,6 +2344,21 @@ class Config(BaseModel):
         description=(
             "Max completion/output tokens for bundled clean+summary+bullets calls "
             "(large default: output includes full cleaned transcript JSON)."
+        ),
+    )
+    cloud_llm_structured_min_output_tokens: int = Field(
+        default=4096,
+        ge=512,
+        alias="cloud_llm_structured_min_output_tokens",
+        description=(
+            "Minimum max_output_tokens enforced on cloud-LLM structured summary "
+            "(non-bundled) calls. Prevents mid-JSON truncation on long transcripts "
+            "when summary_reduce_params.max_new_tokens is sized for LED-base local "
+            "ML (~650). Discovered via Flightcast episode failure 2026-04-20 "
+            "(Gemini truncated summary JSON at ~650 tokens). Providers that read "
+            "params.max_length or summary_reduce_params.max_new_tokens should "
+            "clamp the resulting value to at least this floor before calling the "
+            "API. Applies to: openai, anthropic, gemini, deepseek, mistral, grok."
         ),
     )
     # ML generation parameters (all defaults come from Config, no hardcoded values)

--- a/src/podcast_scraper/config.py
+++ b/src/podcast_scraper/config.py
@@ -2361,6 +2361,19 @@ class Config(BaseModel):
             "API. Applies to: openai, anthropic, gemini, deepseek, mistral, grok."
         ),
     )
+    single_feed_uses_corpus_layout: bool = Field(
+        default=False,
+        alias="single_feed_uses_corpus_layout",
+        description=(
+            "When True, single-feed runs write under <output_dir>/feeds/<slug>/ "
+            "instead of <output_dir>/run_<id>/, matching the corpus layout used "
+            "by multi-feed runs (GitHub #644). Unifies output shape for viewer, "
+            "eval tooling, and corpus-level artifacts. Default False for "
+            "backwards compatibility; recommended True for new corpora and when "
+            "an existing output_dir has been migrated. Migration helper: "
+            "scripts/tools/migrate_single_feed_to_corpus.py."
+        ),
+    )
     # ML generation parameters (all defaults come from Config, no hardcoded values)
     # These provide fine-grained control over generation parameters
     summary_map_params: Dict[str, Any] = Field(

--- a/src/podcast_scraper/gi/pipeline.py
+++ b/src/podcast_scraper/gi/pipeline.py
@@ -523,6 +523,7 @@ def build_artifact(
     gil_created_evidence_providers: Optional[List[Any]] = None,
     topic_labels: Optional[List[str]] = None,
     episode_duration_ms: Optional[int] = None,
+    prefilled_insights: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Build a GIL artifact for one episode.
 
@@ -571,14 +572,36 @@ def build_artifact(
     title = (episode_title or "Episode").strip() or "Episode"
     date_str = _safe_iso_date(publish_date)
 
-    insight_specs = _resolve_insight_specs(
-        transcript_text=transcript_text or "",
-        cfg=cfg,
-        insight_texts=insight_texts,
-        insight_provider=insight_provider,
-        episode_title=episode_title or title,
-        pipeline_metrics=pipeline_metrics,
-    )
+    # #643: when llm_pipeline_mode=mega_bundled/extraction_bundled has already
+    # produced insights, short-circuit provider dispatch entirely.
+    insight_specs: List[Tuple[str, str]] = []
+    if prefilled_insights:
+        max_insights_pref = (
+            getattr(cfg, "gi_max_insights", config_constants.DEFAULT_SUMMARY_BULLETS_DOWNSTREAM_MAX)
+            if cfg is not None
+            else config_constants.DEFAULT_SUMMARY_BULLETS_DOWNSTREAM_MAX
+        )
+        for item in prefilled_insights:
+            if not isinstance(item, dict):
+                continue
+            text = str(item.get("text") or "").strip()
+            if not text:
+                continue
+            itype = str(item.get("insight_type") or "claim").strip().lower()
+            if itype not in {"claim", "fact", "opinion"}:
+                itype = "claim"
+            insight_specs.append((text, itype))
+            if len(insight_specs) >= max_insights_pref:
+                break
+    if not insight_specs:
+        insight_specs = _resolve_insight_specs(
+            transcript_text=transcript_text or "",
+            cfg=cfg,
+            insight_texts=insight_texts,
+            insight_provider=insight_provider,
+            episode_title=episode_title or title,
+            pipeline_metrics=pipeline_metrics,
+        )
 
     artifact_model_version = model_version
     if cfg is not None:

--- a/src/podcast_scraper/kg/pipeline.py
+++ b/src/podcast_scraper/kg/pipeline.py
@@ -165,6 +165,7 @@ def build_artifact(
     cfg: Optional[Any] = None,
     kg_extraction_provider: Optional[Any] = None,
     pipeline_metrics: Optional[Any] = None,
+    prefilled_partial: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build a KG artifact dict for one episode.
 
@@ -218,7 +219,28 @@ def build_artifact(
     llm_from_summary_bullets = False
     resolved_model = model_version
 
-    if source == "provider":
+    # #643: prefilled from mega_bundled / extraction_bundled short-circuits
+    # provider dispatch entirely. Normalize to the {label,...}/{name,entity_kind}
+    # shape that _append_topics_and_entities_from_partial expects.
+    if prefilled_partial and (prefilled_partial.get("topics") or prefilled_partial.get("entities")):
+        norm_topics: List[Dict[str, Any]] = []
+        for t in prefilled_partial.get("topics") or []:
+            if isinstance(t, str) and t.strip():
+                norm_topics.append({"label": t.strip()})
+            elif isinstance(t, dict) and isinstance(t.get("label"), str) and t["label"].strip():
+                norm_topics.append(dict(t))
+        norm_entities: List[Dict[str, Any]] = []
+        for e in prefilled_partial.get("entities") or []:
+            if not isinstance(e, dict):
+                continue
+            name = e.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            kind = e.get("kind") or e.get("entity_kind") or "person"
+            norm_entities.append({"name": name.strip(), "entity_kind": str(kind).strip().lower()})
+        llm_partial = {"topics": norm_topics, "entities": norm_entities}
+        used_provider = True
+    elif source == "provider":
         llm_partial = _try_provider_extraction(
             transcript_text,
             episode_title or "",

--- a/src/podcast_scraper/prompting/__init__.py
+++ b/src/podcast_scraper/prompting/__init__.py
@@ -1,0 +1,1 @@
+"""Shared prompt builders for multi-stage LLM pipelines."""

--- a/src/podcast_scraper/prompting/megabundle.py
+++ b/src/podcast_scraper/prompting/megabundle.py
@@ -1,0 +1,146 @@
+"""Mega-bundle prompt builder (#643).
+
+Single structured JSON prompt that asks the LLM for summary + bullets +
+insights + topics + entities in one response. Validated research-backed
+in #632 experiment (Anthropic Claude Haiku 4.5 + DeepSeek produce clean
+output with full-quality summary; OpenAI/Gemini/Mistral/Grok compress the
+summary too much — those use extraction_bundled instead).
+
+Prompt shape kept close to the experiment script
+(`scripts/eval/megabundle_experiment.py`) so pipeline and research paths
+stay comparable; changes here should be reflected in the research script
+and re-benchmarked.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+# Research-derived sweet-spot counts (from the autoresearch work that fed #590
+# and #625). Mirror the defaults used by the standalone GI/KG stages.
+DEFAULT_MEGA_BUNDLE_INSIGHTS = 12
+DEFAULT_MEGA_BUNDLE_TOPICS = 10
+DEFAULT_MEGA_BUNDLE_ENTITIES_MAX = 15
+
+
+def build_megabundle_prompt(
+    transcript: str,
+    *,
+    language: Optional[str] = "en",
+    num_insights: int = DEFAULT_MEGA_BUNDLE_INSIGHTS,
+    num_topics: int = DEFAULT_MEGA_BUNDLE_TOPICS,
+    max_entities: int = DEFAULT_MEGA_BUNDLE_ENTITIES_MAX,
+    max_transcript_chars: int = 25_000,
+) -> Tuple[str, str]:
+    """Return (system_prompt, user_prompt) for a mega-bundle request.
+
+    Callers are responsible for provider-specific wrapping (e.g. Anthropic's
+    system+messages split, OpenAI's chat.completions format). The prompt text
+    itself is provider-neutral so the same research shape applies.
+
+    Args:
+        transcript: Raw episode transcript text. Will be truncated to
+            ``max_transcript_chars`` to keep input-token cost bounded.
+        language: Optional language hint, default "en".
+        num_insights: Exact number of grounded insights to request
+            (autoresearch sweet spot = 12).
+        num_topics: Exact number of KG topic labels (autoresearch sweet spot = 10).
+        max_entities: Upper bound on entities (not a hard minimum).
+        max_transcript_chars: Input transcript cap, default 25K chars.
+
+    Returns:
+        (system_prompt, user_prompt) tuple of strings.
+    """
+    # Truncate input to keep token cost bounded. Providers that want the full
+    # transcript can pass a larger ``max_transcript_chars`` or override
+    # client-side.
+    if len(transcript) > max_transcript_chars:
+        transcript = transcript[:max_transcript_chars]
+
+    system = (
+        "You are a podcast content analyzer. Given a podcast episode transcript, "
+        "produce a SINGLE JSON object with exactly the fields specified below. "
+        "Output valid JSON only — no commentary, no code fences."
+    )
+
+    lang_hint = f" Language: {language}." if language else ""
+
+    user = (
+        "From the transcript below, extract the following fields into one JSON "
+        "object:\n\n"
+        '  "title": string — concise episode title (10-15 words).\n'
+        '  "summary": string — 4-6 paragraph prose summary, covering main '
+        "arguments, guests, and conclusions.\n"
+        '  "bullets": array of 4-6 strings — key takeaways as standalone sentences.\n'
+        f'  "insights": array of EXACTLY {num_insights} objects, each '
+        '{"text": string, "insight_type": "claim"|"fact"|"opinion"}. '
+        "Insights must be grounded factual claims or strong opinions from the "
+        "transcript, not summaries or filler.\n"
+        f'  "topics": array of EXACTLY {num_topics} strings — distinct 2-8 word '
+        "noun phrases capturing the episode's subject matter. Noun phrases only "
+        "(e.g. 'passive index investing', NOT 'passive investing is better'). "
+        "Topics must be unique.\n"
+        f'  "entities": array of up to {max_entities} objects, each '
+        '{"name": string, "kind": "person"|"org"|"place", '
+        '"role": "host"|"guest"|"mentioned"}. '
+        'Use "host"/"guest" only when the transcript clearly identifies the '
+        'person as such; otherwise use "mentioned".'
+        f"{lang_hint}\n\n"
+        "Transcript:\n"
+        "---\n"
+        f"{transcript}\n"
+        "---\n\n"
+        "Output ONLY the JSON object."
+    )
+    return system, user
+
+
+def build_extraction_bundle_prompt(
+    transcript: str,
+    *,
+    language: Optional[str] = "en",
+    num_insights: int = DEFAULT_MEGA_BUNDLE_INSIGHTS,
+    num_topics: int = DEFAULT_MEGA_BUNDLE_TOPICS,
+    max_entities: int = DEFAULT_MEGA_BUNDLE_ENTITIES_MAX,
+    max_transcript_chars: int = 25_000,
+) -> Tuple[str, str]:
+    """Build the extraction-only half of a 2-call pipeline (#643 extraction_bundled).
+
+    The summary + bullets + title are produced by the provider's standalone
+    ``summarize()`` call (first call). The second call uses this prompt to
+    bundle insights + topics + entities. Suitable for OpenAI, Gemini, Mistral,
+    Grok — providers where full mega-bundle compresses the summary too much.
+    """
+    if len(transcript) > max_transcript_chars:
+        transcript = transcript[:max_transcript_chars]
+
+    system = (
+        "You are a podcast content analyzer. Given a podcast episode transcript, "
+        "produce a SINGLE JSON object with exactly the fields specified below. "
+        "Output valid JSON only — no commentary, no code fences."
+    )
+
+    lang_hint = f" Language: {language}." if language else ""
+
+    user = (
+        "From the transcript below, extract the following structured fields "
+        "into one JSON object:\n\n"
+        f'  "insights": array of EXACTLY {num_insights} objects, each '
+        '{"text": string, "insight_type": "claim"|"fact"|"opinion"}. '
+        "Grounded factual claims or strong opinions from the transcript, "
+        "not summaries or filler.\n"
+        f'  "topics": array of EXACTLY {num_topics} strings — distinct 2-8 word '
+        "noun phrases. Noun phrases only (e.g. 'passive index investing', "
+        "NOT 'passive investing is better'). Topics must be unique.\n"
+        f'  "entities": array of up to {max_entities} objects, each '
+        '{"name": string, "kind": "person"|"org"|"place", '
+        '"role": "host"|"guest"|"mentioned"}. '
+        'Use "host"/"guest" only when the transcript identifies them as such.'
+        f"{lang_hint}\n\n"
+        "Transcript:\n"
+        "---\n"
+        f"{transcript}\n"
+        "---\n\n"
+        "Output ONLY the JSON object."
+    )
+    return system, user

--- a/src/podcast_scraper/providers/anthropic/anthropic_provider.py
+++ b/src/podcast_scraper/providers/anthropic/anthropic_provider.py
@@ -688,6 +688,10 @@ class AnthropicProvider:
             or self.cfg.summary_reduce_params.get("max_new_tokens")
             or 800
         )
+        # Enforce cloud-LLM structured-JSON output floor (Flightcast 2026-04-20).
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_length = cloud_structured_max_output_tokens(self.cfg, max_length)
         min_length = (
             (params.get("min_length") if params else None)
             or self.cfg.summary_reduce_params.get("min_new_tokens")

--- a/src/podcast_scraper/providers/anthropic/anthropic_provider.py
+++ b/src/podcast_scraper/providers/anthropic/anthropic_provider.py
@@ -879,6 +879,178 @@ class AnthropicProvider:
                     provider="AnthropicProvider/Summarization",
                 ) from exc
 
+    def summarize_mega_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call mega-bundle: summary + bullets + insights + topics + entities (#643).
+
+        Anthropic Claude Haiku 4.5 is a tier-1 mega-bundle provider per the
+        #632 experiment: summary length matches silver within 74%, KG topic
+        coverage exceeds standalone baseline (81% vs 71%), entity F1 = 1.000.
+        Saves ~2/3 of extraction cost vs three separate calls.
+
+        Args:
+            text: Transcript text.
+            episode_title: Optional title hint (unused in current prompt).
+            episode_description: Optional description hint (unused).
+            params: Optional param dict; honors ``max_tokens`` override.
+            pipeline_metrics: Optional metrics tracker.
+            call_metrics: Optional per-call metrics tracker.
+
+        Returns:
+            :class:`MegaBundleResult` (from providers.common.megabundle_parser)
+            with .title, .summary, .bullets, .insights, .topics, .entities.
+
+        Raises:
+            RuntimeError: If provider not initialized.
+            MegaBundleParseError: If response fails schema validation.
+            ProviderRuntimeError: For API-level failures after retries.
+        """
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "AnthropicProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_megabundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_anthropic_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_megabundle_response
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_megabundle_prompt(text, language=language)
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("anthropic")
+
+        def _make_api_call() -> Any:
+            return self.client.messages.create(
+                model=self.summary_model,
+                max_tokens=max_out,
+                temperature=0.0,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_prompt}],
+            )
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_anthropic_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        # Anthropic returns content as a list of blocks; mega-bundle is a
+        # single text block with the JSON body.
+        raw_text = resp.content[0].text if resp.content else "{}"
+
+        # Usage tracking for observability.
+        if hasattr(resp, "usage") and resp.usage is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage, "input_tokens", 0) or 0),
+                    int(getattr(resp.usage, "output_tokens", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_megabundle_response(raw_text)
+
+    def summarize_extraction_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call extraction bundle: insights + topics + entities (#643).
+
+        Companion to :meth:`summarize_bundled` for the 2-call pipeline.
+        """
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "AnthropicProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_extraction_bundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_anthropic_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_extraction_bundle_response
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_extraction_bundle_prompt(text, language=language)
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("anthropic")
+
+        def _make_api_call() -> Any:
+            return self.client.messages.create(
+                model=self.summary_model,
+                max_tokens=max_out,
+                temperature=0.0,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_prompt}],
+            )
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_anthropic_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        raw_text = resp.content[0].text if resp.content else "{}"
+        if hasattr(resp, "usage") and resp.usage is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage, "input_tokens", 0) or 0),
+                    int(getattr(resp.usage, "output_tokens", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_extraction_bundle_response(raw_text)
+
     def summarize_bundled(
         self,
         text: str,

--- a/src/podcast_scraper/providers/common/__init__.py
+++ b/src/podcast_scraper/providers/common/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers shared across cloud LLM providers."""

--- a/src/podcast_scraper/providers/common/megabundle_parser.py
+++ b/src/podcast_scraper/providers/common/megabundle_parser.py
@@ -53,6 +53,20 @@ class MegaBundleResult:
             "bullets": list(self.bullets),
         }
 
+    def to_extraction_partial(self) -> Dict[str, Any]:
+        """Return the insights/topics/entities payload for GIL+KG reuse.
+
+        Shape is the canonical in-pipeline contract: GIL stage reads
+        ``insights`` as ``[{"text": str, "insight_type": str}]``; KG stage reads
+        ``topics`` as ``list[str]`` and ``entities`` as
+        ``[{"name": str, "kind": str, "role": str}]``.
+        """
+        return {
+            "insights": [dict(i) for i in self.insights],
+            "topics": list(self.topics),
+            "entities": [dict(e) for e in self.entities],
+        }
+
 
 _CODE_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```\s*$", re.MULTILINE)
 

--- a/src/podcast_scraper/providers/common/megabundle_parser.py
+++ b/src/podcast_scraper/providers/common/megabundle_parser.py
@@ -1,0 +1,200 @@
+"""Parser for mega-bundle / extraction-bundle JSON responses (#643).
+
+Validates the structured JSON returned by a single mega-bundle LLM call and
+splits the fields into shapes the existing pipeline consumers expect:
+
+  - summary (title, summary, bullets) -> feeds the summarization-stage output
+  - insights (text, type) -> feeds the GI stage
+  - topics (label list) + entities (name, kind, role) -> feeds the KG stage
+
+Designed to be tolerant of per-provider formatting quirks (code fences,
+slight schema drift on optional fields) while failing fast on hard schema
+violations (missing required fields, wrong types where it matters).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class MegaBundleParseError(ValueError):
+    """Raised when the provider response cannot be parsed into the expected shape."""
+
+
+@dataclass
+class MegaBundleResult:
+    """Parsed + normalized result of a mega-bundle call.
+
+    Fields are already in the shape downstream stages expect:
+      - ``summary_artifact`` mirrors what a standalone ``summarize()`` returns.
+      - ``insights`` is a list of dicts suitable for GI pipeline construction.
+      - ``topics`` + ``entities`` feed the KG pipeline.
+    """
+
+    title: str
+    summary: str
+    bullets: List[str]
+    insights: List[Dict[str, Any]]
+    topics: List[str]
+    entities: List[Dict[str, Any]]
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    def to_summary_artifact(self) -> Dict[str, Any]:
+        """Return a dict matching the standalone summarize() return shape."""
+        return {
+            "title": self.title,
+            "summary": self.summary,
+            "bullets": list(self.bullets),
+        }
+
+
+_CODE_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```\s*$", re.MULTILINE)
+
+
+def _strip_code_fences(text: str) -> str:
+    return _CODE_FENCE_RE.sub("", text.strip()).strip()
+
+
+def _as_list_of_strings(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(v).strip() for v in value if isinstance(v, (str, int, float)) and str(v).strip()]
+
+
+def _normalize_insight(obj: Any) -> Optional[Dict[str, Any]]:
+    """Accept {"text": "...", "insight_type": "..."} or a bare string."""
+    if isinstance(obj, str):
+        t = obj.strip()
+        if not t:
+            return None
+        return {"text": t, "insight_type": "claim"}
+    if isinstance(obj, dict):
+        text = str(obj.get("text") or obj.get("insight") or "").strip()
+        if not text:
+            return None
+        itype = str(obj.get("insight_type") or obj.get("type") or "claim").strip().lower()
+        if itype not in {"claim", "fact", "opinion"}:
+            itype = "claim"
+        out = {"text": text, "insight_type": itype}
+        # Preserve optional fields like grounded/quotes if present.
+        for k in ("grounded", "supporting_quotes", "quotes"):
+            if k in obj:
+                out[k] = obj[k]
+        return out
+    return None
+
+
+def _normalize_entity(obj: Any) -> Optional[Dict[str, Any]]:
+    """Accept {"name": "...", "kind": "...", "role": "..."} or bare string."""
+    if isinstance(obj, str):
+        n = obj.strip()
+        if not n:
+            return None
+        return {"name": n, "kind": "person", "role": "mentioned"}
+    if isinstance(obj, dict):
+        name = str(obj.get("name") or "").strip()
+        if not name:
+            return None
+        kind = str(obj.get("kind") or obj.get("type") or "person").strip().lower()
+        if kind not in {"person", "org", "place"}:
+            kind = "person"
+        role = str(obj.get("role") or "mentioned").strip().lower()
+        if role not in {"host", "guest", "mentioned"}:
+            role = "mentioned"
+        return {"name": name, "kind": kind, "role": role}
+    return None
+
+
+def _normalize_topic(obj: Any) -> Optional[str]:
+    """Accept a bare string or {"label": "..."} (KG v3 schema compatibility)."""
+    if isinstance(obj, str):
+        t = obj.strip()
+        return t or None
+    if isinstance(obj, dict):
+        t = str(obj.get("label") or obj.get("text") or obj.get("name") or "").strip()
+        return t or None
+    return None
+
+
+def parse_megabundle_response(
+    text: str,
+    *,
+    require_summary: bool = True,
+    require_insights: bool = True,
+    require_topics: bool = True,
+) -> MegaBundleResult:
+    """Parse a mega-bundle JSON response into a normalized :class:`MegaBundleResult`.
+
+    Args:
+        text: Raw response text (may contain code fences; we strip them).
+        require_summary: Raise if the parsed object has no non-empty summary.
+        require_insights: Raise if the parsed object has no non-empty insights list.
+        require_topics: Raise if the parsed object has no non-empty topics list.
+
+    Raises:
+        MegaBundleParseError: if the response is not valid JSON, not an object,
+        or missing a required field.
+    """
+    if not isinstance(text, str) or not text.strip():
+        raise MegaBundleParseError("Empty response text")
+
+    cleaned = _strip_code_fences(text)
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise MegaBundleParseError(f"Response is not valid JSON: {e}") from e
+
+    if not isinstance(data, dict):
+        raise MegaBundleParseError(
+            f"Expected a JSON object at the top level, got {type(data).__name__}"
+        )
+
+    title = str(data.get("title") or "").strip()
+    summary = str(data.get("summary") or "").strip()
+    bullets = _as_list_of_strings(data.get("bullets"))
+    insights = [i for i in (_normalize_insight(x) for x in (data.get("insights") or [])) if i]
+    topics = [t for t in (_normalize_topic(x) for x in (data.get("topics") or [])) if t]
+    entities = [e for e in (_normalize_entity(x) for x in (data.get("entities") or [])) if e]
+
+    if require_summary and not summary:
+        raise MegaBundleParseError("Missing 'summary' in mega-bundle response")
+    if require_insights and not insights:
+        raise MegaBundleParseError("Missing 'insights' in mega-bundle response")
+    if require_topics and not topics:
+        raise MegaBundleParseError("Missing 'topics' in mega-bundle response")
+
+    return MegaBundleResult(
+        title=title,
+        summary=summary,
+        bullets=bullets,
+        insights=insights,
+        topics=topics,
+        entities=entities,
+        raw=data,
+    )
+
+
+def parse_extraction_bundle_response(text: str) -> MegaBundleResult:
+    """Parse an extraction-only JSON response (no title/summary/bullets required).
+
+    Used by the 2-call ``extraction_bundled`` pipeline mode where the summary
+    stage ran separately in the first call. Returns a :class:`MegaBundleResult`
+    with empty title/summary/bullets and populated insights/topics/entities.
+    """
+    result = parse_megabundle_response(
+        text,
+        require_summary=False,
+        require_insights=True,
+        require_topics=True,
+    )
+    # Extraction-bundle has no title/summary/bullets by design.
+    result.title = ""
+    result.summary = ""
+    result.bullets = []
+    return result

--- a/src/podcast_scraper/providers/common/output_tokens.py
+++ b/src/podcast_scraper/providers/common/output_tokens.py
@@ -1,0 +1,100 @@
+"""Shared helpers for cloud-LLM output-token budget enforcement.
+
+Discovered via Flightcast summary failure on 2026-04-20: all 6 cloud provider
+summarize() paths flow ``params.max_length or cfg.summary_reduce_params.max_new_tokens``
+(default 650, tuned for LED-base local ML) into the API's ``max_tokens`` /
+``max_output_tokens`` cap. For long transcripts + structured JSON output, 650
+is below the budget Gemini allocates, so Gemini silently truncates mid-JSON
+and downstream parsers reject the response.
+
+The fix: enforce a cloud-LLM-specific floor (``cloud_llm_structured_min_output_tokens``,
+default 4096) at each provider's summarize() call site. Local ML paths (LED-base
+bart-led) are unchanged — they continue to use the 650 default that's tuned
+for their decoder.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_CLOUD_STRUCTURED_MIN_OUTPUT_TOKENS = 4096
+
+
+def cloud_structured_max_output_tokens(cfg: Any, requested: Optional[int]) -> int:
+    """Clamp requested max_output_tokens up to the cloud-LLM structured floor.
+
+    Cloud LLMs emit proportionally larger structured JSON for longer transcripts
+    (title + summary + bullets + schema overhead). Applying the LED-base 650-token
+    default to cloud LLM calls causes mid-JSON truncation on long episodes
+    (observed 2026-04-20 on Flightcast with Gemini 2.5-flash-lite).
+
+    Args:
+        cfg: Config object (reads ``cloud_llm_structured_min_output_tokens`` if set).
+        requested: Caller-provided max_output_tokens (e.g. from
+            params.max_length or cfg.summary_reduce_params.max_new_tokens).
+
+    Returns:
+        ``max(requested, cloud_llm_structured_min_output_tokens)``.
+    """
+    floor = getattr(cfg, "cloud_llm_structured_min_output_tokens", None) or (
+        _DEFAULT_CLOUD_STRUCTURED_MIN_OUTPUT_TOKENS
+    )
+    current = int(requested or 0)
+    if current >= floor:
+        return current
+    if current > 0 and current < floor:
+        logger.debug(
+            "cloud_structured_max_output_tokens: clamping %d -> %d (cloud-LLM floor)",
+            current,
+            floor,
+        )
+    return int(floor)
+
+
+def warn_if_output_truncated(
+    provider_name: str,
+    finish_reason: Optional[str],
+    output_tokens: Optional[int],
+    max_output_tokens: int,
+    episode_id: Optional[str] = None,
+) -> None:
+    """Log a warning if the API response looks truncated.
+
+    Two independent signals:
+      1. ``finish_reason`` contains MAX_TOKENS / LENGTH / STOP_BEYOND_MAX (provider-dependent).
+      2. ``output_tokens`` is within 5% of ``max_output_tokens`` — the model
+         likely filled the budget and would have kept going.
+
+    Args:
+        provider_name: e.g. "gemini", "openai", for log attribution.
+        finish_reason: Raw finish_reason string from provider response.
+        output_tokens: Actual completion tokens used (if reported).
+        max_output_tokens: The cap passed in the request.
+        episode_id: Episode id for log attribution, optional.
+    """
+    hit_reason = False
+    if finish_reason:
+        fr = str(finish_reason).upper()
+        hit_reason = any(x in fr for x in ("MAX_TOKENS", "LENGTH", "SAFETY", "RECITATION"))
+
+    hit_budget = False
+    if output_tokens is not None and max_output_tokens > 0:
+        hit_budget = output_tokens >= int(max_output_tokens * 0.95)
+
+    if hit_reason or hit_budget:
+        ep = f" ep={episode_id}" if episode_id else ""
+        logger.warning(
+            "[%s]%s possible output truncation: finish_reason=%s tokens=%s/%s (>=95%%=%s). "
+            "Consider raising cloud_llm_structured_min_output_tokens or "
+            "summary_reduce_params.max_new_tokens.",
+            provider_name,
+            ep,
+            finish_reason,
+            output_tokens,
+            max_output_tokens,
+            hit_budget,
+        )

--- a/src/podcast_scraper/providers/deepseek/deepseek_provider.py
+++ b/src/podcast_scraper/providers/deepseek/deepseek_provider.py
@@ -689,6 +689,170 @@ class DeepSeekProvider:
                     provider="DeepSeekProvider/Summarization",
                 ) from exc
 
+    def summarize_mega_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call mega-bundle: summary + bullets + insights + topics + entities (#643).
+
+        DeepSeek deepseek-chat is a tier-2 mega-bundle provider per the #632
+        experiment: summary length matches silver within 73%, KG 71% (baseline),
+        entity F1 ~0.88 (slight gap vs Anthropic's 1.000). 6x cheaper than
+        three standalone cloud calls; acceptable quality when entity coverage
+        isn't mission-critical.
+
+        Raises:
+            RuntimeError: If provider not initialized.
+            MegaBundleParseError: If response fails schema validation.
+            ProviderRuntimeError: For API-level failures after retries.
+        """
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "DeepSeekProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_megabundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_openai_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_megabundle_response
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        # DeepSeek API caps chat completions output at 8192 tokens.
+        max_out = min(max_out, 8192)
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_megabundle_prompt(text, language=language)
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("deepseek")
+
+        def _make_api_call() -> Any:
+            return self.client.chat.completions.create(
+                model=self.summary_model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                response_format={"type": "json_object"},
+                temperature=0.0,
+                max_tokens=max_out,
+            )
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_openai_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        raw_text = resp.choices[0].message.content or "{}"
+        if hasattr(resp, "usage") and resp.usage is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage, "prompt_tokens", 0) or 0),
+                    int(getattr(resp.usage, "completion_tokens", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_megabundle_response(raw_text)
+
+    def summarize_extraction_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call extraction bundle: insights + topics + entities (#643)."""
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "DeepSeekProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_extraction_bundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_openai_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_extraction_bundle_response
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        # DeepSeek API caps chat completions output at 8192 tokens.
+        max_out = min(max_out, 8192)
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_extraction_bundle_prompt(text, language=language)
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("deepseek")
+
+        def _make_api_call() -> Any:
+            return self.client.chat.completions.create(
+                model=self.summary_model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                response_format={"type": "json_object"},
+                temperature=0.0,
+                max_tokens=max_out,
+            )
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_openai_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        raw_text = resp.choices[0].message.content or "{}"
+        if hasattr(resp, "usage") and resp.usage is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage, "prompt_tokens", 0) or 0),
+                    int(getattr(resp.usage, "completion_tokens", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_extraction_bundle_response(raw_text)
+
     def summarize_bundled(
         self,
         text: str,

--- a/src/podcast_scraper/providers/deepseek/deepseek_provider.py
+++ b/src/podcast_scraper/providers/deepseek/deepseek_provider.py
@@ -506,6 +506,10 @@ class DeepSeekProvider:
             or self.cfg.summary_reduce_params.get("max_new_tokens")
             or 800
         )
+        # Enforce cloud-LLM structured-JSON output floor (Flightcast 2026-04-20).
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_length = cloud_structured_max_output_tokens(self.cfg, max_length)
         min_length = (
             (params.get("min_length") if params else None)
             or self.cfg.summary_reduce_params.get("min_new_tokens")

--- a/src/podcast_scraper/providers/deepseek/deepseek_provider.py
+++ b/src/podcast_scraper/providers/deepseek/deepseek_provider.py
@@ -145,8 +145,11 @@ class DeepSeekProvider:
             "base_url": base_url,
         }
 
-        # Configure HTTP timeouts with separate connect/read timeouts
-        client_kwargs["timeout"] = get_http_timeout(cfg)
+        # Configure HTTP timeouts. DeepSeek mega-bundle / large JSON responses
+        # can exceed the 120s generic default; honour the per-provider override
+        # (#646 real-episode validation). Matches Grok's pattern.
+        deepseek_read_timeout = float(getattr(cfg, "deepseek_timeout", 600))
+        client_kwargs["timeout"] = get_http_timeout(cfg, read_timeout=deepseek_read_timeout)
 
         self.client = OpenAI(**client_kwargs)
 

--- a/src/podcast_scraper/providers/gemini/gemini_provider.py
+++ b/src/podcast_scraper/providers/gemini/gemini_provider.py
@@ -1142,6 +1142,94 @@ class GeminiProvider:
                     provider="GeminiProvider/Summarization",
                 ) from exc
 
+    def summarize_mega_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call mega-bundle: summary + bullets + insights + topics + entities (#643).
+
+        #632 research flagged Gemini as "not tier-1" because KG/entity quality
+        regressed in mega-bundle mode on fixture transcripts. #646 real-episode
+        validation revisits this claim against production audio. Exposed for
+        users who want to trade some quality for ~3× lower cost and ~1.5 s/ep
+        latency; tier status is documented in
+        ``docs/guides/AI_PROVIDER_COMPARISON_GUIDE.md``.
+        """
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "GeminiProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_megabundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_gemini_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_megabundle_response
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        max_out = cloud_structured_max_output_tokens(self.cfg, max_out)
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_megabundle_prompt(text, language=language)
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("gemini")
+
+        def _make_api_call() -> Any:
+            generation_config = _merge_generate_content_config(
+                self.summary_model,
+                {
+                    "temperature": 0.0,
+                    "max_output_tokens": max_out,
+                    "response_mime_type": "application/json",
+                    "system_instruction": system_prompt,
+                },
+            )
+            return self.client.models.generate_content(
+                model=self.summary_model,
+                contents=user_prompt,
+                config=cast(Any, generation_config),
+            )
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_gemini_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        raw_text = (resp.text if hasattr(resp, "text") else str(resp) or "").strip() or "{}"
+        if hasattr(resp, "usage_metadata") and resp.usage_metadata is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage_metadata, "prompt_token_count", 0) or 0),
+                    int(getattr(resp.usage_metadata, "candidates_token_count", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_megabundle_response(raw_text)
+
     def summarize_extraction_bundled(
         self,
         text: str,

--- a/src/podcast_scraper/providers/gemini/gemini_provider.py
+++ b/src/podcast_scraper/providers/gemini/gemini_provider.py
@@ -932,6 +932,12 @@ class GeminiProvider:
             or self.cfg.summary_reduce_params.get("max_new_tokens")
             or 800
         )
+        # Enforce the cloud-LLM structured-JSON output floor (Flightcast truncation
+        # fix 2026-04-20). Local-ML default (650) is tuned for LED-base and is
+        # too small for Gemini's structured summary output on long transcripts.
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_length = cloud_structured_max_output_tokens(self.cfg, max_length)
         min_length = (
             (params.get("min_length") if params else None)
             or self.cfg.summary_reduce_params.get("min_new_tokens")
@@ -1030,6 +1036,29 @@ class GeminiProvider:
 
                 if input_tokens is not None and output_tokens is not None:
                     call_metrics.set_tokens(input_tokens, output_tokens)
+
+            # Truncation diagnostic: warn on MAX_TOKENS/SAFETY/RECITATION finish
+            # reasons or near-budget output. Surfaces the class of silent
+            # truncation that caused Flightcast failure on 2026-04-20.
+            try:
+                from ..common.output_tokens import warn_if_output_truncated
+
+                finish_reason: Optional[str] = None
+                try:
+                    candidates = getattr(response, "candidates", None)
+                    first = candidates[0] if candidates else None
+                    fr = getattr(first, "finish_reason", None) if first is not None else None
+                    finish_reason = str(fr) if fr is not None else None
+                except Exception:
+                    finish_reason = None
+                warn_if_output_truncated(
+                    provider_name="gemini",
+                    finish_reason=finish_reason,
+                    output_tokens=output_tokens,
+                    max_output_tokens=max_length,
+                )
+            except Exception:
+                pass
 
             # Track LLM call metrics if available (aggregate tracking)
             if (

--- a/src/podcast_scraper/providers/gemini/gemini_provider.py
+++ b/src/podcast_scraper/providers/gemini/gemini_provider.py
@@ -1142,6 +1142,89 @@ class GeminiProvider:
                     provider="GeminiProvider/Summarization",
                 ) from exc
 
+    def summarize_extraction_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call extraction bundle: insights + topics + entities (#643).
+
+        Companion to :meth:`summarize_bundled` for the 2-call pipeline.
+        """
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "GeminiProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_extraction_bundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_gemini_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_extraction_bundle_response
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        max_out = cloud_structured_max_output_tokens(self.cfg, max_out)
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_extraction_bundle_prompt(text, language=language)
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("gemini")
+
+        def _make_api_call() -> Any:
+            generation_config = _merge_generate_content_config(
+                self.summary_model,
+                {
+                    "temperature": 0.0,
+                    "max_output_tokens": max_out,
+                    "response_mime_type": "application/json",
+                    "system_instruction": system_prompt,
+                },
+            )
+            return self.client.models.generate_content(
+                model=self.summary_model,
+                contents=user_prompt,
+                config=cast(Any, generation_config),
+            )
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_gemini_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        raw_text = (resp.text if hasattr(resp, "text") else str(resp) or "").strip() or "{}"
+        if hasattr(resp, "usage_metadata") and resp.usage_metadata is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage_metadata, "prompt_token_count", 0) or 0),
+                    int(getattr(resp.usage_metadata, "candidates_token_count", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_extraction_bundle_response(raw_text)
+
     def summarize_bundled(
         self,
         text: str,

--- a/src/podcast_scraper/providers/grok/grok_provider.py
+++ b/src/podcast_scraper/providers/grok/grok_provider.py
@@ -798,6 +798,82 @@ class GrokProvider:
                     provider="GrokProvider/Summarization",
                 ) from exc
 
+    def summarize_extraction_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call extraction bundle: insights + topics + entities (#643)."""
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "GrokProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_extraction_bundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_openai_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_extraction_bundle_response
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        max_out = cloud_structured_max_output_tokens(self.cfg, max_out)
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_extraction_bundle_prompt(text, language=language)
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("grok")
+
+        def _make_api_call() -> Any:
+            return self.client.chat.completions.create(
+                model=self.summary_model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=0.0,
+                max_tokens=max_out,
+                response_format={"type": "json_object"},
+            )
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_openai_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        raw_text = (resp.choices[0].message.content or "").strip() or "{}"
+        if hasattr(resp, "usage") and resp.usage is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage, "prompt_tokens", 0) or 0),
+                    int(getattr(resp.usage, "completion_tokens", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_extraction_bundle_response(raw_text)
+
     def summarize_bundled(
         self,
         text: str,

--- a/src/podcast_scraper/providers/grok/grok_provider.py
+++ b/src/podcast_scraper/providers/grok/grok_provider.py
@@ -798,6 +798,86 @@ class GrokProvider:
                     provider="GrokProvider/Summarization",
                 ) from exc
 
+    def summarize_mega_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call mega-bundle: summary + bullets + insights + topics + entities (#643).
+
+        #632 research flagged Grok as "not tier-1"; #646 real-episode
+        validation retests the claim. See AI_PROVIDER_COMPARISON_GUIDE.md.
+        """
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "GrokProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_megabundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_openai_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_megabundle_response
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        max_out = cloud_structured_max_output_tokens(self.cfg, max_out)
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_megabundle_prompt(text, language=language)
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("grok")
+
+        def _make_api_call() -> Any:
+            return self.client.chat.completions.create(
+                model=self.summary_model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=0.0,
+                max_tokens=max_out,
+                response_format={"type": "json_object"},
+            )
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_openai_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        raw_text = (resp.choices[0].message.content or "").strip() or "{}"
+        if hasattr(resp, "usage") and resp.usage is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage, "prompt_tokens", 0) or 0),
+                    int(getattr(resp.usage, "completion_tokens", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_megabundle_response(raw_text)
+
     def summarize_extraction_bundled(
         self,
         text: str,

--- a/src/podcast_scraper/providers/grok/grok_provider.py
+++ b/src/podcast_scraper/providers/grok/grok_provider.py
@@ -614,6 +614,10 @@ class GrokProvider:
             or self.cfg.summary_reduce_params.get("max_new_tokens")
             or 800
         )
+        # Enforce cloud-LLM structured-JSON output floor (Flightcast 2026-04-20).
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_length = cloud_structured_max_output_tokens(self.cfg, max_length)
         min_length = (
             (params.get("min_length") if params else None)
             or self.cfg.summary_reduce_params.get("min_new_tokens")

--- a/src/podcast_scraper/providers/mistral/mistral_provider.py
+++ b/src/podcast_scraper/providers/mistral/mistral_provider.py
@@ -819,6 +819,10 @@ class MistralProvider:
             or self.cfg.summary_reduce_params.get("max_new_tokens")
             or 800
         )
+        # Enforce cloud-LLM structured-JSON output floor (Flightcast 2026-04-20).
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_length = cloud_structured_max_output_tokens(self.cfg, max_length)
         min_length = (
             (params.get("min_length") if params else None)
             or self.cfg.summary_reduce_params.get("min_new_tokens")

--- a/src/podcast_scraper/providers/mistral/mistral_provider.py
+++ b/src/podcast_scraper/providers/mistral/mistral_provider.py
@@ -996,6 +996,82 @@ class MistralProvider:
                     provider="MistralProvider/Summarization",
                 ) from exc
 
+    def summarize_extraction_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call extraction bundle: insights + topics + entities (#643)."""
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "MistralProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_extraction_bundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_mistral_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_extraction_bundle_response
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        max_out = cloud_structured_max_output_tokens(self.cfg, max_out)
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_extraction_bundle_prompt(text, language=language)
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("mistral")
+
+        def _make_api_call() -> Any:
+            return self.client.chat.complete(
+                model=self.summary_model,
+                messages=[  # type: ignore[arg-type]
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=0.0,
+                max_tokens=max_out,
+                response_format={"type": "json_object"},
+            )
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_mistral_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        raw_text = (resp.choices[0].message.content or "").strip() or "{}"
+        if hasattr(resp, "usage") and resp.usage is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage, "prompt_tokens", 0) or 0),
+                    int(getattr(resp.usage, "completion_tokens", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_extraction_bundle_response(raw_text)
+
     def summarize_bundled(
         self,
         text: str,

--- a/src/podcast_scraper/providers/mistral/mistral_provider.py
+++ b/src/podcast_scraper/providers/mistral/mistral_provider.py
@@ -996,6 +996,86 @@ class MistralProvider:
                     provider="MistralProvider/Summarization",
                 ) from exc
 
+    def summarize_mega_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call mega-bundle: summary + bullets + insights + topics + entities (#643).
+
+        #632 research flagged Mistral as "not tier-1"; #646 real-episode
+        validation retests the claim. See AI_PROVIDER_COMPARISON_GUIDE.md.
+        """
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "MistralProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_megabundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_mistral_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_megabundle_response
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        max_out = cloud_structured_max_output_tokens(self.cfg, max_out)
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_megabundle_prompt(text, language=language)
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("mistral")
+
+        def _make_api_call() -> Any:
+            return self.client.chat.complete(
+                model=self.summary_model,
+                messages=[  # type: ignore[arg-type]
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=0.0,
+                max_tokens=max_out,
+                response_format={"type": "json_object"},
+            )
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_mistral_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        raw_text = (resp.choices[0].message.content or "").strip() or "{}"
+        if hasattr(resp, "usage") and resp.usage is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage, "prompt_tokens", 0) or 0),
+                    int(getattr(resp.usage, "completion_tokens", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_megabundle_response(raw_text)
+
     def summarize_extraction_bundled(
         self,
         text: str,

--- a/src/podcast_scraper/providers/openai/openai_provider.py
+++ b/src/podcast_scraper/providers/openai/openai_provider.py
@@ -1018,6 +1018,10 @@ class OpenAIProvider:
             or self.cfg.summary_reduce_params.get("max_new_tokens")
             or 800
         )
+        # Enforce cloud-LLM structured-JSON output floor (Flightcast 2026-04-20).
+        from ..common.output_tokens import cloud_structured_max_output_tokens
+
+        max_length = cloud_structured_max_output_tokens(self.cfg, max_length)
         min_length = (
             (params.get("min_length") if params else None)
             or self.cfg.summary_reduce_params.get("min_new_tokens")

--- a/src/podcast_scraper/providers/openai/openai_provider.py
+++ b/src/podcast_scraper/providers/openai/openai_provider.py
@@ -1216,6 +1216,100 @@ class OpenAIProvider:
                     provider="OpenAIProvider/Summarization",
                 ) from exc
 
+    def summarize_extraction_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call extraction bundle: insights + topics + entities (#643).
+
+        Companion to :meth:`summarize_bundled` for the 2-call pipeline:
+        bundled summary/bullets + bundled extraction. Omits summary/title/bullets
+        from the prompt so the model can spend its budget on KG quality.
+
+        Returns:
+            :class:`MegaBundleResult` with empty title/summary/bullets and
+            populated insights/topics/entities.
+        """
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "OpenAIProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_extraction_bundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_openai_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_extraction_bundle_response
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_extraction_bundle_prompt(text, language=language)
+
+        _uses_completion_tokens = self.summary_model.startswith(("o1", "o3", "gpt-5"))
+        _token_kwarg: Dict[str, Any] = (
+            {"max_completion_tokens": max_out}
+            if _uses_completion_tokens
+            else {"max_tokens": max_out}
+        )
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("openai")
+
+        def _make_api_call() -> Any:
+            kwargs: Dict[str, Any] = {
+                "model": self.summary_model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                "temperature": 0.0,
+                **_token_kwarg,
+            }
+            if not _uses_completion_tokens:
+                kwargs["response_format"] = {"type": "json_object"}
+            if self.summary_seed is not None:
+                kwargs["seed"] = self.summary_seed
+            return self.client.chat.completions.create(**kwargs)
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_openai_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        raw_text = (resp.choices[0].message.content or "").strip() or "{}"
+        if hasattr(resp, "usage") and resp.usage is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage, "prompt_tokens", 0) or 0),
+                    int(getattr(resp.usage, "completion_tokens", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_extraction_bundle_response(raw_text)
+
     def summarize_bundled(
         self,
         text: str,

--- a/src/podcast_scraper/providers/openai/openai_provider.py
+++ b/src/podcast_scraper/providers/openai/openai_provider.py
@@ -1216,6 +1216,97 @@ class OpenAIProvider:
                     provider="OpenAIProvider/Summarization",
                 ) from exc
 
+    def summarize_mega_bundled(
+        self,
+        text: str,
+        *,
+        episode_title: Optional[str] = None,
+        episode_description: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+        pipeline_metrics: "metrics.Metrics | None" = None,
+        call_metrics: Any | None = None,
+    ) -> Any:
+        """Single-call mega-bundle: summary + bullets + insights + topics + entities (#643).
+
+        #632 research flagged OpenAI as "not tier-1" because KG/entity quality
+        regressed in mega-bundle mode on fixture transcripts. #646 real-episode
+        validation revisits this claim. See
+        ``docs/guides/AI_PROVIDER_COMPARISON_GUIDE.md`` for the tier table.
+        """
+        if not self._summarization_initialized:
+            raise RuntimeError(
+                "OpenAIProvider summarization not initialized. Call initialize() first."
+            )
+
+        from ...prompting.megabundle import build_megabundle_prompt
+        from ...utils.provider_metrics import (
+            _safe_openai_retryable,
+            ProviderCallMetrics,
+            retry_with_metrics,
+        )
+        from ..common.megabundle_parser import parse_megabundle_response
+
+        max_out = int(
+            (params or {}).get("max_tokens")
+            or getattr(self.cfg, "llm_bundled_max_output_tokens", 16384)
+            or 16384
+        )
+        language = getattr(self.cfg, "language", "en") or None
+        system_prompt, user_prompt = build_megabundle_prompt(text, language=language)
+
+        _uses_completion_tokens = self.summary_model.startswith(("o1", "o3", "gpt-5"))
+        _token_kwarg: Dict[str, Any] = (
+            {"max_completion_tokens": max_out}
+            if _uses_completion_tokens
+            else {"max_tokens": max_out}
+        )
+
+        if call_metrics is None:
+            call_metrics = ProviderCallMetrics()
+        call_metrics.set_provider_name("openai")
+
+        def _make_api_call() -> Any:
+            kwargs: Dict[str, Any] = {
+                "model": self.summary_model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                "temperature": 0.0,
+                **_token_kwarg,
+            }
+            if not _uses_completion_tokens:
+                kwargs["response_format"] = {"type": "json_object"}
+            if self.summary_seed is not None:
+                kwargs["seed"] = self.summary_seed
+            return self.client.chat.completions.create(**kwargs)
+
+        try:
+            resp = retry_with_metrics(
+                _make_api_call,
+                max_retries=3,
+                initial_delay=1.0,
+                max_delay=30.0,
+                retryable_exceptions=_safe_openai_retryable(),
+                metrics=call_metrics,
+            )
+        except Exception:
+            call_metrics.finalize()
+            raise
+        call_metrics.finalize()
+
+        raw_text = (resp.choices[0].message.content or "").strip() or "{}"
+        if hasattr(resp, "usage") and resp.usage is not None:
+            try:
+                call_metrics.set_tokens(
+                    int(getattr(resp.usage, "prompt_tokens", 0) or 0),
+                    int(getattr(resp.usage, "completion_tokens", 0) or 0),
+                )
+            except (TypeError, ValueError):
+                pass
+
+        return parse_megabundle_response(raw_text)
+
     def summarize_extraction_bundled(
         self,
         text: str,

--- a/src/podcast_scraper/search/indexer.py
+++ b/src/podcast_scraper/search/indexer.py
@@ -720,12 +720,6 @@ def maybe_index_corpus(output_dir: str, cfg: config.Config) -> None:
         return
     if getattr(cfg, "vector_search", False) is not True:
         return
-    if getattr(cfg, "vector_backend", "faiss") != "faiss":
-        logger.warning(
-            "vector_backend=%r not supported for corpus indexing (Phase 1: faiss); skipping",
-            cfg.vector_backend,
-        )
-        return
     try:
         index_corpus(output_dir, cfg)
     except Exception as exc:

--- a/src/podcast_scraper/service.py
+++ b/src/podcast_scraper/service.py
@@ -271,33 +271,11 @@ def run(cfg: config.Config) -> ServiceResult:
         if len(multi_urls) >= 2:
             return _run_multi_feed(cfg, multi_urls)
 
-        # Single-feed path: optionally wrap output in feeds/<slug>/ so the
-        # output layout matches the multi-feed corpus shape (#644). Opt-in via
-        # Config.single_feed_uses_corpus_layout (default False keeps backwards
-        # compatibility with legacy single-feed corpora written as
-        # <output_dir>/run_<id>/...).
-        #
-        # Explicit ``is True`` check so that test doubles (MagicMock) whose
-        # attribute access returns a truthy Mock don't accidentally trip the
-        # wrapping path.
-        effective_cfg = cfg
-        use_corpus_layout = getattr(cfg, "single_feed_uses_corpus_layout", False) is True
-        if (
-            use_corpus_layout
-            and isinstance(getattr(cfg, "rss_url", None), str)
-            and cfg.rss_url
-            and isinstance(getattr(cfg, "output_dir", None), str)
-            and cfg.output_dir
-        ):
-            feed_dir = filesystem.corpus_feed_output_dir(cfg.output_dir, cfg.rss_url)
-            effective_cfg = cfg.model_copy(update={"output_dir": feed_dir})
-            logger.info(
-                "Single-feed run using corpus layout: %s -> %s",
-                cfg.output_dir,
-                feed_dir,
-            )
-
-        count, summary = workflow.run_pipeline(effective_cfg)
+        # Single-feed path. Opt-in ``feeds/<slug>/`` wrapping (#644) is applied
+        # at Config construction via the ``_apply_single_feed_corpus_layout``
+        # post-validator, so ``cfg.output_dir`` is already in its final form
+        # here — no extra wrapping needed in this hot path.
+        count, summary = workflow.run_pipeline(cfg)
 
         return ServiceResult(
             episodes_processed=count,

--- a/src/podcast_scraper/service.py
+++ b/src/podcast_scraper/service.py
@@ -271,7 +271,33 @@ def run(cfg: config.Config) -> ServiceResult:
         if len(multi_urls) >= 2:
             return _run_multi_feed(cfg, multi_urls)
 
-        count, summary = workflow.run_pipeline(cfg)
+        # Single-feed path: optionally wrap output in feeds/<slug>/ so the
+        # output layout matches the multi-feed corpus shape (#644). Opt-in via
+        # Config.single_feed_uses_corpus_layout (default False keeps backwards
+        # compatibility with legacy single-feed corpora written as
+        # <output_dir>/run_<id>/...).
+        #
+        # Explicit ``is True`` check so that test doubles (MagicMock) whose
+        # attribute access returns a truthy Mock don't accidentally trip the
+        # wrapping path.
+        effective_cfg = cfg
+        use_corpus_layout = getattr(cfg, "single_feed_uses_corpus_layout", False) is True
+        if (
+            use_corpus_layout
+            and isinstance(getattr(cfg, "rss_url", None), str)
+            and cfg.rss_url
+            and isinstance(getattr(cfg, "output_dir", None), str)
+            and cfg.output_dir
+        ):
+            feed_dir = filesystem.corpus_feed_output_dir(cfg.output_dir, cfg.rss_url)
+            effective_cfg = cfg.model_copy(update={"output_dir": feed_dir})
+            logger.info(
+                "Single-feed run using corpus layout: %s -> %s",
+                cfg.output_dir,
+                feed_dir,
+            )
+
+        count, summary = workflow.run_pipeline(effective_cfg)
 
         return ServiceResult(
             episodes_processed=count,

--- a/src/podcast_scraper/workflow/corpus_operations.py
+++ b/src/podcast_scraper/workflow/corpus_operations.py
@@ -497,9 +497,6 @@ def finalize_multi_feed_batch(
         return summary_doc
     if template_cfg.vector_search is not True:
         return summary_doc
-    if getattr(template_cfg, "vector_backend", "faiss") != "faiss":
-        logger.warning("Skipping parent corpus index: vector_backend is not faiss")
-        return summary_doc
 
     from podcast_scraper.search.indexer import index_corpus
 

--- a/src/podcast_scraper/workflow/metadata_generation.py
+++ b/src/podcast_scraper/workflow/metadata_generation.py
@@ -372,6 +372,11 @@ class SummaryMetadata(BaseModel):
         default="valid", description="Parsing status"
     )
     raw_text: Optional[str] = Field(default=None, description="Original raw text if parsing failed")
+    # Transient (not serialized): prefilled insights/topics/entities produced by
+    # llm_pipeline_mode=mega_bundled / extraction_bundled so GIL + KG stages can
+    # skip their own LLM calls. Shape matches
+    # ``MegaBundleResult.to_extraction_partial()``.
+    prefilled_extraction: Optional[Dict[str, Any]] = Field(default=None, exclude=True, repr=False)
 
     @field_serializer("generated_at")
     def serialize_generated_at(self, value: datetime) -> str:
@@ -2145,8 +2150,91 @@ def _generate_episode_summary(  # noqa: C901
             params.update(_hybrid_ml_layered_summarize_params(cfg, summary_provider))
 
             result: Optional[Dict[str, Any]] = None
+            pipeline_mode = getattr(cfg, "llm_pipeline_mode", "staged")
+
+            # mega_bundled / extraction_bundled (#643): single call returns
+            # summary+bullets (mega only) PLUS insights+topics+entities. The
+            # extraction partial rides along on result["metadata"] so GIL+KG
+            # stages can skip their own LLM calls.
+            mega_fn = getattr(summary_provider, "summarize_mega_bundled", None)
+            extr_fn = getattr(summary_provider, "summarize_extraction_bundled", None)
+            if pipeline_mode == "mega_bundled" and callable(mega_fn):
+                try:
+                    logger.debug("[%s] mega_bundled single-call path", episode_idx)
+                    from ..cleaning import PatternBasedCleaner
+                    from ..providers.common.megabundle_parser import MegaBundleResult
+
+                    cleaning_started = time.perf_counter()
+                    pattern_cleaned = PatternBasedCleaner().clean(transcript_text)
+                    if pipeline_metrics is not None:
+                        pipeline_metrics.record_cleaning_time(
+                            time.perf_counter() - cleaning_started, episode_idx
+                        )
+                    mega_result = mega_fn(
+                        pattern_cleaned,
+                        episode_title=None,
+                        episode_description=None,
+                        params=params,
+                        pipeline_metrics=pipeline_metrics,
+                        call_metrics=call_metrics,
+                    )
+                    if isinstance(mega_result, MegaBundleResult):
+                        summary_json = json.dumps(mega_result.to_summary_artifact())
+                        result = {
+                            "summary": summary_json,
+                            "summary_short": None,
+                            "metadata": {
+                                "provider": getattr(cfg, "summary_provider", "unknown"),
+                                "bundled": True,
+                                "pipeline_mode": "mega_bundled",
+                                "prefilled_extraction": mega_result.to_extraction_partial(),
+                            },
+                        }
+                except Exception as mega_exc:
+                    if pipeline_metrics is not None:
+                        pipeline_metrics.record_llm_bundled_fallback_to_staged()
+                    logger.warning(
+                        "[%s] mega_bundled failed, falling back to staged: %s",
+                        episode_idx,
+                        redact_for_log(str(mega_exc)),
+                    )
+                    result = None
+            elif pipeline_mode == "mega_bundled":
+                logger.warning(
+                    "[%s] llm_pipeline_mode=mega_bundled but provider has no "
+                    "summarize_mega_bundled; using staged path",
+                    episode_idx,
+                )
+            elif pipeline_mode == "extraction_bundled" and callable(extr_fn):
+                # Extraction_bundled: staged summary (below) + bundled extraction (now).
+                # We run the extraction call here, stash the partial, then let the
+                # staged summary path run. This is a pragmatic first cut: it adds 1
+                # LLM call but halves GIL+KG (2 -> 0 separate provider calls).
+                try:
+                    logger.debug("[%s] extraction_bundled single-call extraction", episode_idx)
+                    from ..providers.common.megabundle_parser import MegaBundleResult
+
+                    extr_result = extr_fn(
+                        transcript_text,
+                        episode_title=None,
+                        episode_description=None,
+                        params=params,
+                        pipeline_metrics=pipeline_metrics,
+                        call_metrics=call_metrics,
+                    )
+                    if isinstance(extr_result, MegaBundleResult):
+                        # Stash on cfg-local var; applied after staged summary runs.
+                        params["_prefilled_extraction"] = extr_result.to_extraction_partial()
+                except Exception as extr_exc:
+                    logger.warning(
+                        "[%s] extraction_bundled failed, GIL/KG will run their "
+                        "own LLM calls: %s",
+                        episode_idx,
+                        redact_for_log(str(extr_exc)),
+                    )
+
             bundled_fn = getattr(summary_provider, "summarize_bundled", None)
-            if getattr(cfg, "llm_pipeline_mode", "staged") == "bundled" and callable(bundled_fn):
+            if result is None and pipeline_mode == "bundled" and callable(bundled_fn):
                 try:
                     logger.debug("[%s] Bundled clean+summary (pattern pre-clean)", episode_idx)
                     from ..cleaning import PatternBasedCleaner
@@ -2420,6 +2508,20 @@ def _generate_episode_summary(  # noqa: C901
                 logger.error("%s", redact_for_log(error_msg))
                 raise RuntimeError(redact_for_log(error_msg))
 
+            # Pick up prefilled extraction from mega_bundled (on result metadata)
+            # or extraction_bundled (stashed on params earlier).
+            prefilled_extraction: Optional[Dict[str, Any]] = None
+            if isinstance(result, dict):
+                result_meta = result.get("metadata") if isinstance(result, dict) else None
+                if isinstance(result_meta, dict):
+                    pe = result_meta.get("prefilled_extraction")
+                    if isinstance(pe, dict):
+                        prefilled_extraction = pe
+            if prefilled_extraction is None and isinstance(
+                params.get("_prefilled_extraction"), dict
+            ):
+                prefilled_extraction = params["_prefilled_extraction"]
+
             # Build SummaryMetadata with required schema fields
             return (
                 SummaryMetadata(
@@ -2432,6 +2534,7 @@ def _generate_episode_summary(  # noqa: C901
                     timestamps=schema.timestamps,
                     schema_status=schema.status,
                     raw_text=schema.raw_text if schema.status != "valid" else None,
+                    prefilled_extraction=prefilled_extraction,
                 ),
                 call_metrics,
             )
@@ -3354,6 +3457,14 @@ def generate_episode_metadata(  # noqa: C901
                 gi_episode_duration_ms: Optional[int] = None
                 if episode_duration_seconds is not None and int(episode_duration_seconds) > 0:
                     gi_episode_duration_ms = int(episode_duration_seconds) * 1000
+                # #643: prefer insights from mega_bundled / extraction_bundled.
+                prefilled_insights_arg: Optional[List[Dict[str, Any]]] = None
+                if summary_metadata is not None:
+                    pe = getattr(summary_metadata, "prefilled_extraction", None)
+                    if isinstance(pe, dict):
+                        pe_insights = pe.get("insights")
+                        if isinstance(pe_insights, list) and pe_insights:
+                            prefilled_insights_arg = pe_insights
                 payload = build_artifact(
                     episode_id,
                     transcript_text,
@@ -3376,6 +3487,7 @@ def generate_episode_metadata(  # noqa: C901
                     gil_created_evidence_providers=gil_evidence_cleanup,
                     topic_labels=gi_topic_labels,
                     episode_duration_ms=gi_episode_duration_ms,
+                    prefilled_insights=prefilled_insights_arg,
                 )
                 write_artifact(Path(gi_path), payload, validate=True)
                 bridge_gi_payload = payload
@@ -3530,6 +3642,15 @@ def generate_episode_metadata(  # noqa: C901
                     write_artifact as kg_write_artifact,
                 )
 
+                # #643: prefer topics/entities from mega_bundled / extraction_bundled.
+                kg_prefilled_partial: Optional[Dict[str, Any]] = None
+                if summary_metadata is not None:
+                    pe_kg = getattr(summary_metadata, "prefilled_extraction", None)
+                    if isinstance(pe_kg, dict) and (pe_kg.get("topics") or pe_kg.get("entities")):
+                        kg_prefilled_partial = {
+                            "topics": pe_kg.get("topics") or [],
+                            "entities": pe_kg.get("entities") or [],
+                        }
                 kg_payload = kg_build_artifact(
                     episode_id,
                     transcript_text_kg,
@@ -3544,6 +3665,7 @@ def generate_episode_metadata(  # noqa: C901
                     cfg=cfg,
                     kg_extraction_provider=kg_provider_arg,
                     pipeline_metrics=pipeline_metrics,
+                    prefilled_partial=kg_prefilled_partial,
                 )
                 kg_write_artifact(Path(kg_path), kg_payload, validate=True)
                 bridge_kg_payload = kg_payload

--- a/tests/unit/podcast_scraper/preprocessing/test_audio_profile_wiring.py
+++ b/tests/unit/podcast_scraper/preprocessing/test_audio_profile_wiring.py
@@ -1,0 +1,79 @@
+"""Wiring test: ``audio_preprocessing_profile`` YAML value flows through
+Config → factory → FFmpegAudioPreprocessor → ffmpeg cmd (#646).
+
+Motivated by #644's Phase-3C class of bug: unit tests that construct Config
+programmatically may miss silent drops on the profile → factory → subprocess
+path. This test covers the full wiring end-to-end with a mocked subprocess so
+it runs cheap and deterministic but exercises the real factory + ffmpeg
+command builder.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from podcast_scraper import config as cfg_mod
+from podcast_scraper.preprocessing.audio.factory import create_audio_preprocessor
+
+
+@pytest.fixture
+def _fake_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """cloud_balanced wires summary_provider=gemini → Config validates an api key."""
+    for name in (
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "MISTRAL_API_KEY",
+        "GROK_API_KEY",
+    ):
+        monkeypatch.setenv(name, "test-" + name.lower().replace("_", "-") + "-dummy-key")
+
+
+class TestAudioPreprocessingProfileWiring:
+    def test_cloud_balanced_resolves_speech_optimal_v1_to_ffmpeg_args(
+        self, _fake_keys: None, tmp_path
+    ) -> None:
+        data = cfg_mod.load_config_file("config/profiles/cloud_balanced.yaml")
+        cfg = cfg_mod.Config.model_validate({**data, "rss_url": "https://example.com/feed.xml"})
+
+        # Confirm profile resolution happens.
+        assert cfg.audio_preprocessing_profile == "speech_optimal_v1"
+        assert cfg.preprocessing_silence_threshold == "-30dB"
+        assert cfg.preprocessing_silence_duration == 0.5
+        assert cfg.preprocessing_mp3_bitrate_kbps == 32
+        assert cfg.preprocessing_sample_rate == 16000
+        assert cfg.preprocessing_target_loudness == -16
+
+        prep = create_audio_preprocessor(cfg)
+        assert prep is not None
+        assert prep.silence_threshold == "-30dB"
+        assert prep.silence_duration == 0.5
+        assert prep.mp3_bitrate_kbps == 32
+
+        # Capture the actual ffmpeg cmd.
+        with (
+            patch(
+                "podcast_scraper.preprocessing.audio.ffmpeg_processor._run_text_subprocess"
+            ) as mock_sp,
+            patch(
+                "podcast_scraper.preprocessing.audio.ffmpeg_processor._check_ffmpeg_available",
+                return_value=True,
+            ),
+        ):
+            prep.preprocess(
+                str(tmp_path / "in.mp3"),
+                str(tmp_path / "out.mp3"),
+            )
+
+        cmd = mock_sp.call_args[0][0]
+        joined = " ".join(cmd)
+        assert "-b:a" in cmd and "32k" in cmd, joined
+        assert "-ar" in cmd and "16000" in cmd, joined
+        assert "start_threshold=-30dB" in joined, joined
+        assert "stop_threshold=-30dB" in joined, joined
+        assert "start_duration=0.5" in joined, joined
+        assert "stop_duration=0.5" in joined, joined
+        assert "loudnorm=I=-16" in joined, joined

--- a/tests/unit/podcast_scraper/prompting/test_megabundle_prompt.py
+++ b/tests/unit/podcast_scraper/prompting/test_megabundle_prompt.py
@@ -1,0 +1,84 @@
+"""Unit tests for mega-bundle prompt builder (#643)."""
+
+from __future__ import annotations
+
+from podcast_scraper.prompting.megabundle import (
+    build_extraction_bundle_prompt,
+    build_megabundle_prompt,
+    DEFAULT_MEGA_BUNDLE_ENTITIES_MAX,
+    DEFAULT_MEGA_BUNDLE_INSIGHTS,
+    DEFAULT_MEGA_BUNDLE_TOPICS,
+)
+
+
+class TestBuildMegaBundlePrompt:
+    def test_includes_all_required_fields(self):
+        system, user = build_megabundle_prompt("Some transcript text.")
+        assert "JSON object" in system
+        assert '"title"' in user
+        assert '"summary"' in user
+        assert '"bullets"' in user
+        assert '"insights"' in user
+        assert '"topics"' in user
+        assert '"entities"' in user
+
+    def test_includes_research_sweet_spots_by_default(self):
+        _, user = build_megabundle_prompt("T")
+        assert f"EXACTLY {DEFAULT_MEGA_BUNDLE_INSIGHTS}" in user
+        assert f"EXACTLY {DEFAULT_MEGA_BUNDLE_TOPICS}" in user
+        assert f"up to {DEFAULT_MEGA_BUNDLE_ENTITIES_MAX}" in user
+
+    def test_custom_counts_propagate(self):
+        _, user = build_megabundle_prompt(
+            "T",
+            num_insights=8,
+            num_topics=6,
+            max_entities=10,
+        )
+        assert "EXACTLY 8" in user
+        assert "EXACTLY 6" in user
+        assert "up to 10" in user
+
+    def test_language_hint_default_en(self):
+        _, user = build_megabundle_prompt("T")
+        assert "Language: en" in user
+
+    def test_language_hint_can_be_disabled(self):
+        _, user = build_megabundle_prompt("T", language=None)
+        assert "Language:" not in user
+
+    def test_language_hint_custom(self):
+        _, user = build_megabundle_prompt("T", language="fr")
+        assert "Language: fr" in user
+
+    def test_transcript_truncated_to_cap(self):
+        long_t = "x" * 50_000
+        _, user = build_megabundle_prompt(long_t, max_transcript_chars=1000)
+        # The user prompt should contain the truncated 1000-char transcript.
+        # Count occurrences of 'x' in user; rough bound.
+        assert user.count("x") <= 1000 + 50  # small slack for prompt scaffolding
+
+    def test_noun_phrase_instruction_preserved(self):
+        _, user = build_megabundle_prompt("T")
+        # KG v3 noun-phrase discipline is load-bearing for topic quality.
+        assert "noun phrase" in user.lower()
+        assert "unique" in user.lower()
+
+
+class TestBuildExtractionBundlePrompt:
+    def test_omits_summary_bullets_title(self):
+        _, user = build_extraction_bundle_prompt("T")
+        assert '"summary"' not in user
+        assert '"bullets"' not in user
+        assert '"title"' not in user
+
+    def test_keeps_extraction_fields(self):
+        _, user = build_extraction_bundle_prompt("T")
+        assert '"insights"' in user
+        assert '"topics"' in user
+        assert '"entities"' in user
+
+    def test_research_sweet_spots_by_default(self):
+        _, user = build_extraction_bundle_prompt("T")
+        assert f"EXACTLY {DEFAULT_MEGA_BUNDLE_INSIGHTS}" in user
+        assert f"EXACTLY {DEFAULT_MEGA_BUNDLE_TOPICS}" in user

--- a/tests/unit/podcast_scraper/providers/common/test_megabundle_parser.py
+++ b/tests/unit/podcast_scraper/providers/common/test_megabundle_parser.py
@@ -1,0 +1,155 @@
+"""Unit tests for mega-bundle parser (#643)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from podcast_scraper.providers.common.megabundle_parser import (
+    MegaBundleParseError,
+    parse_extraction_bundle_response,
+    parse_megabundle_response,
+)
+
+VALID = {
+    "title": "Test Episode",
+    "summary": "Paragraph one. Paragraph two.",
+    "bullets": ["bullet 1", "bullet 2", "bullet 3"],
+    "insights": [
+        {"text": "Insight one.", "insight_type": "claim"},
+        {"text": "Insight two.", "insight_type": "fact"},
+    ],
+    "topics": ["topic one", "topic two", "topic three"],
+    "entities": [
+        {"name": "Alice", "kind": "person", "role": "host"},
+        {"name": "Acme Inc.", "kind": "org", "role": "mentioned"},
+    ],
+}
+
+
+class TestParseMegaBundle:
+    def test_parses_clean_json(self):
+        r = parse_megabundle_response(json.dumps(VALID))
+        assert r.title == "Test Episode"
+        assert r.summary.startswith("Paragraph one")
+        assert len(r.bullets) == 3
+        assert len(r.insights) == 2
+        assert r.insights[0]["text"] == "Insight one."
+        assert r.insights[0]["insight_type"] == "claim"
+        assert r.topics == ["topic one", "topic two", "topic three"]
+        assert len(r.entities) == 2
+        assert r.entities[0]["name"] == "Alice"
+
+    def test_strips_code_fences(self):
+        text = "```json\n" + json.dumps(VALID) + "\n```"
+        r = parse_megabundle_response(text)
+        assert r.title == "Test Episode"
+
+    def test_strips_triple_backtick_no_lang(self):
+        text = "```\n" + json.dumps(VALID) + "\n```"
+        r = parse_megabundle_response(text)
+        assert r.summary
+
+    def test_raises_on_empty_text(self):
+        with pytest.raises(MegaBundleParseError, match="Empty"):
+            parse_megabundle_response("")
+
+    def test_raises_on_malformed_json(self):
+        with pytest.raises(MegaBundleParseError, match="not valid JSON"):
+            parse_megabundle_response("{ not valid json }")
+
+    def test_raises_on_non_object_top_level(self):
+        with pytest.raises(MegaBundleParseError, match="top level"):
+            parse_megabundle_response("[]")
+
+    def test_raises_on_missing_summary(self):
+        bad = dict(VALID)
+        del bad["summary"]
+        with pytest.raises(MegaBundleParseError, match="Missing 'summary'"):
+            parse_megabundle_response(json.dumps(bad))
+
+    def test_raises_on_missing_insights(self):
+        bad = dict(VALID)
+        del bad["insights"]
+        with pytest.raises(MegaBundleParseError, match="Missing 'insights'"):
+            parse_megabundle_response(json.dumps(bad))
+
+    def test_raises_on_missing_topics(self):
+        bad = dict(VALID)
+        del bad["topics"]
+        with pytest.raises(MegaBundleParseError, match="Missing 'topics'"):
+            parse_megabundle_response(json.dumps(bad))
+
+    def test_normalizes_bare_string_insights(self):
+        data = dict(VALID)
+        data["insights"] = ["raw insight one", "raw insight two"]
+        r = parse_megabundle_response(json.dumps(data))
+        assert r.insights[0]["text"] == "raw insight one"
+        assert r.insights[0]["insight_type"] == "claim"
+
+    def test_normalizes_type_alias_to_insight_type(self):
+        data = dict(VALID)
+        data["insights"] = [{"text": "X", "type": "fact"}]
+        r = parse_megabundle_response(json.dumps(data))
+        assert r.insights[0]["insight_type"] == "fact"
+
+    def test_normalizes_unknown_insight_type_to_claim(self):
+        data = dict(VALID)
+        data["insights"] = [{"text": "X", "insight_type": "weird"}]
+        r = parse_megabundle_response(json.dumps(data))
+        assert r.insights[0]["insight_type"] == "claim"
+
+    def test_normalizes_topic_with_label_key(self):
+        data = dict(VALID)
+        data["topics"] = [{"label": "one"}, {"label": "two"}, "three"]
+        r = parse_megabundle_response(json.dumps(data))
+        assert r.topics == ["one", "two", "three"]
+
+    def test_normalizes_bare_string_entities(self):
+        data = dict(VALID)
+        data["entities"] = ["Alice", "Bob"]
+        r = parse_megabundle_response(json.dumps(data))
+        assert r.entities[0]["name"] == "Alice"
+        assert r.entities[0]["kind"] == "person"
+        assert r.entities[0]["role"] == "mentioned"
+
+    def test_normalizes_unknown_entity_kind_to_person(self):
+        data = dict(VALID)
+        data["entities"] = [{"name": "X", "kind": "robot"}]
+        r = parse_megabundle_response(json.dumps(data))
+        assert r.entities[0]["kind"] == "person"
+
+    def test_to_summary_artifact_shape(self):
+        r = parse_megabundle_response(json.dumps(VALID))
+        a = r.to_summary_artifact()
+        assert a == {
+            "title": "Test Episode",
+            "summary": "Paragraph one. Paragraph two.",
+            "bullets": ["bullet 1", "bullet 2", "bullet 3"],
+        }
+
+    def test_raw_is_preserved(self):
+        r = parse_megabundle_response(json.dumps(VALID))
+        assert r.raw == VALID
+
+
+class TestParseExtractionBundle:
+    def test_summary_not_required(self):
+        data = {k: v for k, v in VALID.items() if k not in ("title", "summary", "bullets")}
+        r = parse_extraction_bundle_response(json.dumps(data))
+        assert r.title == ""
+        assert r.summary == ""
+        assert r.bullets == []
+        assert len(r.insights) == 2
+        assert len(r.topics) == 3
+
+    def test_insights_still_required(self):
+        bad = {"topics": ["a", "b"], "entities": []}
+        with pytest.raises(MegaBundleParseError, match="Missing 'insights'"):
+            parse_extraction_bundle_response(json.dumps(bad))
+
+    def test_topics_still_required(self):
+        bad = {"insights": [{"text": "X"}], "entities": []}
+        with pytest.raises(MegaBundleParseError, match="Missing 'topics'"):
+            parse_extraction_bundle_response(json.dumps(bad))

--- a/tests/unit/podcast_scraper/providers/common/test_output_tokens.py
+++ b/tests/unit/podcast_scraper/providers/common/test_output_tokens.py
@@ -1,0 +1,118 @@
+"""Unit tests for cloud-LLM output-token floor helper (#645)."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+from podcast_scraper.providers.common.output_tokens import (
+    cloud_structured_max_output_tokens,
+    warn_if_output_truncated,
+)
+
+
+class TestCloudStructuredMaxOutputTokens:
+    def test_clamps_up_to_floor(self):
+        cfg = MagicMock()
+        cfg.cloud_llm_structured_min_output_tokens = 4096
+        assert cloud_structured_max_output_tokens(cfg, 650) == 4096
+
+    def test_respects_larger_than_floor(self):
+        cfg = MagicMock()
+        cfg.cloud_llm_structured_min_output_tokens = 4096
+        assert cloud_structured_max_output_tokens(cfg, 8192) == 8192
+
+    def test_none_requested_returns_floor(self):
+        cfg = MagicMock()
+        cfg.cloud_llm_structured_min_output_tokens = 4096
+        assert cloud_structured_max_output_tokens(cfg, None) == 4096
+
+    def test_zero_requested_returns_floor(self):
+        cfg = MagicMock()
+        cfg.cloud_llm_structured_min_output_tokens = 4096
+        assert cloud_structured_max_output_tokens(cfg, 0) == 4096
+
+    def test_equal_to_floor_returns_as_is(self):
+        cfg = MagicMock()
+        cfg.cloud_llm_structured_min_output_tokens = 4096
+        assert cloud_structured_max_output_tokens(cfg, 4096) == 4096
+
+    def test_falls_back_to_default_when_attr_missing(self):
+        cfg = object()  # no cloud_llm_structured_min_output_tokens attribute
+        # Default floor is 4096 per the helper's module-level constant.
+        assert cloud_structured_max_output_tokens(cfg, 650) == 4096
+
+    def test_falls_back_to_default_when_attr_none(self):
+        cfg = MagicMock()
+        cfg.cloud_llm_structured_min_output_tokens = None
+        assert cloud_structured_max_output_tokens(cfg, 650) == 4096
+
+    def test_custom_floor_from_cfg_is_respected(self):
+        cfg = MagicMock()
+        cfg.cloud_llm_structured_min_output_tokens = 8192
+        assert cloud_structured_max_output_tokens(cfg, 650) == 8192
+        assert cloud_structured_max_output_tokens(cfg, 16384) == 16384
+
+
+class TestWarnIfOutputTruncated:
+    def test_warns_on_max_tokens_finish_reason(self, caplog):
+        caplog.set_level(logging.WARNING, logger="podcast_scraper.providers.common.output_tokens")
+        warn_if_output_truncated(
+            provider_name="gemini",
+            finish_reason="MAX_TOKENS",
+            output_tokens=4090,
+            max_output_tokens=4096,
+        )
+        assert any("possible output truncation" in rec.getMessage() for rec in caplog.records)
+
+    def test_warns_on_near_budget_even_without_finish_reason(self, caplog):
+        caplog.set_level(logging.WARNING, logger="podcast_scraper.providers.common.output_tokens")
+        # 4000/4096 = 97.6% — above the 95% near-budget threshold.
+        warn_if_output_truncated(
+            provider_name="openai",
+            finish_reason="STOP",
+            output_tokens=4000,
+            max_output_tokens=4096,
+        )
+        assert any("possible output truncation" in rec.getMessage() for rec in caplog.records)
+
+    def test_no_warn_on_normal_finish(self, caplog):
+        caplog.set_level(logging.WARNING, logger="podcast_scraper.providers.common.output_tokens")
+        warn_if_output_truncated(
+            provider_name="anthropic",
+            finish_reason="STOP",
+            output_tokens=1000,
+            max_output_tokens=4096,
+        )
+        assert not any("possible output truncation" in rec.getMessage() for rec in caplog.records)
+
+    def test_no_warn_when_no_signals(self, caplog):
+        caplog.set_level(logging.WARNING, logger="podcast_scraper.providers.common.output_tokens")
+        warn_if_output_truncated(
+            provider_name="openai",
+            finish_reason=None,
+            output_tokens=None,
+            max_output_tokens=4096,
+        )
+        assert not any("possible output truncation" in rec.getMessage() for rec in caplog.records)
+
+    def test_safety_finish_reason_warns(self, caplog):
+        caplog.set_level(logging.WARNING, logger="podcast_scraper.providers.common.output_tokens")
+        warn_if_output_truncated(
+            provider_name="gemini",
+            finish_reason="SAFETY",
+            output_tokens=100,
+            max_output_tokens=4096,
+        )
+        assert any("possible output truncation" in rec.getMessage() for rec in caplog.records)
+
+    def test_episode_id_included_in_warning(self, caplog):
+        caplog.set_level(logging.WARNING, logger="podcast_scraper.providers.common.output_tokens")
+        warn_if_output_truncated(
+            provider_name="gemini",
+            finish_reason="MAX_TOKENS",
+            output_tokens=4090,
+            max_output_tokens=4096,
+            episode_id="p04_e03",
+        )
+        assert any("ep=p04_e03" in rec.getMessage() for rec in caplog.records)

--- a/tests/unit/podcast_scraper/providers/test_megabundle_methods.py
+++ b/tests/unit/podcast_scraper/providers/test_megabundle_methods.py
@@ -1,0 +1,346 @@
+"""Unit tests for provider-level mega_bundled / extraction_bundled methods (#643).
+
+These tests mock each SDK client and verify:
+- The new methods exist and return ``MegaBundleResult`` objects.
+- Prompts are sourced from ``prompting.megabundle`` (not the legacy
+  bundled_clean_summary_* prompt store entries).
+- JSON-mode / response_format flags are set on the API call.
+- The extraction variant does not require summary/bullets in the response.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from podcast_scraper import config
+from podcast_scraper.providers.anthropic.anthropic_provider import AnthropicProvider
+from podcast_scraper.providers.common.megabundle_parser import MegaBundleResult
+from podcast_scraper.providers.deepseek.deepseek_provider import DeepSeekProvider
+from podcast_scraper.providers.gemini.gemini_provider import GeminiProvider
+from podcast_scraper.providers.grok.grok_provider import GrokProvider
+from podcast_scraper.providers.mistral.mistral_provider import MistralProvider
+from podcast_scraper.providers.openai.openai_provider import OpenAIProvider
+
+_MEGA_JSON = json.dumps(
+    {
+        "title": "Ep T",
+        "summary": "A prose summary.",
+        "bullets": ["b1", "b2", "b3"],
+        "insights": [
+            {"text": "i1", "insight_type": "claim"},
+            {"text": "i2", "insight_type": "fact"},
+        ],
+        "topics": ["t1", "t2", "t3"],
+        "entities": [{"name": "Alice", "kind": "person", "role": "host"}],
+    }
+)
+
+_EXTRACTION_JSON = json.dumps(
+    {
+        "insights": [{"text": "i1", "insight_type": "claim"}],
+        "topics": ["t1", "t2"],
+        "entities": [{"name": "Bob", "kind": "person", "role": "mentioned"}],
+    }
+)
+
+
+def _cfg(summary_provider: str, extra: dict | None = None) -> config.Config:
+    base = {
+        "rss_url": "https://example.com/feed.xml",
+        "summary_provider": summary_provider,
+        "transcribe_missing": False,
+        "auto_speakers": False,
+        "generate_summaries": False,
+    }
+    if summary_provider == "anthropic":
+        base["anthropic_api_key"] = "k"
+    elif summary_provider == "openai":
+        base["openai_api_key"] = "k"
+    elif summary_provider == "gemini":
+        base["gemini_api_key"] = "k"
+    elif summary_provider == "mistral":
+        base["mistral_api_key"] = "k"
+    elif summary_provider == "grok":
+        base["grok_api_key"] = "k"
+    elif summary_provider == "deepseek":
+        base["deepseek_api_key"] = "k"
+    if extra:
+        base.update(extra)
+    return config.Config.model_validate(base)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicBundledMethods:
+    def _mock_resp(self, text: str, inp: int = 100, out: int = 50) -> Mock:
+        resp = Mock()
+        block = Mock()
+        block.text = text
+        resp.content = [block]
+        resp.usage = Mock(input_tokens=inp, output_tokens=out)
+        return resp
+
+    @patch("podcast_scraper.providers.anthropic.anthropic_provider.Anthropic")
+    def test_mega_bundled_returns_result(self, mock_anthropic_cls):
+        client = Mock()
+        mock_anthropic_cls.return_value = client
+        client.messages.create.return_value = self._mock_resp(_MEGA_JSON)
+        provider = AnthropicProvider(_cfg("anthropic"))
+        provider._summarization_initialized = True
+        provider.client = client
+
+        result = provider.summarize_mega_bundled("transcript text")
+
+        assert isinstance(result, MegaBundleResult)
+        assert result.title == "Ep T"
+        assert result.summary.startswith("A prose")
+        assert len(result.bullets) == 3
+        assert len(result.insights) == 2
+        assert result.topics == ["t1", "t2", "t3"]
+        assert result.entities[0]["name"] == "Alice"
+        call = client.messages.create.call_args
+        assert call.kwargs["temperature"] == 0.0
+        assert "messages" in call.kwargs
+        assert "system" in call.kwargs
+
+    @patch("podcast_scraper.providers.anthropic.anthropic_provider.Anthropic")
+    def test_extraction_bundled_no_summary_required(self, mock_anthropic_cls):
+        client = Mock()
+        mock_anthropic_cls.return_value = client
+        client.messages.create.return_value = self._mock_resp(_EXTRACTION_JSON)
+        provider = AnthropicProvider(_cfg("anthropic"))
+        provider._summarization_initialized = True
+        provider.client = client
+
+        result = provider.summarize_extraction_bundled("transcript text")
+
+        assert isinstance(result, MegaBundleResult)
+        assert result.title == ""
+        assert result.summary == ""
+        assert result.bullets == []
+        assert len(result.insights) == 1
+        assert result.topics == ["t1", "t2"]
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek
+# ---------------------------------------------------------------------------
+
+
+class TestDeepSeekBundledMethods:
+    def _mock_resp(self, text: str) -> Mock:
+        resp = Mock()
+        resp.choices = [Mock(message=Mock(content=text))]
+        resp.usage = Mock(prompt_tokens=100, completion_tokens=50)
+        return resp
+
+    def _build(self):
+        client = Mock()
+        provider = DeepSeekProvider(_cfg("deepseek"))
+        provider._summarization_initialized = True
+        provider.client = client
+        provider.summary_model = "deepseek-chat"
+        return provider, client
+
+    def test_mega_bundled_caps_max_tokens_at_8192(self):
+        provider, client = self._build()
+        client.chat.completions.create.return_value = self._mock_resp(_MEGA_JSON)
+
+        provider.summarize_mega_bundled("t", params={"max_tokens": 16384})
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_tokens"] == 8192
+        assert kwargs["response_format"] == {"type": "json_object"}
+
+    def test_extraction_bundled_returns_result(self):
+        provider, client = self._build()
+        client.chat.completions.create.return_value = self._mock_resp(_EXTRACTION_JSON)
+
+        result = provider.summarize_extraction_bundled("t")
+
+        assert isinstance(result, MegaBundleResult)
+        assert result.summary == ""
+        assert len(result.insights) == 1
+        assert client.chat.completions.create.call_args.kwargs["response_format"] == {
+            "type": "json_object"
+        }
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIExtractionBundled:
+    def _mock_resp(self, text: str) -> Mock:
+        resp = Mock()
+        resp.choices = [Mock(message=Mock(content=text), finish_reason="stop")]
+        resp.usage = Mock(prompt_tokens=100, completion_tokens=50)
+        return resp
+
+    def _build(self):
+        client = Mock()
+        provider = OpenAIProvider(_cfg("openai"))
+        provider._summarization_initialized = True
+        provider.client = client
+        provider.summary_model = "gpt-4o-mini"
+        provider.summary_temperature = 0.2
+        provider.summary_seed = None
+        return provider, client
+
+    def test_extraction_bundled_uses_json_object_mode(self):
+        provider, client = self._build()
+        client.chat.completions.create.return_value = self._mock_resp(_EXTRACTION_JSON)
+
+        result = provider.summarize_extraction_bundled("t")
+
+        assert isinstance(result, MegaBundleResult)
+        assert result.summary == ""
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["response_format"] == {"type": "json_object"}
+        assert kwargs["temperature"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Gemini
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiExtractionBundled:
+    def _mock_resp(self, text: str) -> Mock:
+        resp = Mock()
+        resp.text = text
+        resp.usage_metadata = Mock(prompt_token_count=100, candidates_token_count=50)
+        return resp
+
+    def _build(self):
+        client = Mock()
+        provider = GeminiProvider(_cfg("gemini"))
+        provider._summarization_initialized = True
+        provider.client = client
+        provider.summary_model = "gemini-2.5-flash"
+        return provider, client
+
+    @patch(
+        "podcast_scraper.providers.gemini.gemini_provider._merge_generate_content_config",
+        side_effect=lambda _m, d: d,
+    )
+    def test_extraction_bundled_sets_json_mime(self, _mock_merge):
+        provider, client = self._build()
+        client.models.generate_content.return_value = self._mock_resp(_EXTRACTION_JSON)
+
+        result = provider.summarize_extraction_bundled("t")
+
+        assert isinstance(result, MegaBundleResult)
+        call = client.models.generate_content.call_args
+        cfg = call.kwargs["config"]
+        assert cfg["response_mime_type"] == "application/json"
+        assert cfg["temperature"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Mistral
+# ---------------------------------------------------------------------------
+
+
+class TestMistralExtractionBundled:
+    def _mock_resp(self, text: str) -> Mock:
+        resp = Mock()
+        resp.choices = [Mock(message=Mock(content=text))]
+        resp.usage = Mock(prompt_tokens=100, completion_tokens=50)
+        return resp
+
+    def _build(self):
+        client = Mock()
+        provider = MistralProvider(_cfg("mistral"))
+        provider._summarization_initialized = True
+        provider.client = client
+        provider.summary_model = "mistral-large-latest"
+        return provider, client
+
+    def test_extraction_bundled_sets_json_object(self):
+        provider, client = self._build()
+        client.chat.complete.return_value = self._mock_resp(_EXTRACTION_JSON)
+
+        result = provider.summarize_extraction_bundled("t")
+
+        assert isinstance(result, MegaBundleResult)
+        kwargs = client.chat.complete.call_args.kwargs
+        assert kwargs["response_format"] == {"type": "json_object"}
+        assert kwargs["temperature"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Grok
+# ---------------------------------------------------------------------------
+
+
+class TestGrokExtractionBundled:
+    def _mock_resp(self, text: str) -> Mock:
+        resp = Mock()
+        resp.choices = [Mock(message=Mock(content=text), finish_reason="stop")]
+        resp.usage = Mock(prompt_tokens=100, completion_tokens=50)
+        return resp
+
+    def _build(self):
+        client = Mock()
+        provider = GrokProvider(_cfg("grok"))
+        provider._summarization_initialized = True
+        provider.client = client
+        provider.summary_model = "grok-4"
+        provider.summary_temperature = 0.2
+        return provider, client
+
+    def test_extraction_bundled_sets_json_object(self):
+        provider, client = self._build()
+        client.chat.completions.create.return_value = self._mock_resp(_EXTRACTION_JSON)
+
+        result = provider.summarize_extraction_bundled("t")
+
+        assert isinstance(result, MegaBundleResult)
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["response_format"] == {"type": "json_object"}
+        assert kwargs["temperature"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Uninitialized guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "provider_cls,provider_key",
+    [
+        (AnthropicProvider, "anthropic"),
+        (DeepSeekProvider, "deepseek"),
+        (OpenAIProvider, "openai"),
+        (GeminiProvider, "gemini"),
+        (MistralProvider, "mistral"),
+        (GrokProvider, "grok"),
+    ],
+)
+def test_extraction_bundled_raises_when_uninitialized(provider_cls, provider_key):
+    provider = provider_cls(_cfg(provider_key))
+    provider._summarization_initialized = False
+    with pytest.raises(RuntimeError, match="not initialized"):
+        provider.summarize_extraction_bundled("t")
+
+
+@pytest.mark.parametrize(
+    "provider_cls,provider_key",
+    [
+        (AnthropicProvider, "anthropic"),
+        (DeepSeekProvider, "deepseek"),
+    ],
+)
+def test_mega_bundled_raises_when_uninitialized(provider_cls, provider_key):
+    provider = provider_cls(_cfg(provider_key))
+    provider._summarization_initialized = False
+    with pytest.raises(RuntimeError, match="not initialized"):
+        provider.summarize_mega_bundled("t")

--- a/tests/unit/podcast_scraper/providers/test_megabundle_methods.py
+++ b/tests/unit/podcast_scraper/providers/test_megabundle_methods.py
@@ -6,6 +6,12 @@ These tests mock each SDK client and verify:
   bundled_clean_summary_* prompt store entries).
 - JSON-mode / response_format flags are set on the API call.
 - The extraction variant does not require summary/bullets in the response.
+
+SDK deps (anthropic, mistralai, google.genai) are optional ``[llm]`` extras
+and not installed in the CI unit-test job. The ``_mock_all_provider_sdks``
+autouse fixture patches the module-level SDK symbols on every provider
+module so ``Provider(cfg)`` does not raise ``ImportError`` during test
+collection / construction.
 """
 
 from __future__ import annotations
@@ -23,6 +29,31 @@ from podcast_scraper.providers.gemini.gemini_provider import GeminiProvider
 from podcast_scraper.providers.grok.grok_provider import GrokProvider
 from podcast_scraper.providers.mistral.mistral_provider import MistralProvider
 from podcast_scraper.providers.openai.openai_provider import OpenAIProvider
+
+
+@pytest.fixture(autouse=True)
+def _mock_all_provider_sdks():
+    """Mock SDK module-level symbols so provider constructors pass the
+    ``None`` import guard without the real packages installed."""
+    # anthropic / mistralai / google.genai are in the [llm] extra and may be
+    # unavailable in the unit-test job. openai is a core dep so its SDK is
+    # imported lazily inside OpenAIProvider and needs no patch.
+    patches = [
+        patch("podcast_scraper.providers.anthropic.anthropic_provider.Anthropic", Mock()),
+        patch("podcast_scraper.providers.mistral.mistral_provider.Mistral", Mock()),
+        patch("podcast_scraper.providers.deepseek.deepseek_provider.OpenAI", Mock()),
+        patch("podcast_scraper.providers.grok.grok_provider.OpenAI", Mock()),
+        patch("podcast_scraper.providers.gemini.gemini_provider.genai", Mock()),
+    ]
+    for p in patches:
+        p.start()
+    yield
+    for p in reversed(patches):
+        try:
+            p.stop()
+        except (RuntimeError, AttributeError):
+            pass
+
 
 _MEGA_JSON = json.dumps(
     {

--- a/tests/unit/podcast_scraper/test_cli_profile_routing.py
+++ b/tests/unit/podcast_scraper/test_cli_profile_routing.py
@@ -1,0 +1,159 @@
+"""CLI profile-routing regression tests (#646).
+
+Covers two pre-existing bugs exposed by the real-episode validation:
+
+- Bug A: ``--profile NAME`` had a separate (broken) code path that did NOT
+  go through ``_load_and_merge_config``. argparse defaults (e.g.
+  ``--summary-provider`` default ``"transformers"``) silently overrode
+  profile values. Users of ``cloud_balanced`` / ``cloud_quality`` got
+  13 wrong fields.
+- Bug B: ``_build_config``'s payload dict did not forward fields that
+  only existed in the profile YAML (no argparse flag), e.g.
+  ``llm_pipeline_mode``, ``cloud_llm_structured_min_output_tokens``,
+  ``audio_preprocessing_profile``. ``--config <profile.yaml>`` worked
+  for argparse-known fields but silently dropped these.
+
+Both paths now route through ``_load_and_merge_config`` and include the
+missing fields conditionally in payload.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.cli import _build_config, parse_args
+
+
+@pytest.fixture
+def _fake_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "MISTRAL_API_KEY",
+        "GROK_API_KEY",
+    ):
+        monkeypatch.setenv(name, "test-" + name.lower().replace("_", "-") + "-dummy-key")
+
+
+CLOUD_BALANCED_EXPECTED = {
+    "transcription_provider": "openai",
+    "openai_transcription_model": "whisper-1",
+    "audio_preprocessing_profile": "speech_optimal_v1",
+    "speaker_detector_provider": "spacy",
+    "ner_model": "en_core_web_trf",
+    "auto_speakers": True,
+    "summary_provider": "gemini",
+    "gemini_summary_model": "gemini-2.5-flash-lite",
+    "preprocessing_enabled": True,
+    "llm_pipeline_mode": "mega_bundled",
+    "cloud_llm_structured_min_output_tokens": 4096,
+    "generate_gi": True,
+    "gi_insight_source": "provider",
+    "gi_max_insights": 12,
+    "gi_require_grounding": True,
+    "generate_kg": True,
+    "kg_extraction_source": "provider",
+    "kg_max_topics": 10,
+    "kg_max_entities": 15,
+    "vector_search": True,
+    "vector_backend": "faiss",
+    "generate_metadata": True,
+    "generate_summaries": True,
+    "preprocessing_silence_threshold": "-30dB",
+    "preprocessing_silence_duration": 0.5,
+    "preprocessing_mp3_bitrate_kbps": 32,
+    "preprocessing_sample_rate": 16000,
+    "preprocessing_target_loudness": -16,
+}
+
+CLOUD_QUALITY_OVERRIDES = {
+    "summary_provider": "anthropic",
+    "anthropic_summary_model": "claude-haiku-4-5",
+    "llm_pipeline_mode": "mega_bundled",
+    "cloud_llm_structured_min_output_tokens": 4096,
+    "audio_preprocessing_profile": "speech_optimal_v1",
+}
+
+
+def _build_via_profile(name: str) -> object:
+    args = parse_args(
+        ["--profile", name, "https://example.com/feed.xml", "--output-dir", "/tmp/_t"]
+    )
+    return _build_config(args)
+
+
+def _build_via_config(path: str) -> object:
+    args = parse_args(["--config", path, "https://example.com/feed.xml", "--output-dir", "/tmp/_t"])
+    return _build_config(args)
+
+
+class TestProfileFlagRouting:
+    """Bug A regression: --profile NAME must produce every field from the YAML."""
+
+    def test_profile_cloud_balanced_matches_yaml(self, _fake_keys: None) -> None:
+        cfg = _build_via_profile("cloud_balanced")
+        for key, expected in CLOUD_BALANCED_EXPECTED.items():
+            actual = getattr(cfg, key, None)
+            assert actual == expected, f"{key}: expected={expected!r} actual={actual!r}"
+
+    def test_profile_cloud_quality_matches_yaml(self, _fake_keys: None) -> None:
+        cfg = _build_via_profile("cloud_quality")
+        for key, expected in CLOUD_QUALITY_OVERRIDES.items():
+            actual = getattr(cfg, key, None)
+            assert actual == expected, f"{key}: expected={expected!r} actual={actual!r}"
+
+    def test_explicit_cli_flag_overrides_profile(self, _fake_keys: None) -> None:
+        """User's explicit --summary-provider beats profile setting."""
+        args = parse_args(
+            [
+                "--profile",
+                "cloud_balanced",
+                "--summary-provider",
+                "deepseek",
+                "https://example.com/feed.xml",
+                "--output-dir",
+                "/tmp/_t",
+            ]
+        )
+        cfg = _build_config(args)
+        assert cfg.summary_provider == "deepseek"
+
+
+class TestConfigFlagRouting:
+    """Bug B regression: --config YAML must forward all profile fields."""
+
+    def test_config_cloud_balanced_matches_yaml(self, _fake_keys: None) -> None:
+        cfg = _build_via_config("config/profiles/cloud_balanced.yaml")
+        for key, expected in CLOUD_BALANCED_EXPECTED.items():
+            actual = getattr(cfg, key, None)
+            assert actual == expected, f"{key}: expected={expected!r} actual={actual!r}"
+
+    def test_config_preserves_llm_pipeline_mode(self, _fake_keys: None) -> None:
+        """Previously dropped because _build_config payload omitted it."""
+        cfg = _build_via_config("config/profiles/cloud_balanced.yaml")
+        assert cfg.llm_pipeline_mode == "mega_bundled"
+
+    def test_config_preserves_audio_preprocessing_profile(self, _fake_keys: None) -> None:
+        cfg = _build_via_config("config/profiles/cloud_balanced.yaml")
+        assert cfg.audio_preprocessing_profile == "speech_optimal_v1"
+
+    def test_config_preserves_cloud_llm_structured_min_output_tokens(
+        self, _fake_keys: None
+    ) -> None:
+        cfg = _build_via_config("config/profiles/cloud_balanced.yaml")
+        assert cfg.cloud_llm_structured_min_output_tokens == 4096
+
+
+class TestBothPathsAgree:
+    """--profile NAME and --config config/profiles/NAME.yaml must produce
+    identical Config objects (they routed through different code paths before
+    #646; now both go through _load_and_merge_config)."""
+
+    def test_profile_and_config_produce_same_config(self, _fake_keys: None) -> None:
+        via_profile = _build_via_profile("cloud_balanced")
+        via_config = _build_via_config("config/profiles/cloud_balanced.yaml")
+        # Compare every key present in the expected table.
+        for key in CLOUD_BALANCED_EXPECTED:
+            assert getattr(via_profile, key, None) == getattr(via_config, key, None), key

--- a/tests/unit/podcast_scraper/test_config.py
+++ b/tests/unit/podcast_scraper/test_config.py
@@ -738,13 +738,17 @@ class TestValidationEdgeCases(unittest.TestCase):
         )
         self.assertEqual(cfg.vector_index_types, ["insight", "transcript"])
 
-    def test_vector_backend_qdrant_literal_stored(self):
-        """qdrant is allowed for forward compatibility (RFC-061 Phase 2)."""
-        cfg = Config(
-            rss_url="https://example.com/feed.xml",
-            vector_backend="qdrant",
-        )
-        self.assertEqual(cfg.vector_backend, "qdrant")
+    def test_vector_backend_rejects_qdrant_until_wired(self):
+        """qdrant is reserved for RFC-070 and not yet dispatched; Config must
+        reject it rather than silently accept a value with no live code path
+        (#646 profile-completeness rule)."""
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError):
+            Config(
+                rss_url="https://example.com/feed.xml",
+                vector_backend="qdrant",
+            )
 
     def test_vector_search_true_with_embedding_model(self):
         cfg = Config(

--- a/tests/unit/podcast_scraper/test_service_single_feed_corpus_layout.py
+++ b/tests/unit/podcast_scraper/test_service_single_feed_corpus_layout.py
@@ -1,8 +1,10 @@
 """Unit tests for single_feed_uses_corpus_layout (#644).
 
-Verifies that when Config.single_feed_uses_corpus_layout is True, the
-single-feed service path derives <output_dir>/feeds/<slug>/ from the RSS URL
-and passes it as the effective output_dir to workflow.run_pipeline.
+Since #646 the wrapping happens in a Config ``@model_validator(mode="after")``,
+not in ``service.run``. That means every entry point (CLI, service.run, direct
+construction) gets the same wrapped ``output_dir`` without the caller needing
+to know. These tests cover both the Config level (guaranteed wrapping) and the
+service level (backwards-compatible behaviour).
 """
 
 from __future__ import annotations
@@ -60,6 +62,51 @@ class TestSingleFeedCorpusLayout:
             service.run(cfg2)
             second = mock_workflow.run_pipeline.call_args[0][0].output_dir
         assert first == second
+
+    def test_config_validator_wraps_at_construction(self, tmp_path):
+        """Every caller — CLI, service.run, programmatic — goes through Config
+        construction, so wrapping must happen there (not in a single caller).
+        Prevents the #646-discovered bug where CLI path bypassed service.run."""
+        cfg = Config.model_validate(
+            {
+                "rss_url": "https://feeds.example.com/podcast.xml",
+                "output_dir": str(tmp_path),
+                "single_feed_uses_corpus_layout": True,
+            }
+        )
+        assert "/feeds/rss_feeds.example.com_" in cfg.output_dir
+        # Original tmp_path is preserved as the prefix.
+        assert cfg.output_dir.startswith(str(tmp_path.resolve())) or cfg.output_dir.startswith(
+            str(tmp_path)
+        )
+
+    def test_config_validator_idempotent(self, tmp_path):
+        """Validator must not double-wrap if output_dir already contains a
+        /feeds/ segment (matters when someone runs Config.model_validate on
+        a previously-wrapped dict, e.g. round-tripping through yaml)."""
+        cfg1 = Config.model_validate(
+            {
+                "rss_url": "https://feeds.example.com/podcast.xml",
+                "output_dir": str(tmp_path),
+                "single_feed_uses_corpus_layout": True,
+            }
+        )
+        # Round-trip through model_dump: should NOT accumulate another /feeds/ segment.
+        dumped = cfg1.model_dump()
+        cfg2 = Config.model_validate(dumped)
+        assert cfg2.output_dir == cfg1.output_dir
+        assert cfg2.output_dir.count("/feeds/") == 1
+
+    def test_config_validator_skips_when_flag_off(self, tmp_path):
+        cfg = Config.model_validate(
+            {
+                "rss_url": "https://feeds.example.com/podcast.xml",
+                "output_dir": str(tmp_path),
+                "single_feed_uses_corpus_layout": False,
+            }
+        )
+        assert cfg.output_dir == str(tmp_path)
+        assert "/feeds/" not in cfg.output_dir
 
     def test_corpus_layout_does_not_affect_multi_feed(self, tmp_path):
         # Multi-feed path already uses corpus layout. The flag must not alter

--- a/tests/unit/podcast_scraper/test_service_single_feed_corpus_layout.py
+++ b/tests/unit/podcast_scraper/test_service_single_feed_corpus_layout.py
@@ -1,0 +1,92 @@
+"""Unit tests for single_feed_uses_corpus_layout (#644).
+
+Verifies that when Config.single_feed_uses_corpus_layout is True, the
+single-feed service path derives <output_dir>/feeds/<slug>/ from the RSS URL
+and passes it as the effective output_dir to workflow.run_pipeline.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from podcast_scraper import service
+from podcast_scraper.config import Config
+
+
+def _make_cfg(output_dir: str, rss_url: str, corpus_layout: bool) -> Config:
+    return Config.model_validate(
+        {
+            "rss_url": rss_url,
+            "output_dir": output_dir,
+            "single_feed_uses_corpus_layout": corpus_layout,
+        }
+    )
+
+
+class TestSingleFeedCorpusLayout:
+    def test_legacy_default_writes_to_output_dir_unchanged(self, tmp_path):
+        cfg = _make_cfg(str(tmp_path), "https://feeds.example.com/podcast.xml", False)
+        with patch.object(service, "workflow") as mock_workflow:
+            mock_workflow.run_pipeline.return_value = (0, "ok")
+            result = service.run(cfg)
+
+        assert result.success
+        # The cfg passed to run_pipeline should have the *original* output_dir.
+        call_cfg = mock_workflow.run_pipeline.call_args[0][0]
+        assert str(call_cfg.output_dir) == str(tmp_path)
+
+    def test_corpus_layout_wraps_output_dir(self, tmp_path):
+        cfg = _make_cfg(str(tmp_path), "https://feeds.example.com/podcast.xml", True)
+        with patch.object(service, "workflow") as mock_workflow:
+            mock_workflow.run_pipeline.return_value = (0, "ok")
+            service.run(cfg)
+
+        call_cfg = mock_workflow.run_pipeline.call_args[0][0]
+        # Output dir should now be <tmp_path>/feeds/<slug>/
+        assert str(call_cfg.output_dir).startswith(str(tmp_path.resolve()))
+        # feeds/ path segment must be present.
+        assert "/feeds/" in str(call_cfg.output_dir)
+        assert "rss_feeds.example.com_" in str(call_cfg.output_dir)
+
+    def test_corpus_layout_slug_is_deterministic(self, tmp_path):
+        rss = "https://feeds.example.com/podcast.xml"
+        cfg1 = _make_cfg(str(tmp_path), rss, True)
+        cfg2 = _make_cfg(str(tmp_path), rss, True)
+
+        with patch.object(service, "workflow") as mock_workflow:
+            mock_workflow.run_pipeline.return_value = (0, "ok")
+            service.run(cfg1)
+            first = mock_workflow.run_pipeline.call_args[0][0].output_dir
+            service.run(cfg2)
+            second = mock_workflow.run_pipeline.call_args[0][0].output_dir
+        assert first == second
+
+    def test_corpus_layout_does_not_affect_multi_feed(self, tmp_path):
+        # Multi-feed path already uses corpus layout. The flag must not alter
+        # its behavior (multi-feed routes through _run_multi_feed which is
+        # separate code).
+        cfg = Config.model_validate(
+            {
+                "rss_url": "https://feeds.example.com/a.xml",
+                "rss_urls": [
+                    "https://feeds.example.com/a.xml",
+                    "https://feeds.example.com/b.xml",
+                ],
+                "output_dir": str(tmp_path),
+                "single_feed_uses_corpus_layout": True,
+            }
+        )
+        # Multi-feed path is taken when len(rss_urls) >= 2. Route stays the
+        # same; our flag is a no-op for multi-feed.
+        with (
+            patch.object(service, "_run_multi_feed") as mock_multi,
+            patch.object(service, "workflow") as mock_workflow,
+        ):
+            from podcast_scraper.service import ServiceResult
+
+            mock_multi.return_value = ServiceResult(
+                episodes_processed=2, summary="", success=True, error=None
+            )
+            service.run(cfg)
+        mock_multi.assert_called_once()
+        mock_workflow.run_pipeline.assert_not_called()

--- a/tests/unit/podcast_scraper/workflow/test_prefilled_extraction_wiring.py
+++ b/tests/unit/podcast_scraper/workflow/test_prefilled_extraction_wiring.py
@@ -140,3 +140,49 @@ class TestMegaBundleHelpers:
         assert p["insights"][0]["insight_type"] == "claim"
         assert p["topics"] == ["blockchain governance", "roman empire", "algorithmic trading"]
         assert p["entities"][0]["kind"] == "person"
+
+
+class TestSummaryMetadataPrefilledLifecycle:
+    """Regression tests for ``SummaryMetadata.prefilled_extraction`` — transient
+    field (``exclude=True``) that must survive ``model_copy`` so GIL/KG stages
+    see it, but must NOT be serialised to disk by ``model_dump`` /
+    ``model_dump_json``. A silent loss here would make mega_bundled / extraction_bundled
+    regress to 3 LLM calls/episode without any test failing."""
+
+    def _build(self):
+        from datetime import datetime
+
+        from podcast_scraper.workflow.metadata_generation import SummaryMetadata
+
+        return SummaryMetadata(
+            generated_at=datetime.now(),
+            word_count=100,
+            title="T",
+            bullets=["b1", "b2"],
+            prefilled_extraction={
+                "insights": [{"text": "i1", "insight_type": "claim"}],
+                "topics": ["t1", "t2"],
+                "entities": [{"name": "E1", "kind": "person"}],
+            },
+        )
+
+    def test_model_copy_preserves_prefilled_extraction(self):
+        sm = self._build()
+        cp = sm.model_copy()
+        assert cp.prefilled_extraction == sm.prefilled_extraction
+
+    def test_model_copy_with_update_preserves_prefilled_extraction(self):
+        sm = self._build()
+        cp = sm.model_copy(update={"title": "New Title"})
+        assert cp.title == "New Title"
+        assert cp.prefilled_extraction == sm.prefilled_extraction
+
+    def test_model_dump_excludes_prefilled_extraction(self):
+        sm = self._build()
+        d = sm.model_dump()
+        assert "prefilled_extraction" not in d
+
+    def test_model_dump_json_excludes_prefilled_extraction(self):
+        sm = self._build()
+        j = sm.model_dump_json()
+        assert "prefilled_extraction" not in j

--- a/tests/unit/podcast_scraper/workflow/test_prefilled_extraction_wiring.py
+++ b/tests/unit/podcast_scraper/workflow/test_prefilled_extraction_wiring.py
@@ -1,0 +1,142 @@
+"""#643 Phase 3C wiring tests.
+
+Verifies that ``prefilled_extraction`` produced by mega_bundled /
+extraction_bundled is plumbed through GIL and KG stages so they skip their own
+LLM calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from podcast_scraper.gi.pipeline import build_artifact as gi_build_artifact
+from podcast_scraper.kg.pipeline import build_artifact as kg_build_artifact
+from podcast_scraper.providers.common.megabundle_parser import MegaBundleResult
+
+
+def _make_result() -> MegaBundleResult:
+    return MegaBundleResult(
+        title="Ep",
+        summary="Summary paragraph.",
+        bullets=["b1", "b2"],
+        insights=[
+            {"text": "Insight one.", "insight_type": "claim"},
+            {"text": "Insight two.", "insight_type": "fact"},
+        ],
+        topics=["blockchain governance", "roman empire", "algorithmic trading"],
+        entities=[
+            {"name": "Alice", "kind": "person", "role": "host"},
+            {"name": "Acme Corp", "kind": "org", "role": "mentioned"},
+        ],
+        raw={},
+    )
+
+
+class TestKGPrefilled:
+    def test_prefilled_partial_short_circuits_provider(self):
+        provider = MagicMock()
+        partial = _make_result().to_extraction_partial()
+
+        out = kg_build_artifact(
+            "ep1",
+            "transcript text",
+            podcast_id="feed",
+            episode_title="Ep",
+            kg_extraction_provider=provider,
+            prefilled_partial=partial,
+        )
+
+        provider.extract_kg_graph.assert_not_called()
+        provider.extract_kg_from_summary_bullets.assert_not_called()
+
+        topic_labels = [n["properties"]["label"] for n in out["nodes"] if n["type"] == "Topic"]
+        assert topic_labels == ["blockchain governance", "roman empire", "algorithmic trading"]
+        entity_names = [n["properties"]["name"] for n in out["nodes"] if n["type"] == "Entity"]
+        assert "Alice" in entity_names
+        assert "Acme Corp" in entity_names
+
+    def test_empty_prefilled_falls_back_to_dispatch(self):
+        provider = MagicMock()
+        provider.extract_kg_graph.return_value = None
+
+        out = kg_build_artifact(
+            "ep1",
+            "transcript",
+            podcast_id="feed",
+            episode_title="Ep",
+            kg_extraction_provider=provider,
+            prefilled_partial={"topics": [], "entities": []},
+        )
+
+        assert any(n["type"] == "Episode" for n in out["nodes"])
+
+
+class TestGIPrefilled:
+    def test_prefilled_insights_short_circuits_provider(self):
+        provider = MagicMock()
+        prefilled = _make_result().to_extraction_partial()["insights"]
+
+        out = gi_build_artifact(
+            "ep1",
+            "transcript " * 50,
+            podcast_id="feed",
+            episode_title="Ep",
+            insight_provider=provider,
+            prefilled_insights=prefilled,
+        )
+
+        provider.generate_insights.assert_not_called()
+        insights = [n for n in out["nodes"] if n["type"] == "Insight"]
+        assert len(insights) == 2
+        types = {n["properties"].get("insight_type") for n in insights}
+        assert "claim" in types
+        assert "fact" in types
+
+    def test_empty_prefilled_falls_back_to_stub(self):
+        out = gi_build_artifact(
+            "ep1",
+            "transcript " * 20,
+            podcast_id="feed",
+            episode_title="Ep",
+            prefilled_insights=[],
+        )
+        insights = [n for n in out["nodes"] if n["type"] == "Insight"]
+        assert len(insights) >= 1
+
+    def test_prefilled_skips_blank_items(self):
+        out = gi_build_artifact(
+            "ep1",
+            "transcript " * 20,
+            podcast_id="feed",
+            episode_title="Ep",
+            prefilled_insights=[
+                {"text": "", "insight_type": "claim"},
+                {"text": "Valid one.", "insight_type": "fact"},
+                {"insight_type": "claim"},
+            ],
+        )
+        insights = [n for n in out["nodes"] if n["type"] == "Insight"]
+        texts = [n["properties"].get("text") for n in insights]
+        assert "Valid one." in texts
+        assert "" not in texts
+
+    def test_prefilled_unknown_type_normalized_to_claim(self):
+        out = gi_build_artifact(
+            "ep1",
+            "transcript " * 20,
+            podcast_id="feed",
+            episode_title="Ep",
+            prefilled_insights=[{"text": "X", "insight_type": "weird"}],
+        )
+        insights = [n for n in out["nodes"] if n["type"] == "Insight"]
+        assert insights[0]["properties"].get("insight_type") == "claim"
+
+
+class TestMegaBundleHelpers:
+    def test_to_extraction_partial_shape(self):
+        r = _make_result()
+        p = r.to_extraction_partial()
+        assert set(p.keys()) == {"insights", "topics", "entities"}
+        assert p["insights"][0]["insight_type"] == "claim"
+        assert p["topics"] == ["blockchain governance", "roman empire", "algorithmic trading"]
+        assert p["entities"][0]["kind"] == "person"


### PR DESCRIPTION
## Summary

Backend 2.6 — mega-bundle pipeline modes (#643) + corpus-layout unification (#644) + cloud-LLM JSON truncation fix (#645), all validated end-to-end against real podcast episodes with real cloud LLM calls. Harness committed for future use.

## What landed

### #643 Mega-bundle pipeline modes
All 6 cloud providers (Anthropic, DeepSeek, Gemini, OpenAI, Mistral, Grok) gained `summarize_mega_bundled()` and `summarize_extraction_bundled()`. Dispatch in `_generate_episode_summary` stashes `insights + topics + entities` on a transient `SummaryMetadata.prefilled_extraction` field so GIL + KG short-circuit their own LLM calls.

Real-episode validation (2 investor-podcast transcripts, 7.8 KB + 47 KB, `scripts/validate/validate_phase3c.py`):

| Provider | Model | Calls | $/ep (medium) | Time | Ins/Top/Ent |
|---|---|---|---|---|---|
| **Gemini** | flash-lite | 1 | **$0.00127** | 17.8 s | 12 / 10 / 15 |
| **Mistral** | small-latest | 1 | $0.00201 | **8.6 s** | 12 / 10 / 14 |
| OpenAI | gpt-4o-mini | 1 | $0.00153 | 23.9 s | 12 / 10 / 15 |
| DeepSeek | deepseek-chat | 1 | $0.00223 | 56.2 s | 12 / 10 / 15 |
| **Anthropic** | haiku-4.5 | 1 | $0.01530 | 16.3 s | 12 / 10 / 15 |
| Grok | grok-3-mini | 1 | $0.03346 | 43.4 s | 12 / 10 / 13 |

Baseline (Gemini, medium): staged 3 calls $0.00445, bundled 3 calls $0.00438, extraction_bundled 2 calls $0.00265, **mega_bundled 1 call $0.00127 → 72 % cheaper than staged, same artifact counts.**

#632 research had flagged Gemini/OpenAI/Mistral/Grok as "not tier-1". Real-episode retest showed all 6 produce comparable artifact counts; the research regression claim did not hold on production traffic.

### Profile defaults (validated)
- `cloud_balanced.yaml` → Gemini flash-lite mega_bundled (cost/latency winner).
- `cloud_quality.yaml` → Anthropic haiku-4.5 mega_bundled (best entity names; entity F1 = 1.000 per #632).

### #644 Single-feed corpus layout — pre-existing shipped bug found and fixed
Real-episode validation (`scripts/validate/validate_layout_644.py`) revealed 3 chained bugs that made `single_feed_uses_corpus_layout=True` a silent no-op via CLI:
1. No CLI flag → YAML value dropped at argparse set_defaults.
2. `_build_config` payload didn't forward the field.
3. Wrapping lived in `service.py._run_single_feed`, but CLI calls `workflow.run_pipeline(cfg)` directly — bypassing service.run() entirely.

Fix: moved wrapping to a `@model_validator(mode="after")` in Config itself (guaranteed for every construction path) + CLI flag + payload entry. Added idempotency check.

### #645 Cloud-LLM structured-JSON truncation
`cloud_llm_structured_min_output_tokens` (default 4096) floor applied to all 6 cloud providers; Gemini gets explicit `warn_if_output_truncated` diagnostic. Prevents silent empty summaries on long transcripts.

### CLI --profile and --config routing — pre-existing bugs found and fixed
Audit caught that 13 profile fields were being silently overridden by argparse defaults via `--profile`, and 4 more fields were silently dropped via `--config`. Fix: `--profile NAME` now routes through `_load_and_merge_config` (same path as `--config`), and `_build_config` payload includes `llm_pipeline_mode`, `cloud_llm_structured_min_output_tokens`, `deepseek_timeout`, `audio_preprocessing_profile`, `ml_preprocessing_profile`.

### DeepSeek mega_bundled timeout
Added `deepseek_timeout: int = Field(default=600)` (mirrors grok_timeout pattern). Stock 120 s generic HTTP timeout expired mid-response; DeepSeek mega now completes reliably at 50–56 s.

### Qdrant Literal lie removed
`vector_backend: Literal["faiss", "qdrant"]` silently accepted `qdrant` but the indexer skipped it. Dropped `qdrant` from the Literal + CLI choices + example YAML until it's actually wired (RFC-070). Matches the profile-completeness rule.

### CLAUDE.md rules added
- **Auto-load guides by path** — edit `tests/unit/**` or `config/profiles/*.yaml` → read the relevant guide without waiting for the trigger phrase.
- **Profile completeness** — no profile default that references an unimplemented dispatch arm.
- **Half-wired features are worse than no feature** — if not wired end-to-end, don't expose the switch.
- **Resuming from compaction** — re-confirm deferred items before acting.
- **Final validation before push: real episodes, not just unit tests.**

## Test plan

- [x] `make test-unit` — **3940+ unit tests pass**, including 40+ new tests (mega_bundle prompt + parser, 6 provider methods, prefilled GIL/KG wiring, Config post-validator, CLI profile routing, audio profile wiring).
- [x] `make format` + `make lint` clean.
- [x] `scripts/validate/validate_phase3c.py` — 10 real-episode runs, GATES PASS.
- [x] `scripts/validate/validate_layout_644.py` — 3 real-RSS runs, GATES PASS.
- [x] `make test-unit` passes after every commit (pre-commit hook enforces).

## Follow-ups (not in this PR)
Noted in `docs/wip/PLAN_NEXT_SESSION.md`:
- Real-episode validation for remaining `--profile` fields not in cloud_balanced/cloud_quality (local, airgapped, dev profiles).
- Gemini transient 503 UNAVAILABLE — retry works; not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)