### PR TITLE
ci: pre-prod deploy pipeline — multi-arch publish + post-deploy smoke (#710, #712)

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -1,0 +1,188 @@
+name: Post-deploy codespace smoke
+
+# Closes the operator validation loop after ``deploy-codespace.yml``
+# rebuilds the pre-prod codespace. SSHes into the codespace, runs a
+# real-episode pipeline through ``cloud_balanced``, asserts the corpus
+# artifacts came out right, then auto-stops the codespace so the
+# compute meter doesn't run forever. See issue #710 for the full
+# rationale.
+#
+# Operator setup (one-time, in addition to deploy-codespace.yml's
+# CODESPACES_PAT + PREPROD_CODESPACE_NAME):
+#
+#   1. Set repo variable ``SMOKE_FEED_URL`` to the RSS URL of a
+#      stable podcast with at least one short episode (~5 min). Used
+#      as ``feed_url`` in ``POST /api/jobs``. Without this, the smoke
+#      logs a warning and skips — codespace still gets stopped so the
+#      compute meter doesn't leak.
+#   2. (Optional) Set repo variable ``SMOKE_FEED_NAME`` to a
+#      human-readable corpus directory name (defaults to
+#      ``smoke``).
+#   3. (Optional) Set secret ``SMOKE_WEBHOOK_URL`` to a Slack / HA
+#      / RFC-081 §Layer 4 webhook for the green / red ping.
+#
+# When this workflow lands, re-enable the upstream deploy:
+#
+#   gh workflow enable "Deploy to pre-prod codespace" \
+#       --repo chipi/podcast_scraper
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Deploy to pre-prod codespace"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    env:
+      CODESPACES_PAT: ${{ secrets.CODESPACES_PAT }}
+      PREPROD_CODESPACE: ${{ vars.PREPROD_CODESPACE_NAME }}
+      # Operator-pinned via repo variables. Smoke is skipped (warning
+      # logged) when SMOKE_FEED_URL is empty.
+      SMOKE_FEED_URL: ${{ vars.SMOKE_FEED_URL }}
+      SMOKE_FEED_NAME: ${{ vars.SMOKE_FEED_NAME || 'smoke' }}
+      SMOKE_WEBHOOK_URL: ${{ secrets.SMOKE_WEBHOOK_URL }}
+      # Time budget for the in-codespace smoke. Real-episode runs on
+      # cloud_balanced + bundled GIL average ~3-4 min on whisper-1
+      # transcription + gemini-2.5-flash-lite. 7 min covers slow days.
+      SMOKE_BUDGET_SECONDS: '420'
+    outputs:
+      result: ${{ steps.smoke.outputs.result }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Preconditions
+        id: pre
+        run: |
+          set -euo pipefail
+          if [ -z "${CODESPACES_PAT:-}" ] || [ -z "${PREPROD_CODESPACE:-}" ]; then
+            echo "::warning::CODESPACES_PAT or PREPROD_CODESPACE_NAME not set — skipping smoke."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=missing-prereqs" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${SMOKE_FEED_URL:-}" ]; then
+            echo "::warning::SMOKE_FEED_URL repo variable not set — skipping smoke."
+            echo "::warning::Pin via Settings → Variables → Actions → SMOKE_FEED_URL."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=missing-feed-url" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Copy smoke script into codespace
+        if: steps.pre.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CODESPACES_PAT }}
+        run: |
+          set -euo pipefail
+          # ``gh codespace cp`` lands in $HOME by default. Place into
+          # /tmp so /home is left untouched.
+          gh codespace cp scripts/smoke/post_deploy.py "remote:/tmp/post_deploy.py" \
+              --codespace "$PREPROD_CODESPACE"
+
+      - name: Run smoke inside codespace
+        id: smoke
+        if: steps.pre.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CODESPACES_PAT }}
+        run: |
+          set -euo pipefail
+          # Smoke script reads its config from env vars passed via
+          # ``gh codespace ssh -- env ... python ...``.
+          # The ``2>&1 | tee`` pattern lets the GHA log show progress
+          # AND captures the exit code via PIPESTATUS.
+          set +e
+          gh codespace ssh --codespace "$PREPROD_CODESPACE" -- \
+              "SMOKE_FEED_URL='${SMOKE_FEED_URL}' \
+               SMOKE_FEED_NAME='${SMOKE_FEED_NAME}' \
+               SMOKE_BUDGET_SECONDS='${SMOKE_BUDGET_SECONDS}' \
+               EXPECTED_SHORT_SHA='${{ github.event.workflow_run.head_sha || github.sha }}' \
+               python3 /tmp/post_deploy.py" 2>&1 | tee /tmp/smoke.log
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "result=green" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=red" >> "$GITHUB_OUTPUT"
+            echo "::error::Smoke failed (rc=$rc) — see /tmp/smoke.log artifact."
+            exit 1
+          fi
+
+      - name: Stop codespace (green path)
+        if: steps.pre.outputs.skip != 'true' && success()
+        env:
+          GH_TOKEN: ${{ secrets.CODESPACES_PAT }}
+        run: |
+          set -euo pipefail
+          # Smoke green → stop the codespace so the compute meter halts.
+          # GitHub auto-suspends idle codespaces at 30 min by default,
+          # but stopping immediately tightens that to seconds.
+          echo "==> Stopping codespace: $PREPROD_CODESPACE"
+          gh codespace stop --codespace "$PREPROD_CODESPACE" || true
+
+      - name: Leave codespace running (red path)
+        if: steps.pre.outputs.skip != 'true' && failure()
+        run: |
+          echo "::warning::Smoke failed — codespace left running so operator can SSH in to debug."
+          echo "::warning::Reach it via: gh codespace ssh --codespace $PREPROD_CODESPACE"
+          echo "::warning::When done debugging: gh codespace stop --codespace $PREPROD_CODESPACE"
+
+      - name: Capture failure artifacts
+        if: steps.pre.outputs.skip != 'true' && failure()
+        env:
+          GH_TOKEN: ${{ secrets.CODESPACES_PAT }}
+        run: |
+          set -euo pipefail
+          # Best-effort post-mortem snapshot. None of these are blocking;
+          # we'd rather report partial info than fail the failure path.
+          mkdir -p /tmp/smoke-artifacts
+          cp /tmp/smoke.log /tmp/smoke-artifacts/ 2>/dev/null || true
+          gh codespace ssh --codespace "$PREPROD_CODESPACE" -- \
+              'curl -fsS http://localhost:8090/api/jobs?path=/app/output' \
+              > /tmp/smoke-artifacts/jobs.json 2>&1 || true
+          gh codespace ssh --codespace "$PREPROD_CODESPACE" -- \
+              'curl -fsS http://localhost:8090/api/health' \
+              > /tmp/smoke-artifacts/health.json 2>&1 || true
+          gh codespace ssh --codespace "$PREPROD_CODESPACE" -- \
+              'docker compose -f /workspaces/podcast_scraper/compose/docker-compose.prod.yml logs --tail=400 api' \
+              > /tmp/smoke-artifacts/api.log 2>&1 || true
+          gh codespace ssh --codespace "$PREPROD_CODESPACE" -- \
+              'df -h' \
+              > /tmp/smoke-artifacts/df.txt 2>&1 || true
+
+      - uses: actions/upload-artifact@v4
+        if: steps.pre.outputs.skip != 'true' && failure()
+        with:
+          name: smoke-artifacts-${{ github.run_id }}
+          path: /tmp/smoke-artifacts/
+          retention-days: 14
+
+      - name: Webhook ping
+        if: steps.pre.outputs.skip != 'true' && always()
+        run: |
+          set -euo pipefail
+          if [ -z "${SMOKE_WEBHOOK_URL:-}" ]; then
+            echo "::notice::SMOKE_WEBHOOK_URL not set; skipping webhook ping."
+            exit 0
+          fi
+          SHORT="${{ github.event.workflow_run.head_sha || github.sha }}"
+          SHORT="${SHORT:0:7}"
+          RESULT="${{ steps.smoke.outputs.result }}"
+          if [ "$RESULT" = "green" ]; then
+            MSG="Smoke: green on \`$SHORT\`; codespace stopped."
+          else
+            MSG="Smoke: red on \`$SHORT\`; codespace \`$PREPROD_CODESPACE\` still up."
+          fi
+          curl -fsS -X POST -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" \
+              "$SMOKE_WEBHOOK_URL" || echo "::warning::webhook ping failed (non-fatal)"

