### PR TITLE
fix(grafana-agent): purge env-substitution syntax from comments (#681 re-fix)

### DIFF
--- a/compose/grafana-agent.yaml
+++ b/compose/grafana-agent.yaml
@@ -21,13 +21,17 @@ metrics:
   global:
     scrape_interval: 30s
     external_labels:
-      # Grafana Agent's ``-config.expand-env=true`` uses Go's
-      # ``os.ExpandEnv``, which only handles ``$VAR`` / ``${VAR}`` —
-      # NOT bash-style ``${VAR:-default}``. The ``:-default`` syntax
-      # was being parsed as a literal var name ``VAR:-default`` and
-      # crashing the agent. Compose-side defaulting now sets these
-      # to non-empty values via the prod overlay (``PODCAST_ENV``
-      # always populated; ``PODCAST_RELEASE`` may be empty in dev).
+      # Grafana Agent runs with -config.expand-env=true which uses
+      # Go's os.ExpandEnv. ExpandEnv processes the WHOLE file as a
+      # string before YAML parsing — including comments — and only
+      # supports plain $VAR / curly-brace forms with no default
+      # syntax. Do not write bash-style fallback expressions in
+      # this file (in either values OR comments) because ExpandEnv
+      # treats the literal text as a variable reference and crashes
+      # with "unable to parse variable name". Compose-side defaulting
+      # now sets these to non-empty values via the prod overlay
+      # (PODCAST_ENV always populated; PODCAST_RELEASE may be empty
+      # in dev).
       env: "${PODCAST_ENV}"
       release: "${PODCAST_RELEASE}"
 
@@ -43,12 +47,17 @@ metrics:
           metrics_path: /metrics
 
       remote_write:
-        # Quote env substitutions: ``-config.expand-env=true`` inlines values
+        # Quote env substitutions: -config.expand-env=true inlines values
         # before YAML parse, and Grafana Cloud API keys typically contain
-        # ``:`` / ``-`` / ``=`` chars that break unquoted scalars (the agent
-        # crashed on bare unquoted ``password: ${...}`` with
-        # "block sequence entries are not allowed in this context"). Wrapping
-        # in double quotes is unconditionally safe; URLs are well-formed.
+        # `:` / `-` / `=` chars that break unquoted scalars (the agent
+        # crashed on bare unquoted password lines with "block sequence
+        # entries are not allowed in this context"). Wrapping in double
+        # quotes is unconditionally safe; URLs are well-formed.
+        # Also: do not embed any literal curly-brace env-substitution
+        # syntax (or its bash-default variant) inside comments — Go's
+        # ExpandEnv processes the whole file as one string before YAML
+        # parsing and treats such text as a variable reference, which
+        # crashes the agent.
         - url: "${GRAFANA_CLOUD_PROM_URL}"
           basic_auth:
             username: "${GRAFANA_CLOUD_USER}"


### PR DESCRIPTION
## What

Grafana Agent on the codespace was still restart-looping after PR #700/#704
landed and the codespace bounced — same "unable to parse variable name"
error as before #700. The agent runs with ``-config.expand-env=true``
which uses Go's ``os.ExpandEnv``. ExpandEnv processes the **whole file**
as a string **before** YAML parsing, comments included. So literal
env-substitution syntax inside comments still crashes the agent.

PR #700's earlier fix (commit ``eb47b6d``) removed bash-style fallback
syntax from real **values**, but left two comments containing the
literal text as documentation:

- line 26: bash-style fallback example
- line 53: ``${...}`` placeholder reference

Both are processed by ExpandEnv → variable parse failure → crash loop.

## Fix

Rewrite both comments without embedding any literal curly-brace
env-substitution syntax. Add an explicit warning at the top of the
section: do not embed such syntax inside comments either, because
ExpandEnv processes them too.

## Test plan

- [ ] CI green (yaml syntax + lint).
- [ ] Post-merge: codespace bounce (workflow_run via stack-test → publish
      → deploy-codespace) → ``docker logs compose-grafana-agent-1``
      shows ``level=info`` startup with no parse-name errors.
- [ ] Grafana Cloud query ``up{component="api"}`` returns data series
      from the agent's first scrape (~30s after start).

## Other open follow-ups (not in this PR)

- Codespaces secrets ``PODCAST_AVAILABLE_PROFILES`` /
  ``PODCAST_DEFAULT_PROFILE`` still set to ``cloud_thin`` from earlier
  in the validation session — needs a manual update at
  ``github.com/settings/codespaces`` to either delete (lets prod overlay
  defaults take over) or change to ``cloud_balanced,cloud_thin`` /
  ``cloud_balanced``. Tracked separately.
- ``deploy-codespace.yml`` workflow doesn't pull latest main on the
  codespace's ``/workspaces/podcast_scraper`` checkout, so file-mounted
  configs (compose, agent yaml) can lag behind the GHCR image set.
  Would benefit from a ``git pull --ff-only origin main`` step before
  ``docker compose up``. Filing as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)