### PR TITLE
fix(operator-config): auto-create missing corpus subdir (unblock stack-test on main)

### DIFF
--- a/docs/ci/CODEQL_DISMISSALS.md
+++ b/docs/ci/CODEQL_DISMISSALS.md
@@ -181,6 +181,8 @@ number, file, line, date, and a short comment.
 | 1 | #305 | server/jobs_log_path.py | 74 | 2026-04-24 | Type 1: ``log_path`` from ``normpath_if_under_root`` after ``safe_relpath_under_corpus_root`` before ``isfile``; dismissed ``gh api`` (PR #666) |
 | 1 | #306 | server/routes/corpus_library.py | 395 | 2026-04-25 | Type 1: ``root`` sanitized via ``_resolve_corpus_root`` → ``resolve_corpus_path_param`` (normpath+startswith anchor); ``.resolve()`` on the already-anchored path. Dismissed ``gh api`` (PR #675) |
 | 1 | #307 | server/routes/corpus_library.py | 401 | 2026-04-25 | Type 1: ``target = os.path.normpath(os.path.join(root_s, bridge_relative_path))`` followed by inline ``target.startswith(root_s + os.sep)`` prefix-guard before ``open()``. Dismissed ``gh api`` (PR #675) |
+| 1 | #308 | server/routes/operator_config.py | 136 | 2026-04-28 | Type 1: ``corpus_root`` from ``resolve_corpus_path_param`` (normpath + startswith anchor) immediately before ``corpus_root.mkdir(parents=True, exist_ok=True)`` on GET handler — auto-create restricted to subdirs under the configured corpus root (#693 first-run UX). Dismissed ``gh api`` (PR #702) |
+| 1 | #309 | server/routes/operator_config.py | 195 | 2026-04-28 | Type 1: same sanitizer chain as #308, mirror on PUT handler. Dismissed ``gh api`` (PR #702) |
 
 ## Still open (not yet dismissed)
 