--- a/.github/workflows/stack-test.yml
+++ b/.github/workflows/stack-test.yml
@@ -210,6 +210,14 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
+      # #712: arm64 builds run via QEMU emulation on this amd64 runner.
+      # setup-qemu-action must come before setup-buildx-action so the
+      # builder picks up the registered binfmt_misc handlers.
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -230,25 +238,37 @@ jobs:
           echo "ref_main=:main" >> "$GITHUB_OUTPUT"
           echo "ref_sha=:sha-${SHORT}" >> "$GITHUB_OUTPUT"
 
+      # #712: each publish step does two buildx invocations.
+      # Step 1: build linux/amd64 only with --load so the no-secrets-in-image
+      # script can ``docker run`` against a real local image. Multi-arch
+      # buildx output can't be --load'd (the local Docker daemon is
+      # single-arch), so we keep the secrets gate on amd64 — it inspects
+      # bake-time COPY surfaces which are arch-identical.
+      # Step 2: build linux/amd64,linux/arm64 with --push directly to GHCR,
+      # tagging both :main and :sha-<short> in one shot. Cache from step 1
+      # makes the amd64 layer near-instant; arm64 is the only new build cost.
       - name: Build + assert + push (api)
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.OWNER }}/podcast-scraper-stack-api
           SHORT_SHA: ${{ steps.tags.outputs.short_sha }}
         run: |
           set -euo pipefail
-          # Build to local docker first so the no-secrets assertion can run
-          # against the built image before any push.
           docker buildx build \
+            --platform linux/amd64 \
             --tag "${IMAGE}:build-${SHORT_SHA}" \
             --load \
             --cache-from "type=gha,scope=publish-api" \
             --cache-to "type=gha,scope=publish-api,mode=max" \
             -f docker/api/Dockerfile .
           scripts/check/no-secrets-in-image.sh "${IMAGE}:build-${SHORT_SHA}"
-          docker tag "${IMAGE}:build-${SHORT_SHA}" "${IMAGE}:main"
-          docker tag "${IMAGE}:build-${SHORT_SHA}" "${IMAGE}:sha-${SHORT_SHA}"
-          docker push "${IMAGE}:main"
-          docker push "${IMAGE}:sha-${SHORT_SHA}"
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag "${IMAGE}:main" \
+            --tag "${IMAGE}:sha-${SHORT_SHA}" \
+            --push \
+            --cache-from "type=gha,scope=publish-api" \
+            --cache-to "type=gha,scope=publish-api,mode=max" \
+            -f docker/api/Dockerfile .
 
       - name: Build + assert + push (viewer)
         env:
@@ -260,6 +280,7 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx build \
+            --platform linux/amd64 \
             --tag "${IMAGE}:build-${SHORT_SHA}" \
             --load \
             --cache-from "type=gha,scope=publish-viewer" \
@@ -269,10 +290,17 @@ jobs:
             --build-arg "VITE_PODCAST_RELEASE=podcast-scraper@sha-${SHORT_SHA}" \
             -f docker/viewer/Dockerfile .
           scripts/check/no-secrets-in-image.sh "${IMAGE}:build-${SHORT_SHA}"
