### PR TITLE
fix(devcontainer): drop yarn apt source so feature install can refresh

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+# Upstream image's yarnpkg.com apt source has a rotated GPG key
+# (NO_PUBKEY 62D54FD4003F6525) that breaks ``apt-get update`` during
+# devcontainer feature install (docker-in-docker, github-cli, node).
+# yarn isn't used by this project (Vue/Vite uses npm), so just remove
+# the unused source list. apt's GPG verification on every other repo
+# (debian.org / debian-security) keeps working with full integrity.
+#
+# Once Microsoft refreshes the python:1-3.12-bookworm tag with a valid
+# yarnpkg keyring this Dockerfile can be deleted and devcontainer.json
+# can switch back to ``"image": "mcr.microsoft.com/devcontainers/..."``.
+RUN rm -f /etc/apt/sources.list.d/yarn.list /usr/share/keyrings/yarnpkg.gpg

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "podcast-scraper pre-prod (Codespaces)",
-  "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",


### PR DESCRIPTION
## Why

Codespace creation against the freshly-merged RFC-081 Phase 1 wiring
lands in **recovery mode** because the upstream Microsoft Python
devcontainer base image (``mcr.microsoft.com/devcontainers/python:1-3.12-bookworm``)
ships a stale yarn apt source whose Debian repo GPG key has been
rotated upstream. apt refuses to refresh that source (signature
unverifiable, ``NO_PUBKEY 62D54FD4003F6525``) and aborts the whole
``apt-get update`` non-zero. The ``docker-in-docker`` feature install
then fails because it can't refresh apt during build.

Creation log error:

```
W: GPG error: https://dl.yarnpkg.com/debian stable InRelease:
   The following signatures couldn't be verified because the public key
   is not available: NO_PUBKEY 62D54FD4003F6525
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
ERROR: Feature "Docker (Docker-in-Docker)" failed to install!
```

## Fix

Two-file change. Add ``.devcontainer/Dockerfile`` that extends the
upstream base image and ``rm``s the unused yarn source list before any
devcontainer feature install runs. Switch ``devcontainer.json`` from
``"image": "..."`` to ``"build": { "dockerfile": "Dockerfile" }`` so
the patched image is what features install into.

yarn isn't used anywhere in this project (Vue/Vite uses npm), so
removing the source is pure attack-surface reduction — apt's GPG
verification continues to enforce signatures on every other repo
(``debian.org``, ``debian-security``).

## Reverting once upstream is fixed

Once Microsoft refreshes the ``python:1-3.12-bookworm`` tag with a
valid yarnpkg keyring (or drops the yarn repo, which would be cleaner),
this Dockerfile can be deleted and ``devcontainer.json`` can switch
back to a plain ``"image": ...`` line. Comment in the Dockerfile flags
this.

## Test plan

- [x] Pre-commit hooks (JSON syntax + linters) pass locally
- [ ] CI green on this PR (lint, json validation, viewer-unit, etc — no Codespace-specific check exists in CI)
- [ ] After merge: ``gh codespace rebuild --full --codespace podcast-scraper-preprod-g4rvv5vq4hwxp5`` (or re-dispatch ``Deploy to pre-prod codespace`` workflow) → codespace boots out of recovery mode
- [ ] ``postStartCommand`` runs ``bash .devcontainer/start.sh`` → ``docker compose pull`` succeeds → ``/api/health`` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)