### PR TITLE
chore(codespace): start.sh syncs /workspaces to origin/main when clean

### DIFF
--- a/.devcontainer/start.sh
+++ b/.devcontainer/start.sh
@@ -21,6 +21,46 @@ COMPOSE_FILES=(
 
 echo "==> Codespace pre-prod stack startup"
 
+# Sync /workspaces/podcast_scraper to origin/main before docker compose,
+# so file-mounted configs (compose overlay, grafana-agent.yaml,
+# nginx.conf when bind-mounted, etc.) are at the same commit as the
+# images we're about to pull from GHCR.
+#
+# Without this, the codespace's git checkout drifts behind whatever
+# branch the operator originally created the codespace from. We hit
+# this twice (today, post-#700 merge): the deploy-codespace workflow
+# rebuilt the container with new images, but ``compose/grafana-agent.yaml``
+# on disk was an older version → grafana-agent crash-looped on a
+# yaml that the published image's runtime expected to be different.
+#
+# Guard: only sync when on the ``main`` branch AND the working tree is
+# clean. A user manually testing on a feature branch keeps their state;
+# uncommitted shell-side edits aren't clobbered.
+if [ -d /workspaces/podcast_scraper/.git ]; then
+  CURRENT_BRANCH=$(git -C /workspaces/podcast_scraper rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+  WORKTREE_DIRTY=$(git -C /workspaces/podcast_scraper status --porcelain 2>/dev/null | head -1)
+  if [ "$CURRENT_BRANCH" = "main" ] && [ -z "$WORKTREE_DIRTY" ]; then
+    echo "==> Sync /workspaces/podcast_scraper to origin/main (clean tree, on main)"
+    if git -C /workspaces/podcast_scraper fetch --quiet origin main 2>&1; then
+      OLD_HEAD=$(git -C /workspaces/podcast_scraper rev-parse HEAD)
+      git -C /workspaces/podcast_scraper reset --hard origin/main 2>&1 | tail -1
+      NEW_HEAD=$(git -C /workspaces/podcast_scraper rev-parse HEAD)
+      if [ "$OLD_HEAD" != "$NEW_HEAD" ]; then
+        echo "    Synced ${OLD_HEAD:0:7} → ${NEW_HEAD:0:7}"
+      else
+        echo "    Already at HEAD."
+      fi
+    else
+      echo "::warning::git fetch origin main failed; continuing with workspace as-is."
+    fi
+  elif [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "==> Skip workspace sync — on branch '$CURRENT_BRANCH' (not main); operator-controlled."
+  else
+    echo "==> Skip workspace sync — uncommitted changes in /workspaces/podcast_scraper."
+    echo "    Stash or commit before next bounce if you want auto-sync."
+  fi
+fi
+
 # stack.yml's viewer service publishes to ``${VIEWER_PORT:-8080}:80``.
 # devcontainer.json forwards 8090 (operator-facing convention from
 # RFC-081), so pin the host-side port here to match. Without this,


### PR DESCRIPTION
## Why

Recurring trap surfaced during the PR #700/#702/#704/#705 cycle:

- **deploy-codespace workflow** rebuilds the container and pulls new
  images from GHCR.
- **/workspaces/podcast_scraper** is a *persistent* codespace volume —
  git state stays at whatever was checked out when the codespace was
  first created.
- So **file-mounted configs** (compose overlay, ``grafana-agent.yaml``,
  ``nginx.conf`` if you ever bind-mount it, etc.) drift behind the
  images we just pulled. Runtime breaks in confusing ways.

Concrete examples we hit:

- Post-#700: workspace stayed on ``fix/preprod-codespace-followups``;
  the freshly-pulled pipeline-llm image expected PR #702 + #704 code,
  but the operator-config endpoint hit a stale prod overlay from the
  branch's snapshot.
- Post-#705: even after manual ``git checkout main``, the bind-mounted
  ``compose/grafana-agent.yaml`` was a pre-#705 version → grafana-agent
  kept crash-looping until we manually ``git pull``'d.

## What

Guarded auto-sync at the top of ``start.sh``:

- **On ``main`` branch + clean working tree** → ``fetch origin main`` +
  ``reset --hard origin/main``. File-mounted configs always match the
  published image set.
- **On a feature branch** → skip; preserve operator's manual state.
- **Dirty working tree** → skip; preserve uncommitted shell-side edits
  (with a hint to stash before next bounce).

start.sh runs on every codespace boot (postStart), so:

- ``make deploy-codespace`` (workflow rebuild) → next boot auto-syncs.
- ``make codespace-start`` while on main + clean → also auto-syncs.
  Low risk; deterministic.

## Test plan

- [ ] CI green
- [ ] Post-merge: ``make codespace-start`` → start.sh log includes
      ``Sync /workspaces/podcast_scraper to origin/main`` and reports
      ``Synced <old> → <new>`` (or ``Already at HEAD``).
- [ ] Manual feature-branch test: SSH into codespace, ``git checkout -b
      test-feature``, exit, ``make codespace-stop && codespace-start``
      → start.sh log shows ``Skip workspace sync — on branch
      'test-feature'``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)