--- a/src/podcast_scraper/server/routes/operator_config.py
+++ b/src/podcast_scraper/server/routes/operator_config.py
@@ -125,7 +125,13 @@ async def get_operator_config(
     ``--profile`` + ``--config``).
     """
     anchor = getattr(request.app.state, "output_dir", None)
-    corpus_root = resolve_corpus_path_param(path, anchor)
+    # First-run UX (#693 / day-1 operator workflow): allow the corpus subdir
+    # to be missing on disk and auto-create it before seeding viewer_operator.yaml.
+    # The path is still validated to live under ``anchor`` (security: same
+    # ``startswith anchor + sep`` check), so the operator can only auto-create
+    # subdirs of the configured corpus root, not arbitrary filesystem paths.
+    corpus_root = resolve_corpus_path_param(path, anchor, must_be_dir=False)
+    corpus_root.mkdir(parents=True, exist_ok=True)
     cfg_raw = _operator_file(request, corpus_root)
     cfg_path = _verified_operator_config_path(request, corpus_root, cfg_raw)
     profiles = list_packaged_profile_names()
@@ -178,7 +184,11 @@ async def put_operator_config(
 ) -> OperatorConfigGetResponse:
     """Validate and atomically write operator YAML to the configured resolved path."""
     anchor = getattr(request.app.state, "output_dir", None)
-    corpus_root = resolve_corpus_path_param(path, anchor)
+    # Mirror GET handler: auto-create the corpus subdir if missing so PUT
+    # also works against fresh paths (operator chooses path → Save → dir
+    # appears alongside viewer_operator.yaml).
+    corpus_root = resolve_corpus_path_param(path, anchor, must_be_dir=False)
+    corpus_root.mkdir(parents=True, exist_ok=True)
     cfg_raw = _operator_file(request, corpus_root)
     cfg_path = _verified_operator_config_path(request, corpus_root, cfg_raw)
     to_write = expand_profile_only_with_packaged_example(

--- a/src/podcast_scraper/server/routes/operator_config.py
+++ b/src/podcast_scraper/server/routes/operator_config.py
@@ -131,6 +131,8 @@ async def get_operator_config(
     # ``startswith anchor + sep`` check), so the operator can only auto-create
     # subdirs of the configured corpus root, not arbitrary filesystem paths.
     corpus_root = resolve_corpus_path_param(path, anchor, must_be_dir=False)
+    # codeql[py/path-injection] -- corpus_root validated by resolve_corpus_path_param's
+    # normpath + ``startswith(anchor + sep)`` check (the documented sanitizer pair).
     corpus_root.mkdir(parents=True, exist_ok=True)
     cfg_raw = _operator_file(request, corpus_root)
     cfg_path = _verified_operator_config_path(request, corpus_root, cfg_raw)
@@ -188,6 +190,8 @@ async def put_operator_config(
     # also works against fresh paths (operator chooses path → Save → dir
     # appears alongside viewer_operator.yaml).
     corpus_root = resolve_corpus_path_param(path, anchor, must_be_dir=False)
+    # codeql[py/path-injection] -- corpus_root validated by resolve_corpus_path_param's
+    # normpath + ``startswith(anchor + sep)`` check (the documented sanitizer pair).
     corpus_root.mkdir(parents=True, exist_ok=True)
     cfg_raw = _operator_file(request, corpus_root)
     cfg_path = _verified_operator_config_path(request, corpus_root, cfg_raw)

--- a/tests/integration/server/test_viewer_feeds_operator_config.py
+++ b/tests/integration/server/test_viewer_feeds_operator_config.py
@@ -90,6 +90,54 @@ def test_operator_config_roundtrip(corpus: Path) -> None:
     assert "local" in g2.json()["available_profiles"]
 
 
+def test_operator_config_get_auto_creates_missing_subdir(corpus: Path) -> None:
+    """First-run UX (#693): GET /api/operator-config against a fresh subdir of
+    the configured corpus root must auto-create the directory and seed
+    ``viewer_operator.yaml`` from the packaged example.
+
+    Regression guard for the failure surfaced by ``operator-first-run.spec.ts``
+    on stack-test post-merge: ``resolve_corpus_path_param`` previously rejected
+    missing directories with 400 "Not a directory", so the day-1 operator path
+    (pick a fresh subdir → viewer makes it work) was unreachable. The route
+    now passes ``must_be_dir=False`` and ``mkdir(parents=True, exist_ok=True)``
+    before seeding.
+    """
+    fresh_subdir = corpus / "firstrun-empty"
+    assert not fresh_subdir.exists()  # precondition: subdir doesn't exist on disk
+
+    app = create_app(corpus, static_dir=False, enable_operator_config_api=True)
+    client = TestClient(app)
+
+    g = client.get("/api/operator-config", params={"path": str(fresh_subdir)})
+    assert (
+        g.status_code == 200
+    ), f"Expected 200 (auto-create + seed), got {g.status_code}: {g.text[:200]}"
+    assert fresh_subdir.is_dir(), "GET should have auto-created the corpus subdir"
+    body = g.json()
+    assert body["corpus_path"] == str(fresh_subdir.resolve())
+    # If a packaged example is present in this env, content is non-empty.
+    seeded = body["content"].strip()
+    if seeded:
+        assert "max_episodes" in seeded
+
+
+def test_operator_config_path_outside_anchor_still_rejected(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Auto-create path doesn't loosen the anchor check — paths escaping the
+    configured corpus root still 400. Security regression guard for #693 fix.
+    """
+    corpus_dir = tmp_path_factory.mktemp("corpus_inside")
+    outside = tmp_path_factory.mktemp("elsewhere_separate") / "not-allowed"
+    app = create_app(corpus_dir, static_dir=False, enable_operator_config_api=True)
+    client = TestClient(app)
+    g = client.get("/api/operator-config", params={"path": str(outside)})
+    assert (
+        g.status_code == 400
+    ), f"Path outside anchor must be rejected with 400, got {g.status_code}"
+    assert not outside.exists(), "auto-create must NOT happen for paths outside anchor"
+
+
 def test_operator_put_profile_only_merges_packaged_example(corpus: Path) -> None:
     """PUT with only ``profile:`` (empty overrides) picks up packaged example keys."""
     app = create_app(corpus, static_dir=False, enable_operator_config_api=True)


### PR DESCRIPTION
## What

Hotfix for PR #700 stack-test failure on main (commit 7fbfe5d1).

The new ``operator-first-run.spec.ts`` (#693 part A, added in PR #700)
calls ``GET /api/operator-config?path=/app/output/firstrun-empty``
against a subdir that doesn't exist on disk. The route's path validator
returned 400 "Not a directory" before the auto-seed handler could run.

This blocks the post-merge chain: **stack-test fails → publish skipped
→ deploy-codespace skipped → new pipeline-llm + api images (with
[search] extras) never reach GHCR → codespace can't pull them**.

## Fix

Pass ``must_be_dir=False`` on GET + PUT, then ``mkdir(parents=True,
exist_ok=True)`` on the validated path. Two integration regression
tests added in the standard PR test set (not stack-test only) so this
class of regression surfaces on PR CI in future:

- ``test_operator_config_get_auto_creates_missing_subdir`` — exact
  failure mode from ``operator-first-run.spec.ts``.
- ``test_operator_config_path_outside_anchor_still_rejected`` —
  verifies the anchor escape still 400s and does NOT mkdir; security
  guard.

## Why this is the right scope

- The test was added in PR #700 with the design intent that the api
  auto-creates fresh corpus subdirs on first GET. The implementation
  side wasn't done — that's the actual bug being fixed.
- Anchor check unchanged: ``startswith(anchor + sep)`` still validates,
  so the only thing that's relaxed is "directory must already exist".
  Operator can only auto-create subdirs of the configured corpus root,
  not arbitrary filesystem paths.
- Adds the regression to PR test set so a future change here can't slip
  through PR CI again — stack-test only runs on main.

## Validation

- 19 / 19 tests pass in test_viewer_feeds_operator_config.py
- 3810 unit + integration tests pass total locally
- ``make docs`` strict mode green

## Test plan

- [ ] CI green
- [ ] Post-merge: stack-test passes → publish job uploads new images
      to GHCR → deploy-codespace fires → codespace lands with new
      pipeline-llm (incl. [search] extras) + new api → cloud_balanced
      runs end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)