-          docker tag "${IMAGE}:build-${SHORT_SHA}" "${IMAGE}:main"
-          docker tag "${IMAGE}:build-${SHORT_SHA}" "${IMAGE}:sha-${SHORT_SHA}"
-          docker push "${IMAGE}:main"
-          docker push "${IMAGE}:sha-${SHORT_SHA}"
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag "${IMAGE}:main" \
+            --tag "${IMAGE}:sha-${SHORT_SHA}" \
+            --push \
+            --cache-from "type=gha,scope=publish-viewer" \
+            --cache-to "type=gha,scope=publish-viewer,mode=max" \
+            --build-arg "VITE_SENTRY_DSN_VIEWER=${VITE_SENTRY_DSN_VIEWER}" \
+            --build-arg "VITE_PODCAST_ENV=preprod" \
+            --build-arg "VITE_PODCAST_RELEASE=podcast-scraper@sha-${SHORT_SHA}" \
+            -f docker/viewer/Dockerfile .
 
       - name: Build + assert + push (pipeline-llm — cloud variant only)
         env:
@@ -283,6 +311,7 @@ jobs:
           # INSTALL_EXTRAS=llm = cloud-thin variant (OpenAI/Gemini SDKs).
           # PRELOAD_ML_MODELS=false because this image has no local ML models.
           docker buildx build \
+            --platform linux/amd64 \
             --tag "${IMAGE}:build-${SHORT_SHA}" \
             --load \
             --cache-from "type=gha,scope=publish-pipeline-llm" \
@@ -291,19 +320,51 @@ jobs:
             --build-arg "PRELOAD_ML_MODELS=false" \
             -f docker/pipeline/Dockerfile .
           scripts/check/no-secrets-in-image.sh "${IMAGE}:build-${SHORT_SHA}"
-          docker tag "${IMAGE}:build-${SHORT_SHA}" "${IMAGE}:main"
-          docker tag "${IMAGE}:build-${SHORT_SHA}" "${IMAGE}:sha-${SHORT_SHA}"
-          docker push "${IMAGE}:main"
-          docker push "${IMAGE}:sha-${SHORT_SHA}"
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag "${IMAGE}:main" \
+            --tag "${IMAGE}:sha-${SHORT_SHA}" \
+            --push \
+            --cache-from "type=gha,scope=publish-pipeline-llm" \
+            --cache-to "type=gha,scope=publish-pipeline-llm,mode=max" \
+            --build-arg "INSTALL_EXTRAS=llm" \
+            --build-arg "PRELOAD_ML_MODELS=false" \
+            -f docker/pipeline/Dockerfile .
+
+      - name: Verify multi-arch manifests
+        env:
+          IMAGE_API: ${{ env.REGISTRY }}/${{ env.OWNER }}/podcast-scraper-stack-api
+          IMAGE_VIEWER: ${{ env.REGISTRY }}/${{ env.OWNER }}/podcast-scraper-stack-viewer
+          IMAGE_PIPELINE: ${{ env.REGISTRY }}/${{ env.OWNER }}/podcast-scraper-stack-pipeline-llm
+          SHORT_SHA: ${{ steps.tags.outputs.short_sha }}
+        run: |
+          set -euo pipefail
+          # #712 acceptance gate: assert each pushed :main manifest lists both
+          # linux/amd64 and linux/arm64 digests. Belt-and-suspenders against
+          # silent platform regressions (someone removes --platform later).
+          for IMAGE in "$IMAGE_API" "$IMAGE_VIEWER" "$IMAGE_PIPELINE"; do
+            echo "==> Inspecting ${IMAGE}:sha-${SHORT_SHA}"
+            MANIFEST=$(docker buildx imagetools inspect "${IMAGE}:sha-${SHORT_SHA}" --raw)
+            for ARCH in amd64 arm64; do
+              if ! echo "$MANIFEST" | grep -q "\"architecture\": \"${ARCH}\""; then
+                echo "::error::${IMAGE}:sha-${SHORT_SHA} missing linux/${ARCH} in manifest"
+                echo "$MANIFEST"
+                exit 1
+              fi
+            done
+            echo "  ${IMAGE}:sha-${SHORT_SHA} OK (amd64 + arm64)"
+          done
 
       - name: Summary
         run: |
           set -euo pipefail
           SHORT="${{ steps.tags.outputs.short_sha }}"
           {
-            echo "## GHCR publish complete"
+            echo "## GHCR publish complete (multi-arch)"
             echo ""
-            echo "Pushed three images with tags ``:main`` + ``:sha-${SHORT}``:"
+            echo "Pushed three images with tags ``:main`` + ``:sha-${SHORT}``,"
+            echo "each as a multi-arch manifest covering ``linux/amd64`` +"
+            echo "``linux/arm64`` (#712 — unblocks Hetzner CAX prod target)."
             echo ""
             echo "* ``ghcr.io/${{ env.OWNER }}/podcast-scraper-stack-api:main``"
             echo "* ``ghcr.io/${{ env.OWNER }}/podcast-scraper-stack-viewer:main``"
@@ -312,4 +373,7 @@ jobs:
             echo "The ``pipeline-ml`` image (with HuggingFace cache + SummLlama)"
             echo "is intentionally NOT published — RFC-081 §Layer 1 license"
             echo "decision; never redistribute restricted-license model bundles."
+            echo "It also stays amd64-only — no current consumer needs ARM ML,"
+            echo "and torch / sentence-transformers / spaCy on arm64 is a"
+            echo "separate (non-trivial) port."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/guides/INTEGRATION_TESTING_GUIDE.md
+++ b/docs/guides/INTEGRATION_TESTING_GUIDE.md
@@ -125,6 +125,53 @@ def test_transcription_workflow(self):
         # Verify provider creation and lifecycle, not ML output
 ```
 
+### Mocking LLM SDKs at `sys.modules` (scoped, not module-global) {#sdk-sys-modules-mock}
+
+> **Always pair `patch.dict("sys.modules", …).start()` with a matching `tearDownModule` `.stop()`.** Otherwise the mock leaks across test files and breaks downstream tests that need the real SDK.
+
+When an integration test needs to construct a real provider class (`OpenAIProvider`, `AnthropicProvider`, `GeminiProvider`, etc.) but doesn't want the test machine to require `[llm]` extras for **collection**, the canonical pattern is to mock the SDK package at `sys.modules` import time. Provider modules use soft imports (`try: from openai import OpenAI; except ImportError: openai = None`), so mocking `openai` in `sys.modules` makes the import succeed and the symbol non-None.
+
+**Wrong** (the unscoped `.start()` leaks the mock for the rest of the pytest process — including xdist workers — and a later test like `tests/integration/infrastructure/test_e2e_server.py` ends up with a `MagicMock()` `openai` client instead of the real one):
+
+```python
+mock_openai = MagicMock()
+patch.dict("sys.modules", {"openai": mock_openai}).start()  # ❌ leak
+```
+
+**Right** (scope to this module via `setUpModule` / `tearDownModule`):
+
+```python
+mock_openai = MagicMock()
+mock_openai.__spec__ = importlib.util.spec_from_loader("openai", loader=None)
+_patch_openai = patch.dict("sys.modules", {"openai": mock_openai})
+
+
+def setUpModule():
+    # Scope the SDK mock to this module only — otherwise it leaks into
+    # other integration test files that need the real SDK.
+    _patch_openai.start()
+
+
+def tearDownModule():
+    _patch_openai.stop()
+
+
+# Provider import happens AFTER the patch object exists but BEFORE setUpModule
+# fires. That's fine: the integration tier has the SDK installed for real, so
+# the import succeeds with the real package. The mock activates for tests that
+# need to bypass real SDK constructors via ``provider.client = MagicMock()``.
+from podcast_scraper.providers.openai.openai_provider import OpenAIProvider
+```
+
+Canonical examples in the repo:
+
+- `tests/integration/providers/llm/test_gemini_provider.py` — Gemini (`google.genai`)
+- `tests/integration/providers/llm/test_openai_provider.py` — OpenAI
+- `tests/integration/providers/llm/test_ollama_provider.py` — Ollama (`openai` + `httpx`)
+- `tests/integration/providers/llm/test_*_bundled_methods.py` — #698 bundled-method tests, same pattern
+
+**Don't mock `httpx` at integration tier.** Several provider modules do real `isinstance(base, httpx.Timeout)` checks in `timeout_config.py`. Mocking `httpx` in `sys.modules` makes the type check raise `TypeError: isinstance() arg 2 must be a type`. The integration tier has `[llm]` (which includes `httpx`) installed for real — let it through. The exception is `OllamaProvider` which has an `if httpx is None` runtime check at `__init__`; that's already handled by the real `httpx` being importable.
+
 ### Local HTTP Server Test
 
 ```python

--- a/docs/guides/UNIT_TESTING_GUIDE.md
+++ b/docs/guides/UNIT_TESTING_GUIDE.md
@@ -148,6 +148,8 @@ sys.modules["transformers"] = MagicMock()
 from podcast_scraper.providers.ml import ml_provider
 ```
 
+> **Direct `sys.modules[...] = MagicMock()` is fine in unit tests** because each unit-test module is small-scoped and `tests/unit/` is the leaf of the test pyramid (nothing downstream needs the real package). For **integration tests** that mock SDKs at `sys.modules`, use the **scoped** `setUpModule` / `tearDownModule` pattern instead — see [Integration Testing Guide → Mocking LLM SDKs at sys.modules](INTEGRATION_TESTING_GUIDE.md#sdk-sys-modules-mock). Otherwise the mock leaks into other integration files that need the real SDK.
+
 **CI Verification:**
 
 - `scripts/tools/check_unit_test_imports.py` (`make check-unit-imports`) -- verifies

--- a/docs/rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md
+++ b/docs/rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md
@@ -116,7 +116,7 @@ IaC + a GitOps deploy loop**:
 
 [ New for prod ]
   1. infra/ directory: Terraform + cloud-init + deploy script
-  2. Hetzner CX32 (or CCX13) provisioned via Terraform
+  2. Hetzner CAX31 (or CX33 interim — see Decision 1) provisioned via Terraform
   3. Tailscale daemon on the VPS, auto-joins tailnet via auth key
   4. GHA workflow deploy-prod.yml fires on stack-test success → main
   5. Host bind-mount: /srv/podcast-scraper/corpus
@@ -125,17 +125,58 @@ IaC + a GitOps deploy loop**:
 
 ### Decision 1 — Hosting target
 
-**Hetzner CX32** (4 vCPU shared, 8 GB RAM, 80 GB SSD, ~€7.89/mo, EU).
-Operator-confirmed EU geography + want predictable flat billing.
+**Hetzner CAX31** (8 vCPU ARM Ampere, 16 GB RAM, 160 GB SSD, 20 TB
+traffic, **€15.99/mo**, EU). Operator-confirmed EU geography + want
+predictable flat billing.
 
-Upgrade path: **CCX13** (2 dedicated vCPU, 8 GB, 80 GB, ~€13.99/mo)
-if shared-CPU jitter shows up in pipeline ffmpeg stages. Both are
-within the cost ceiling.
+CAX31 wins on price/perf at the chosen budget tier: it's the same
+monthly cost as CCX13 (the dedicated-AMD option) but ships **4× the
+vCPUs (8 vs 2) and 2× the RAM (16 vs 8 GB)**. For a workload that's
+ffmpeg + cloud-LLM SDK calls + viewer + grafana-agent — none of which
+benefits from x86-specific instructions — that's a free headroom
+upgrade at the same euro spend.
 
-Optional: a separate Hetzner Volume (€0.0476/GB/month) for the corpus
-bind-mount, so the VPS image can be replaced without touching corpus
-data. ~€2.50/mo for 50 GB. Recommended once corpus grows past ~20 GB
-on the boot disk.
+**Why ARM is low-risk for this stack.** Prod runs the cloud-thin
+profile (`INSTALL_EXTRAS=llm`): no torch / spaCy / FAISS / Whisper /
+llama-cpp. The arm64 dependency surface reduces to
+`python:3.12-slim-bookworm` (official multi-arch), `nginx:alpine`
+(viewer; official multi-arch), debian-package ffmpeg (first-class on
+Ampere), pure-Python provider SDKs, and grafana-agent (official ARM
+build). None of the typical "port to ARM" pain points (compiled ML
+wheels, CUDA, native llama.cpp) are in the prod image set.
+
+**Prerequisite.** GHCR publish currently emits amd64-only manifests.
+Moving to CAX is gated on
+[#712 — Multi-arch (amd64+arm64) GHCR publish](https://github.com/chipi/podcast_scraper/issues/712),
+which adds `--platform linux/amd64,linux/arm64` to the three
+`docker buildx build` invocations in `stack-test.yml` and validates
+one real episode end-to-end on a throwaway CAX21 before the prod
+flip. Until #712 lands, the **interim deploy target is CX33**
+(4 vCPU shared Intel/AMD, 8 GB, 80 GB, €6.49/mo) so prod isn't
+blocked on the publish change.
+
+> **Naming note.** Hetzner renamed the CX line in 2024 (CX22 / CX32 /
+> CX42 → CX23 / CX33 / CX43) and pushed a 30–37% price hike on
+> 2026-04-01. Earlier drafts of this RFC referenced "CX32 at €7.89" —
+> that SKU no longer exists; CX33 is the same shape post-rename. EUR
+> figures throughout reflect Hetzner's post-2026-04-01 list price.
+
+**Alternatives kept on the bench (in order, only if CAX31 falls
+short):**
+
+| Trigger | Move to | Specs | Price |
+| --- | --- | --- | --- |
+| #712 not yet landed; need to ship prod now on amd64 | **CX33** (interim) | 4 vCPU shared Intel/AMD, 8 GB, 80 GB | €6.49/mo |
+| #712 not yet landed AND shared-CPU jitter visible | **CCX13** (interim, dedicated) | 2 dedicated AMD vCPU, 8 GB, 80 GB | €15.99/mo |
+| ARM perf surprise — Ampere wall-time materially worse than amd64 baseline | **CCX23** | 4 dedicated AMD vCPU, 16 GB, 160 GB | €31.49/mo |
+
+CAX31 sits at $17/mo (~$3 under the $20 ceiling). The CCX23 fallback
+breaks the ceiling and would need an explicit budget revision.
+
+**Storage add-on:** a separate Hetzner Volume (€0.0572/GB/month, post
+April-2026 pricing) for the corpus bind-mount, so the VPS image can
+be replaced without touching corpus data. ~€2.86/mo for 50 GB.
+Recommended once corpus grows past ~20 GB on the boot disk.
 
 ### Decision 2 — Auth wall: Tailscale
 
@@ -228,8 +269,9 @@ rather than as a host-side cron that escapes git visibility.
 
 **Optional: Hetzner Volume snapshots.** If corpus moves to a
 detached Volume, Hetzner's automatic snapshot feature is a
-zero-config secondary safety net (~€0.0119/GB/month). Out of scope
-for this RFC unless corpus grows large enough to matter.
+zero-config secondary safety net (€0.0143/GB/month, post-2026-04-01
+pricing). Out of scope for this RFC unless corpus grows large
+enough to matter.
 
 ### Decision 5 — IaC: Terraform with the hetznercloud provider
 
@@ -257,7 +299,8 @@ infra/
   with the `hetznercloud/hcloud` provider, also supports the
   `tailscale/tailscale` provider. Avoids the BSL-license question on
   HashiCorp Terraform.
-- **`hetznercloud/hcloud` provider** — declares the CX32 server,
+- **`hetznercloud/hcloud` provider** — declares the CAX31 server
+  (or CX33 during the #712 interim window),
   attached Volume, firewall rules (default-deny inbound; allow
   outbound), SSH key registration.
 - **`tailscale/tailscale` provider** — declares the auth key (so
@@ -292,8 +335,8 @@ loop so operators don't manage the dance manually.
 
 **Trade-offs vs. alternatives:**
 
-| | sops + age (chosen) | Hetzner Object Storage | Terraform Cloud |
-|---|---|---|---|
+| Dimension | sops + age (chosen) | Hetzner Object Storage | Terraform Cloud |
+| --- | --- | --- | --- |
 | Cost | $0 | ~€0.50/mo | $0 free tier (5 users) |
 | Vendor surface | none new | one (already on Hetzner) | new |
 | State in git history | yes (encrypted blob) | no | no |
@@ -308,7 +351,7 @@ changed" signal. If we ever go multi-operator, swap to Object Storage
 **Bootstrap flow:**
 
 1. Operator clones repo locally, runs `cd infra/terraform && tofu apply`.
-2. OpenTofu provisions Hetzner CX32 + attaches Volume + registers
+2. OpenTofu provisions Hetzner CAX31 (or CX33 interim) + attaches Volume + registers
    tailscale auth key.
 3. cloud-init runs on first boot: installs Docker, Tailscale, joins
    tailnet, pulls repo, copies operator-staged `.env`, runs
@@ -572,7 +615,7 @@ runbook. The corpus is recoverable to within ~24 h of pre-disaster
 state (last `backup-corpus.yml` run).
 
 If the corpus loss matters more than the speed of recovery,
-optionally enable Hetzner Volume snapshots (€0.0119/GB/month) for a
+optionally enable Hetzner Volume snapshots (€0.0143/GB/month) for a
 secondary safety net with ~hour-level RPO.
 
 ### Image set and pull behavior
@@ -586,7 +629,7 @@ exactly as in pre-prod.
 
 First-deploy image pull on a fresh VPS is ~3 GB total (~1.5 GB
 pipeline-llm + ~700 MB api + ~50 MB viewer + ~250 MB grafana-agent).
-Bandwidth allowance on Hetzner CX32 is 20 TB/mo; first-deploy pull
+Bandwidth allowance on Hetzner CAX31 / CX33 is 20 TB/mo; first-deploy pull
 is negligible against that. Subsequent deploys reuse layers and pull
 ~50-200 MB per release.
 
@@ -618,20 +661,26 @@ is negligible against that. Subsequent deploys reuse layers and pull
 
 ## Costs
 
+All EUR figures reflect Hetzner's post-2026-04-01 price list.
+
 | Component | Plan | Cost / mo |
-|---|---|---|
-| Hetzner CX32 (or CCX13) | flat | €7.89 (~$9) or €13.99 (~$15) |
-| Hetzner Volume 50 GB (optional) | flat | ~€2.50 |
-| Hetzner Object Storage (state) | flat | ~€0.50 |
+| --- | --- | --- |
+| Hetzner CAX31 (chosen, post-#712) | flat | €15.99 (~$17) |
+| Hetzner CX33 (interim until #712 lands) | flat | €6.49 (~$7) |
+| Hetzner Volume 50 GB (optional) | flat | ~€2.86 (~$3) |
+| sops + age state storage (in-repo, no vendor) | — | $0 |
 | Tailscale Personal | up to 100 devices | $0 |
 | GitHub (CI / Packages public) | included | $0 |
 | Grafana Cloud Free | unchanged | $0 |
 | Sentry Free | unchanged | $0 |
 | **Pipeline LLM calls** | metered (operator's keys) | varies — same as pre-prod |
-| **Total fixed** | | **~$10-19/mo** |
+| **Total fixed (CAX31 + 50 GB Volume)** | | **~$20/mo** |
+| **Total fixed (CX33 interim, no Volume)** | | **~$7/mo** |
 
-Within the $20/mo ceiling even on the dedicated-CPU CCX13 + 50 GB
-Volume + state storage.
+CAX31 + 50 GB Volume sits right at the $20 ceiling. The CX33 interim
+target sits well under, leaving headroom for the Volume add-on
+during the gap before #712 lands. Any further upgrade (CCX23, larger
+Volume) breaks the ceiling and needs an explicit budget revision.
 
 ## Phased Rollout
 
@@ -679,9 +728,15 @@ The original "Open Questions" set has been resolved (see RFC-082
 discussion thread). Recording here so the implementation has explicit
 direction:
 
-1. **Hetzner CX32** (€7.89, shared CPU). Start here; measure ffmpeg /
-   preprocessing wall-time during real-feed runs; upgrade to CCX13
-   (€13.99, dedicated) only if the shared-CPU jitter is observable.
+1. **Hetzner CAX31** (€15.99, 8 vCPU ARM Ampere, 16 GB) is the chosen
+   target — best price/perf at the $20 ceiling. Gated on
+   [#712](https://github.com/chipi/podcast_scraper/issues/712)
+   (multi-arch GHCR publish). Until #712 lands, deploy on **CX33**
+   (€6.49, shared Intel/AMD, 8 GB; the 2024-renamed successor to the
+   old CX32) as the amd64 interim. Fall back to CCX13 (€15.99,
+   dedicated AMD) if the interim shows shared-CPU jitter, or CCX23
+   (€31.49, breaks the ceiling) only if ARM perf surprises us. EUR
+   figures are post-2026-04-01 list price.
 2. **No detached Volume on day one.** 80 GB boot disk is enough for
    early use. Add a Volume on first VPS replacement when we already
    need to migrate the corpus anyway.

--- a/scripts/smoke/post_deploy.py
+++ b/scripts/smoke/post_deploy.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Post-deploy codespace smoke (#710).
+
+Runs *inside* the pre-prod codespace via ``gh codespace ssh``. Validates
+that the freshly rebuilt codespace has actually-working internals — not
+just that the container started. Steps:
+
+1. ``GET /api/health`` returns 200 with the expected capability flags.
+2. ``GET /api/scheduled-jobs`` returns 200 with a valid shape (catches
+   APScheduler boot regressions).
+3. ``POST /api/jobs`` with the operator-pinned smoke RSS feed +
+   ``cloud_balanced`` profile + ``max_episodes: 1``. Poll
+   ``GET /api/jobs/{id}`` until status is ``succeeded`` or ``failed``,
+   bounded by ``SMOKE_BUDGET_SECONDS``.
+4. After the job succeeds, walk the corpus on disk and assert at least
+   one episode has the four expected artifacts (``.gi.json`` /
+   ``.kg.json`` / ``.bridge.json`` / ``.metadata.json``). Quick eye-check
+   on the GI: ``model_version`` field non-empty, ``nodes`` contains at
+   least one ``Insight`` (regression catch for #701-class stub
+   regressions).
+
+Exit codes:
+    0  — all steps green.
+    1  — one or more steps failed (reason printed to stderr; the GHA
+         workflow leaves the codespace running so an operator can SSH
+         in and continue debugging).
+    2  — usage / setup error (missing env vars, etc).
+
+Reads from environment (set by the GHA workflow):
+    SMOKE_FEED_URL          — RSS URL to ingest. Required.
+    SMOKE_FEED_NAME         — corpus directory name (default: ``smoke``).
+    SMOKE_BUDGET_SECONDS    — wall-clock budget for the pipeline run
+                              (default: 420 = 7 min).
+    EXPECTED_SHORT_SHA      — commit SHA the smoke is validating (used
+                              for the diagnostic banner only; image
+                              freshness check is intentionally omitted
+                              because docker compose images metadata
+                              isn't a reliable freshness signal —
+                              GHCR pulls the same :main tag regardless).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+API_BASE = "http://localhost:8090"
+CORPUS_ROOT = Path("/app/output")
+
+
+def _http_json(method: str, url: str, body: dict[str, Any] | None = None) -> tuple[int, Any]:
+    """Tiny stdlib HTTP client — codespace may not have requests installed."""
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = resp.read().decode()
+            try:
+                return resp.status, json.loads(payload) if payload else None
+            except json.JSONDecodeError:
+                return resp.status, payload
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode(errors="replace")
+        return e.code, body_text
+
+
+def step_health() -> bool:
+    print("==> [1/4] GET /api/health", flush=True)
+    code, body = _http_json("GET", f"{API_BASE}/api/health")
+    if code != 200:
+        print(f"   FAIL: status={code} body={body!r}", file=sys.stderr)
+        return False
+    if not isinstance(body, dict):
+        print(f"   FAIL: body is not JSON object: {body!r}", file=sys.stderr)
+        return False
+    # Capability flags surface api factory state. ``jobs_api`` /
+    # ``feeds_api`` should both be true on a healthy codespace; absence
+    # is a regression we want to catch.
+    for flag in ("jobs_api", "feeds_api"):
+        if not body.get(flag):
+            print(f"   FAIL: capability flag {flag!r} missing/false: {body!r}", file=sys.stderr)
+            return False
+    print(f"   OK: {body}", flush=True)
+    return True
+
+
+def step_scheduled_jobs() -> bool:
+    print("==> [2/4] GET /api/scheduled-jobs", flush=True)
+    code, body = _http_json("GET", f"{API_BASE}/api/scheduled-jobs")
+    if code != 200:
+        print(f"   FAIL: status={code} body={body!r}", file=sys.stderr)
+        return False
+    # Shape: {jobs: [...], timezone: "UTC", ...}. APScheduler boot
+    # regressions show as 500 / missing timezone / lifespan crash.
+    if not isinstance(body, dict) or "jobs" not in body or not body.get("timezone"):
+        print(f"   FAIL: bad shape: {body!r}", file=sys.stderr)
+        return False
+    print(f"   OK: {len(body['jobs'])} scheduled jobs, tz={body['timezone']}", flush=True)
+    return True
+
+
+def step_real_episode(feed_url: str, feed_name: str, budget_s: int) -> tuple[bool, str | None]:
+    print(f"==> [3/4] POST /api/jobs feed={feed_url!r}", flush=True)
+    corpus_path = f"/app/output/{feed_name}"
+    payload = {
+        "feed_url": feed_url,
+        "path": corpus_path,
+        "profile": "cloud_balanced",
+        "max_episodes": 1,
+    }
+    code, body = _http_json("POST", f"{API_BASE}/api/jobs", body=payload)
+    if code not in (200, 201, 202):
+        print(f"   FAIL: status={code} body={body!r}", file=sys.stderr)
+        return False, None
+    if not isinstance(body, dict) or "job_id" not in body:
+        print(f"   FAIL: response missing job_id: {body!r}", file=sys.stderr)
+        return False, None
+    job_id = body["job_id"]
+    print(f"   queued job_id={job_id}; polling (budget={budget_s}s)", flush=True)
+
+    deadline = time.monotonic() + budget_s
+    last_status = "?"
+    quoted_path = urllib.parse.quote(corpus_path, safe="")
+    while time.monotonic() < deadline:
+        code, body = _http_json("GET", f"{API_BASE}/api/jobs/{job_id}?path={quoted_path}")
+        if code == 200 and isinstance(body, dict):
+            last_status = body.get("status", "?")
+            if last_status == "succeeded":
+                print(f"   OK: job succeeded in {body.get('finished_at')}", flush=True)
+                return True, corpus_path
+            if last_status == "failed":
+                print(
+                    f"   FAIL: job failed exit_code={body.get('exit_code')} "
+                    f"reason={body.get('error_reason')}",
+                    file=sys.stderr,
+                )
+                return False, corpus_path
+        time.sleep(5)
+    print(
+        f"   FAIL: budget exhausted after {budget_s}s (last_status={last_status!r})",
+        file=sys.stderr,
+    )
+    return False, corpus_path
+
+
+def step_artifacts(corpus_path: str) -> bool:
+    print(f"==> [4/4] verify artifacts in {corpus_path}", flush=True)
+    metadata_dir = Path(corpus_path) / "metadata"
+    if not metadata_dir.is_dir():
+        print(f"   FAIL: {metadata_dir} not found", file=sys.stderr)
+        return False
+    # Find at least one episode with all four artifact suffixes.
+    suffixes = (".gi.json", ".kg.json", ".bridge.json", ".metadata.json")
+    by_episode: dict[str, set[str]] = {}
+    for f in metadata_dir.iterdir():
+        for sfx in suffixes:
+            if f.name.endswith(sfx):
+                stem = f.name[: -len(sfx)]
+                by_episode.setdefault(stem, set()).add(sfx)
+    complete = [ep for ep, found in by_episode.items() if set(found) == set(suffixes)]
+    if not complete:
+        print(
+            f"   FAIL: no episode with all 4 artifacts. by_episode={by_episode}",
+            file=sys.stderr,
+        )
+        return False
+    ep = complete[0]
+    print(f"   OK: episode {ep!r} has all 4 artifacts", flush=True)
+
+    # Eye-check on GI: the #701-class regression looked like a stub
+    # artifact (1 placeholder Insight, model_version=stub) sneaking past
+    # the file-existence check. Refuse stubs explicitly.
+    gi_path = metadata_dir / f"{ep}.gi.json"
+    try:
+        gi = json.loads(gi_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"   FAIL: cannot read {gi_path}: {e}", file=sys.stderr)
+        return False
+    model_version = gi.get("model_version", "")
+    if not model_version or "stub" in model_version.lower():
+        print(
+            f"   FAIL: GI artifact looks stubbed (model_version={model_version!r})",
+            file=sys.stderr,
+        )
+        return False
+    insight_nodes = [n for n in gi.get("nodes", []) if n.get("type") == "Insight"]
+    if not insight_nodes:
+        print("   FAIL: GI artifact has no Insight nodes", file=sys.stderr)
+        return False
+    print(
+        f"   OK: GI model_version={model_version!r}, " f"insights={len(insight_nodes)}",
+        flush=True,
+    )
+    return True
+
+
+def main() -> int:
+    feed_url = os.environ.get("SMOKE_FEED_URL", "").strip()
+    feed_name = os.environ.get("SMOKE_FEED_NAME", "smoke").strip()
+    try:
+        budget_s = int(os.environ.get("SMOKE_BUDGET_SECONDS", "420"))
+    except ValueError:
+        print("SMOKE_BUDGET_SECONDS must be int", file=sys.stderr)
+        return 2
+    if not feed_url:
+        print("SMOKE_FEED_URL is required", file=sys.stderr)
+        return 2
+    expected = os.environ.get("EXPECTED_SHORT_SHA", "?")[:7]
+    print(f"==> Smoke against codespace, expected sha={expected}", flush=True)
+
+    if not step_health():
+        return 1
+    if not step_scheduled_jobs():
+        return 1
+    ok, corpus_path = step_real_episode(feed_url, feed_name, budget_s)
+    if not ok or not corpus_path:
+        return 1
+    if not step_artifacts(corpus_path):
+        return 1
+
+    print("==> Smoke green.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the pre-prod deploy loop end-to-end. Two related infrastructure improvements bundled because they share a coherent theme — making the publish → deploy → validate → stop chain hands-off — plus a small docs capture from PR #711.

- **#712** — Multi-arch (`linux/amd64,linux/arm64`) GHCR publish so the future Hetzner CAX (ARM Ampere) prod target can pull from the same `:main` tag pre-prod uses. RFC-082 amended to promote CAX31 from \"alternative\" to chosen Decision-1 with CX33 as amd64 interim.
- **#710** — Post-deploy codespace smoke + auto-stop. Triggers on `Deploy to pre-prod codespace` workflow_run success, `gh codespace ssh`'s in, runs a real `cloud_balanced` episode through the pipeline, asserts artifacts, and stops the codespace. On failure leaves it running for live debug + uploads logs as workflow artifact.
- **Docs** — Capture the `sys.modules` SDK mock scoping pattern from PR #711's leak fix in `INTEGRATION_TESTING_GUIDE.md` so future test additions follow it from the start.

## Commits

- `a7dbaf10` — `ci(publish): #712 multi-arch (amd64+arm64) GHCR images + RFC-082 CAX31 amendment`
- `2b7393f4` — `ci(deploy): #710 post-deploy codespace smoke + auto-stop`
- `2bb8ca08` — `docs(testing): capture sys.modules SDK mock scoping pattern (lesson from #711)`

## Files changed

| File | Purpose | Lines |
| :--- | :--- | ---: |
| `.github/workflows/stack-test.yml` | Multi-arch publish (3 images × QEMU + verify-manifests step) | +96 |
| `.github/workflows/post-deploy-smoke.yml` | New smoke workflow | +188 |
| `scripts/smoke/post_deploy.py` | New stdlib-only smoke script | +234 |
| `docs/rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md` | CAX31 → Decision 1 | +115 / -40 |
| `docs/guides/INTEGRATION_TESTING_GUIDE.md` | New \"Mocking LLM SDKs at sys.modules\" section | +47 |
| `docs/guides/UNIT_TESTING_GUIDE.md` | Cross-reference to integration-tier pattern | +2 |

## Acceptance / verification gates (pending operator action — out of #712 scope)

Per #712 acceptance criteria:

- [ ] One real podcast episode runs E2E on a throwaway Hetzner CAX21 (€0.01/h × ~1h ≈ €0.01 + LLM costs ~\\$0.005) using the published `:main` images, producing a valid GI + KG artifact.
- [ ] Wall-time delta vs amd64 baseline (e.g. CCX13 or Codespaces) recorded as a comment on this PR.

Per #710 acceptance:

- [ ] After merge: re-enable the deploy workflow with `gh workflow enable \"Deploy to pre-prod codespace\" --repo chipi/podcast_scraper` (it was disabled May 2 because of the no-auto-validation gap; this PR closes that gap).
- [ ] Pin `SMOKE_FEED_URL` repo variable to a stable RSS with one ~5min episode.
- [ ] Optional: `SMOKE_FEED_NAME` repo variable + `SMOKE_WEBHOOK_URL` repo secret.

## Test plan

- [x] `make lint` + `make type` + `make docs` (mkdocs strict) green
- [x] YAML syntax validation for both new workflows
- [x] Stack-test publish step modifications: in-place edit, no behavior change for existing single-arch consumers (multi-arch manifest resolves to amd64 digest on amd64 hosts, arm64 digest on arm64 hosts, same `:main` tag both times)
- [ ] First post-deploy smoke run after merge — operator-driven, validates the full chain in preprod
- [ ] First Hetzner CAX21 spin-up after merge — operator-driven, validates ARM image works end-to-end

## Risks accepted

- **Publish wall-time roughly doubles** (QEMU emulates arm64 on amd64 runner). Acceptable per #712 issue body. Mitigations available if painful: `docker/build-push-action` cache, dedicated arm64 runner, GitHub native arm64 (paid).
- **Stack-test default profile is `airgapped_thin`** (transformers/CrossEncoder for evidence) — bundled cloud path NOT exercised by stack-test. The post-deploy smoke (#710) closes that gap by exercising `cloud_balanced` + bundled GIL on a real episode in preprod after every merge.

## Out of scope

- Sentry / Grafana Cloud roundtrip checks — deferred per #710 issue body (V2 add-on; needs API tokens).
- Auto-stopping codespace on idle outside the smoke window — GitHub's built-in 30-min idle suspend handles it.
- Smoke against the future prod VPS — different topology; covered when RFC-082 prod ships.
- ML pipeline image multi-arch — license-clean rule keeps it off prod regardless; arm64 ML port is its own ticket.

## References

- Issue #710 — post-deploy codespace smoke + auto-stop
- Issue #712 — multi-arch (amd64+arm64) GHCR publish
- Issue #715 — companion test-tier audit (no overlap with this PR)
- RFC-081 — pre-prod environment + control plane
- RFC-082 — always-on pre-prod and prod hosting
- PR #711 — bundled-method tests where the doc capture lesson came from

🤖 Generated with [Claude Code](https://claude.com/claude-code)