### PR TITLE
feat(rfc-082): prod-infra v2.6 — Hetzner VPS + Tailscale + IaC + deploy

### DIFF
--- a/.github/workflows/backup-corpus-prod.yml
+++ b/.github/workflows/backup-corpus-prod.yml
@@ -1,0 +1,187 @@
+name: Backup corpus snapshot (prod VPS)
+
+# Daily backup of the prod VPS corpus directory to a private GitHub Releases
+# asset on chipi/podcast_scraper-backup. RFC-082 Decision 4 (Phase A).
+#
+# Runs IN PARALLEL with the existing codespace-target backup-corpus.yml
+# during the cutover window so we can spot-check that both produce the same
+# shape of snapshot before disabling the codespace path. After ~1 week of
+# operator confidence, the cutover follow-up (#723) disables the codespace
+# workflow and flips this one's schedule on. Until then this workflow is
+# workflow_dispatch-only (no `schedule:` trigger).
+#
+# Closes #722 (Phase A side).
+#
+# Operator prerequisites (#714):
+#   secrets: TS_OAUTH_CLIENT_ID, TS_OAUTH_CLIENT_SECRET, BACKUP_REPO_TOKEN
+#   vars:    PROD_TAILNET_FQDN, PODCAST_BACKUP_REPO (defaults to chipi/podcast_scraper-backup)
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run without uploading (logs the would-do tarball size + retention prune list)"
+        required: false
+        type: boolean
+        default: true
+  # `schedule:` intentionally absent — flipped on by the #723 cutover follow-up
+  # once the operator has confirmed parallel-run produces matching snapshots.
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Pre-flight — required secrets/variables present?
+        id: preflight
+        env:
+          TS_OAUTH_CLIENT_ID:     ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_CLIENT_SECRET: ${{ secrets.TS_OAUTH_CLIENT_SECRET }}
+          BACKUP_REPO_TOKEN:      ${{ secrets.BACKUP_REPO_TOKEN }}
+          PROD_TAILNET_FQDN:      ${{ vars.PROD_TAILNET_FQDN }}
+        run: |
+          set -euo pipefail
+          MISSING=""
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ]     && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_CLIENT_SECRET:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_SECRET"
+          [ -z "${PROD_TAILNET_FQDN:-}" ]      && MISSING="$MISSING PROD_TAILNET_FQDN"
+          if [ "${{ inputs.dry_run }}" = "false" ] && [ -z "${BACKUP_REPO_TOKEN:-}" ]; then
+            MISSING="$MISSING BACKUP_REPO_TOKEN"
+          fi
+          if [ -n "$MISSING" ]; then
+            echo "::warning::Missing prereqs:$MISSING — skipping."
+            echo "::warning::Stage them per #714 then re-run."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Join the tailnet
+        if: steps.preflight.outputs.skip != 'true'
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret:    ${{ secrets.TS_OAUTH_CLIENT_SECRET }}
+          tags:            tag:gha-deployer
+          version:         latest
+
+      - name: Pull corpus from VPS over Tailscale
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          SSH_TARGET: deploy@${{ vars.PROD_TAILNET_FQDN }}
+        run: |
+          set -euo pipefail
+          # Stream the corpus dir as a tarball over SSH. Unlike `gh codespace cp`
+          # this is a single-file streaming operation; if SSH cuts mid-stream the
+          # exit code propagates and we fail fast (no half-tarball that passes
+          # naive size checks). The VPS bind-mount path is /srv/podcast-scraper/corpus
+          # per RFC-082 Decision 4.
+          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+            'tar -czf - -C /srv/podcast-scraper corpus' > snapshot.tgz
+
+          echo "Tarball created: $(du -h snapshot.tgz | cut -f1)"
+
+          # Sanity: refuse empty / suspiciously small.
+          size=$(stat -c%s snapshot.tgz)
+          if [ "$size" -lt 1024 ]; then
+            echo "::error::Tarball is suspiciously small ($size bytes); aborting." >&2
+            exit 1
+          fi
+
+          # Sanity: a healthy corpus has at least one .gi.json (per-episode
+          # GI insights). Catches "ssh succeeded but corpus dir was empty".
+          # NOTE: don't use `grep -q` here — under `set -o pipefail`, grep -q
+          # SIGPIPEs tar mid-stream and the pipe exits non-zero even on a
+          # successful match. Use `grep -c` (counts; tar runs to completion).
+          # Matches the pattern from the codespace workflow (#699 fix).
+          gi_in_tar=$(tar -tzf snapshot.tgz | grep -c '\.gi\.json$' || true)
+          echo "gi.json entries in tarball: $gi_in_tar"
+          if [ "$gi_in_tar" -eq 0 ]; then
+            echo "::warning::Tarball has no .gi.json artifacts; corpus likely empty."
+            echo "::warning::This is OK for a fresh VPS bootstrap; otherwise investigate."
+          fi
+
+      - name: Upload snapshot to backup repo
+        if: steps.preflight.outputs.skip != 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN:    ${{ secrets.BACKUP_REPO_TOKEN }}
+          BACKUP_REPO: ${{ vars.PODCAST_BACKUP_REPO || 'chipi/podcast_scraper-backup' }}
+        run: |
+          set -euo pipefail
+          # Tag with -prod suffix so codespace + prod snapshots from the same
+          # day don't collide during the parallel-run window.
+          TAG="snapshot-prod-$(date -u +%Y%m%d)"
+          if gh release view "$TAG" --repo "$BACKUP_REPO" >/dev/null 2>&1; then
+            echo "Release $TAG exists; uploading asset (will clobber)."
+            gh release upload "$TAG" snapshot.tgz --repo "$BACKUP_REPO" --clobber
+          else
+            echo "Release $TAG does not exist; creating with asset."
+            gh release create "$TAG" snapshot.tgz \
+              --repo "$BACKUP_REPO" \
+              --title "Corpus snapshot $TAG (prod VPS)" \
+              --notes "Automated daily backup of /srv/podcast-scraper/corpus over Tailscale. Retention 7 daily + 4 weekly."
+          fi
+          echo "Uploaded snapshot.tgz as release tag $TAG"
+
+      - name: Prune older prod snapshots (keep 7 daily + 4 weekly)
+        if: steps.preflight.outputs.skip != 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN:    ${{ secrets.BACKUP_REPO_TOKEN }}
+          BACKUP_REPO: ${{ vars.PODCAST_BACKUP_REPO || 'chipi/podcast_scraper-backup' }}
+        run: |
+          set -euo pipefail
+          # Same retention policy as backup-corpus.yml but scoped to snapshot-prod-
+          # tags so we don't touch codespace-era snapshots during cutover overlap.
+          mapfile -t TAGS < <(gh release list --repo "$BACKUP_REPO" --limit 200 \
+            --json tagName -q '.[].tagName' | grep -E '^snapshot-prod-[0-9]{8}$' || true)
+          if [ ${#TAGS[@]} -le 7 ]; then
+            echo "Only ${#TAGS[@]} prod release(s); nothing to prune."
+            exit 0
+          fi
+          KEEP_DAILY=("${TAGS[@]:0:7}")
+          REMAINDER=("${TAGS[@]:7}")
+          KEEP_WEEKLY=()
+          for tag in "${REMAINDER[@]}"; do
+            d="${tag#snapshot-prod-}"
+            wd=$(date -d "$d" +%u 2>/dev/null || true)
+            if [ "$wd" = "1" ]; then
+              KEEP_WEEKLY+=("$tag")
+              [ ${#KEEP_WEEKLY[@]} -ge 4 ] && break
+            fi
+          done
+          KEEP=("${KEEP_DAILY[@]}" "${KEEP_WEEKLY[@]}")
+          echo "Keeping: ${KEEP[*]}"
+          for tag in "${TAGS[@]}"; do
+            keep=false
+            for k in "${KEEP[@]}"; do
+              [ "$tag" = "$k" ] && keep=true && break
+            done
+            if [ "$keep" = "false" ]; then
+              echo "Pruning $tag"
+              gh release delete "$tag" --repo "$BACKUP_REPO" --yes --cleanup-tag || true
+            fi
+          done
+
+      - name: Dry-run report
+        if: steps.preflight.outputs.skip != 'true' && inputs.dry_run == true
+        env:
+          GH_TOKEN:    ${{ secrets.BACKUP_REPO_TOKEN }}
+          BACKUP_REPO: ${{ vars.PODCAST_BACKUP_REPO || 'chipi/podcast_scraper-backup' }}
+        run: |
+          set -euo pipefail
+          echo "=== Dry-run mode (prod VPS source) ==="
+          echo "Tarball size: $(du -h snapshot.tgz 2>/dev/null | cut -f1 || echo 'NONE')"
+          echo "Tarball contents (top-level):"
+          tar -tzf snapshot.tgz 2>/dev/null | head -5 || echo "(empty)"
+          if [ -n "${GH_TOKEN:-}" ]; then
+            echo ""
+            echo "Existing snapshot-prod-* releases on $BACKUP_REPO:"
+            gh release list --repo "$BACKUP_REPO" --limit 20 \
+              --json tagName -q '.[] | .tagName' \
+              | grep -E '^snapshot-prod-' || echo "(none yet)"
+          fi
+          echo ""
+          echo "Nothing uploaded (dry_run=true)."

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,125 @@
+name: Deploy to prod VPS
+
+# RFC-082 Decision 3: deploy to the always-on Hetzner VPS over Tailscale.
+#
+# Manual-trigger only at first land. After the operator's first `tofu apply`
+# (#714 + #716) and a few green manual runs, a follow-up PR adds the
+# `workflow_run: ["Stack test"]` trigger to complete the GitOps deploy loop
+# (RFC-082 Decision 6).
+#
+# Closes #718 (workflow scaffold), #720 (post-deploy /api/health smoke),
+# #721 (PODCAST_RELEASE=sha-<short> wiring for Sentry release grouping).
+#
+# Operator prerequisites (#714):
+#   - secrets: TS_OAUTH_CLIENT_ID, TS_OAUTH_CLIENT_SECRET
+#   - vars:    PROD_TAILNET_FQDN (e.g. "prod-podcast.example.ts.net")
+
+on:
+  workflow_dispatch:
+    inputs:
+      override_image_sha:
+        description: "Image :sha-<7> tag to deploy (blank = current main HEAD short SHA)"
+        required: false
+        default: ""
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  # Serialize prod deploys. A second deploy waits for the first; we don't
+  # cancel-in-progress because cancelling mid-`compose up` leaves the stack
+  # in an unknown state.
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Pre-flight — required secrets/variables present?
+        id: preflight
+        env:
+          TS_OAUTH_CLIENT_ID:     ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_CLIENT_SECRET: ${{ secrets.TS_OAUTH_CLIENT_SECRET }}
+          PROD_TAILNET_FQDN:      ${{ vars.PROD_TAILNET_FQDN }}
+        run: |
+          set -euo pipefail
+          MISSING=""
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ]     && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_CLIENT_SECRET:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_SECRET"
+          [ -z "${PROD_TAILNET_FQDN:-}" ]      && MISSING="$MISSING PROD_TAILNET_FQDN"
+          if [ -n "$MISSING" ]; then
+            echo "::warning::Missing prereqs:$MISSING"
+            echo "::warning::Stage them per #714 then re-run this workflow."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve target image SHA
+        id: sha
+        if: steps.preflight.outputs.skip != 'true'
+        run: |
+          SHA_SHORT="${{ github.event.inputs.override_image_sha }}"
+          if [ -z "$SHA_SHORT" ]; then
+            SHA_SHORT=$(echo "${{ github.event.workflow_run.head_sha || github.sha }}" | cut -c1-7)
+          fi
+          echo "short=$SHA_SHORT" >> "$GITHUB_OUTPUT"
+          echo "::notice::Deploying image tag sha-$SHA_SHORT"
+
+      - name: Join the tailnet
+        if: steps.preflight.outputs.skip != 'true'
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret:    ${{ secrets.TS_OAUTH_CLIENT_SECRET }}
+          tags:            tag:gha-deployer
+          version:         latest
+
+      - name: Wire PODCAST_RELEASE into host .env (#721 — Sentry release grouping)
+        # Idempotent: prior PODCAST_RELEASE=... line is removed before the new
+        # one is appended, so re-runs don't accumulate duplicates.
+        # init_sentry() already reads PODCAST_RELEASE per
+        # src/podcast_scraper/utils/sentry_init.py, so no app code change needed.
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          SHA_SHORT:  ${{ steps.sha.outputs.short }}
+          SSH_TARGET: deploy@${{ vars.PROD_TAILNET_FQDN }}
+        run: |
+          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+            "sudo sed -i '/^PODCAST_RELEASE=/d' /srv/podcast-scraper/.env && \
+             echo 'PODCAST_RELEASE=sha-${SHA_SHORT}' | sudo tee -a /srv/podcast-scraper/.env >/dev/null"
+
+      - name: Deploy (git pull + compose pull + compose up + VPS-local /api/health)
+        # deploy.sh on the VPS exits 0 only on healthy stack — failures here
+        # surface red within the SSH session.
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          SSH_TARGET: deploy@${{ vars.PROD_TAILNET_FQDN }}
+        run: |
+          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+            '/srv/podcast-scraper/infra/deploy/deploy.sh'
+
+      - name: External /api/health probe over Tailscale (#720)
+        # Belt-and-suspenders: the VPS-local probe in deploy.sh confirms the
+        # api answers on 127.0.0.1; this probes via tailnet MagicDNS to also
+        # catch any Tailscale-routing/cert issue. 60s timeout (12 × 5s).
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          PROBE_URL: https://${{ vars.PROD_TAILNET_FQDN }}/api/health
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 12); do
+            if curl -fsS "$PROBE_URL" | jq -e '.status == "ok"' >/dev/null 2>&1; then
+              echo "::notice::/api/health OK over tailnet after $((i * 5))s"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::/api/health did not return ok within 60s over tailnet"
+          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+            "deploy@${{ vars.PROD_TAILNET_FQDN }}" \
+            'docker logs --tail 50 compose-api-1' 2>&1 || true
+          exit 1

--- a/.github/workflows/infra-apply.yml
+++ b/.github/workflows/infra-apply.yml
@@ -1,0 +1,127 @@
+name: Infra apply (manual)
+
+# RFC-082 Decision 6 — GitOps loop, apply side. Manual dispatch only (NOT
+# auto on merge) so a typo in main.tf can't accidentally tofu destroy prod.
+# The PR's plan comment (from infra-ci.yml) is the preview; this is the
+# explicit "yes, do it" gate.
+#
+# Closes #719 (apply half).
+#
+# State persistence model: this workflow uploads the post-apply
+# `terraform.tfstate.enc` as a workflow artifact (30-day retention). The
+# operator downloads it and commits to main manually. Auto-commit-back is
+# deferred to a follow-up (needs branch-protection bypass via PAT or
+# deploy key, which adds vendor surface).
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "APPLY" to confirm you want to apply'
+        required: true
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: infra-apply
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Use a `prod` Environment so the operator can configure required-reviewer
+    # protection in repo Settings → Environments → prod. If the environment
+    # doesn't exist, GitHub creates it on first run with no protection — the
+    # operator should add themselves as a required reviewer post-merge.
+    environment: prod
+    steps:
+      - name: Confirm input
+        run: |
+          if [ "${{ github.event.inputs.confirm }}" != "APPLY" ]; then
+            echo "::error::Must type APPLY to confirm. Got: '${{ github.event.inputs.confirm }}'"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v5
+
+      - name: Pre-flight — required secrets present?
+        env:
+          HCLOUD_TOKEN:           ${{ secrets.HCLOUD_TOKEN }}
+          TS_OAUTH_CLIENT_ID:     ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_CLIENT_SECRET: ${{ secrets.TS_OAUTH_CLIENT_SECRET }}
+          TFSTATE_AGE_KEY:        ${{ secrets.TFSTATE_AGE_KEY }}
+        run: |
+          set -euo pipefail
+          MISSING=""
+          [ -z "${HCLOUD_TOKEN:-}" ]           && MISSING="$MISSING HCLOUD_TOKEN"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ]     && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_CLIENT_SECRET:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_SECRET"
+          [ -z "${TFSTATE_AGE_KEY:-}" ]        && MISSING="$MISSING TFSTATE_AGE_KEY"
+          if [ -n "$MISSING" ]; then
+            echo "::error::Missing prereqs:$MISSING. Stage them per #714 first."
+            exit 1
+          fi
+
+      - name: Install OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.6.0
+
+      - name: Install sops + age
+        run: |
+          set -euo pipefail
+          sudo curl -fsSL -o /usr/local/bin/sops \
+            https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64
+          sudo chmod +x /usr/local/bin/sops
+          curl -fsSL https://github.com/FiloSottile/age/releases/download/v1.2.1/age-v1.2.1-linux-amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin --strip-components=1 age/age age/age-keygen
+
+      - name: Decrypt state (if any prior apply has happened)
+        env:
+          SOPS_AGE_KEY: ${{ secrets.TFSTATE_AGE_KEY }}
+        run: |
+          if [ -f infra/terraform/terraform.tfstate.enc ]; then
+            sops -d infra/terraform/terraform.tfstate.enc > infra/terraform/terraform.tfstate
+          fi
+
+      - name: tofu init + apply
+        working-directory: infra/terraform
+        env:
+          TF_VAR_hcloud_token:                  ${{ secrets.HCLOUD_TOKEN }}
+          TF_VAR_tailscale_oauth_client_id:     ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TF_VAR_tailscale_oauth_client_secret: ${{ secrets.TS_OAUTH_CLIENT_SECRET }}
+          TF_VAR_ssh_public_key:                ${{ vars.OPERATOR_SSH_PUBLIC_KEY }}
+          TF_VAR_tailscale_tailnet:             ${{ vars.TAILNET_NAME }}
+        run: |
+          tofu init -input=false
+          tofu apply -auto-approve -input=false
+
+      - name: Re-encrypt state (always — even if apply failed; preserves partial state)
+        if: always()
+        env:
+          SOPS_AGE_KEY: ${{ secrets.TFSTATE_AGE_KEY }}
+        run: |
+          if [ -f infra/terraform/terraform.tfstate ]; then
+            sops -e infra/terraform/terraform.tfstate > infra/terraform/terraform.tfstate.enc.new
+            mv infra/terraform/terraform.tfstate.enc.new infra/terraform/terraform.tfstate.enc
+          fi
+
+      - name: Upload new encrypted state as artifact
+        # OPERATOR: download terraform.tfstate.enc from this run's artifacts
+        # and commit to main. Auto-commit-back is a future follow-up
+        # (needs PAT or deploy key with branch-protection bypass).
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-state-after-apply
+          path: infra/terraform/terraform.tfstate.enc
+          retention-days: 30
+
+      - name: Cleanup plaintext state
+        if: always()
+        run: |
+          shred -u infra/terraform/terraform.tfstate 2>/dev/null \
+            || rm -f infra/terraform/terraform.tfstate

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -1,0 +1,136 @@
+name: Infra CI
+
+# RFC-082 Decision 6 — GitOps loop, PR side. On any PR touching infra/** or
+# tailscale/policy.hujson, run `tofu fmt -check && validate && plan` and post
+# the plan as a PR comment so the reviewer sees what `tofu apply` would do.
+#
+# Closes #719 (PR-CI half). The infra-apply.yml workflow handles the manual
+# dispatch side.
+#
+# Operator prerequisites (#714):
+#   secrets: HCLOUD_TOKEN, TS_OAUTH_CLIENT_ID, TS_OAUTH_CLIENT_SECRET,
+#            TFSTATE_AGE_KEY
+#   vars:    OPERATOR_SSH_PUBLIC_KEY, TAILNET_NAME
+
+on:
+  pull_request:
+    paths:
+      - 'infra/**'
+      - 'tailscale/policy.hujson'
+
+permissions:
+  contents: read
+  pull-requests: write  # required to post the plan comment
+
+concurrency:
+  group: infra-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Pre-flight — required secrets present?
+        id: preflight
+        env:
+          HCLOUD_TOKEN:           ${{ secrets.HCLOUD_TOKEN }}
+          TS_OAUTH_CLIENT_ID:     ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_CLIENT_SECRET: ${{ secrets.TS_OAUTH_CLIENT_SECRET }}
+          TFSTATE_AGE_KEY:        ${{ secrets.TFSTATE_AGE_KEY }}
+        run: |
+          set -euo pipefail
+          MISSING=""
+          [ -z "${HCLOUD_TOKEN:-}" ]           && MISSING="$MISSING HCLOUD_TOKEN"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ]     && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_CLIENT_SECRET:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_SECRET"
+          [ -z "${TFSTATE_AGE_KEY:-}" ]        && MISSING="$MISSING TFSTATE_AGE_KEY"
+          if [ -n "$MISSING" ]; then
+            echo "::warning::Missing prereqs:$MISSING — skipping live plan."
+            echo "::warning::Stage them per #714 to enable PR-time tofu plan."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install OpenTofu
+        if: steps.preflight.outputs.skip != 'true'
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.6.0
+
+      - name: Install sops + age
+        if: steps.preflight.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          sudo curl -fsSL -o /usr/local/bin/sops \
+            https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64
+          sudo chmod +x /usr/local/bin/sops
+          curl -fsSL https://github.com/FiloSottile/age/releases/download/v1.2.1/age-v1.2.1-linux-amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin --strip-components=1 age/age age/age-keygen
+
+      - name: tofu fmt -check
+        if: steps.preflight.outputs.skip != 'true'
+        working-directory: infra/terraform
+        run: tofu fmt -check -diff
+
+      - name: tofu init + validate
+        if: steps.preflight.outputs.skip != 'true'
+        working-directory: infra/terraform
+        run: |
+          tofu init -input=false
+          tofu validate
+
+      - name: Decrypt state (if any prior apply has happened)
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          SOPS_AGE_KEY: ${{ secrets.TFSTATE_AGE_KEY }}
+        run: |
+          if [ -f infra/terraform/terraform.tfstate.enc ]; then
+            sops -d infra/terraform/terraform.tfstate.enc > infra/terraform/terraform.tfstate
+          fi
+
+      - name: tofu plan
+        if: steps.preflight.outputs.skip != 'true'
+        id: plan
+        working-directory: infra/terraform
+        env:
+          TF_VAR_hcloud_token:                  ${{ secrets.HCLOUD_TOKEN }}
+          TF_VAR_tailscale_oauth_client_id:     ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TF_VAR_tailscale_oauth_client_secret: ${{ secrets.TS_OAUTH_CLIENT_SECRET }}
+          TF_VAR_ssh_public_key:                ${{ vars.OPERATOR_SSH_PUBLIC_KEY }}
+          TF_VAR_tailscale_tailnet:             ${{ vars.TAILNET_NAME }}
+        run: |
+          set +e
+          tofu plan -no-color -input=false 2>&1 | tee plan.txt
+          PLAN_EXIT="${PIPESTATUS[0]}"
+          # Cap to GitHub's 65k comment-body limit, leaving headroom for our wrapper.
+          head -c 60000 plan.txt > plan.trunc.txt
+          exit "$PLAN_EXIT"
+
+      - name: Post plan as PR comment
+        if: steps.preflight.outputs.skip != 'true' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let plan;
+            try { plan = fs.readFileSync('infra/terraform/plan.trunc.txt', 'utf8'); }
+            catch (e) { plan = '(plan output unavailable — see workflow logs)'; }
+            const body = '## OpenTofu plan\n\n```\n' + plan + '\n```\n\n' +
+                         '_Workflow run: ' + context.runId + '_';
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });
+
+      - name: Cleanup plaintext state
+        if: always() && steps.preflight.outputs.skip != 'true'
+        run: |
+          shred -u infra/terraform/terraform.tfstate 2>/dev/null \
+            || rm -f infra/terraform/terraform.tfstate
+          rm -f infra/terraform/plan.bin infra/terraform/plan.txt infra/terraform/plan.trunc.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,32 @@ These are the patterns where you have failed this user repeatedly:
 4. When the user is frustrated, stop proposing actions; acknowledge and wait.
 5. Read what was last asked, not what you think makes sense.
 6. Validate the cost of an action before taking it (does it restart CI? does it push? does it require approval?).
+7. **Make commands MUST be assessable at the end.** ALWAYS invoke `make` with an exit-code terminator from the start, so the LAST line of output unambiguously says PASS/FAIL. NEVER re-run a `make` command "to check the exit code". See [How to run make commands](#how-to-run-make-commands) below.
+
+## How to run make commands
+
+You repeatedly burn 5–10 minutes by running `make ci-fast` (or any other long `make` target), failing to extract the exit status from the output, then re-running it "to verify". This is a permanent prohibition.
+
+**The rule: every `make <target>` invocation MUST end with an exit-code terminator from the very first run, so PASS/FAIL is the last visible line.** Choose ONE form per call:
+
+```bash
+# Form A — the default, always-safe form. Last line is "MAKE_EXIT=0" or "MAKE_EXIT=N".
+make <target>; echo "MAKE_EXIT=$?"
+
+# Form B — single-shot interpretable terminator. Last line is "PASS" or "FAIL N".
+make <target> && echo "PASS" || echo "FAIL $?"
+```
+
+**Why both lines instead of trusting the prior output:** `make` exits non-zero on the first failing subtarget but the FINAL printed line of a long run is whatever the last subtarget happened to print (often a build success message even when an earlier step failed). The output's *trailing prose* is NOT the exit code. Without the explicit terminator, you cannot tell PASS from FAIL by inspection — and you should NOT re-run the whole target to find out.
+
+**Forbidden:**
+
+- Running `make X` without an exit-code terminator, then running it again "to check".
+- Piping `make X` through `tail`, `grep`, `head` without `set -o pipefail` AND an exit-code echo at the end.
+- Treating "no obvious error in the last 60 lines" as PASS. Inspect the explicit `MAKE_EXIT=` / `PASS` / `FAIL` line.
+- Re-running `make ci-fast` to "verify the exit code" of a previous run. If the prior run lacked the terminator, that is on you — work with what you have, ask the user, or grep the prior output for explicit failure markers. Do NOT spend another 10 minutes.
+
+**On a failing `make ci-fast`:** identify the failing SUBTARGET (docs / lint / format / test / etc.) and validate the fix by re-running ONLY that subtarget — `make docs` is 10 s, `make ci-fast` is 10 min. Then run `make ci-fast` ONCE at the very end as the whole-gate confirmation. (See `feedback_no_redundant_ci_fast.md` and `feedback_subtarget_reverify.md` in user memory.)
 
 ## Reference files (load on demand)
 

--- a/compose/docker-compose.vps-prod.yml
+++ b/compose/docker-compose.vps-prod.yml
@@ -8,6 +8,7 @@
 #
 # Adds:
 #   - VPS-flavored nginx (basic-auth + landing page) over the viewer's default
+#   - landing page bind-mounted into nginx's docroot (so /welcome resolves)
 #   - .htpasswd bind-mount from /srv/podcast-scraper/.htpasswd (operator-staged)
 
 services:
@@ -16,6 +17,10 @@ services:
       # Auth-enabled nginx config replaces the auth-free default that's baked
       # into the published image.
       - ../docker/viewer/nginx-prod.conf:/etc/nginx/conf.d/default.conf:ro
+      # Landing page for the public /welcome route. Bind-mounted (not COPY'd
+      # into the published viewer image) so the prod-only landing surface
+      # doesn't leak into Codespaces or alter the image's contents.
+      - ../docker/viewer/landing.html:/usr/share/nginx/html/landing.html:ro
       # The htpasswd file. Operator generates it on the host with:
       #   htpasswd -bcB /srv/podcast-scraper/.htpasswd <user> <pass>
       # See docs/guides/PROD_RUNBOOK.md "Basic-auth credentials" section.

--- a/compose/docker-compose.vps-prod.yml
+++ b/compose/docker-compose.vps-prod.yml
@@ -1,0 +1,22 @@
+# VPS-prod-only overlay (RFC-082 + #713).
+#
+# Layered ON TOP of docker-compose.stack.yml + docker-compose.prod.yml when
+# the stack runs on the always-on Hetzner VPS. Used by infra/deploy/deploy.sh
+# and the systemd unit in infra/cloud-init/prod.user-data; NOT used by
+# Codespaces (pre-prod), which sticks with stack + prod only and keeps the
+# auth-free default nginx config.
+#
+# Adds:
+#   - VPS-flavored nginx (basic-auth + landing page) over the viewer's default
+#   - .htpasswd bind-mount from /srv/podcast-scraper/.htpasswd (operator-staged)
+
+services:
+  viewer:
+    volumes:
+      # Auth-enabled nginx config replaces the auth-free default that's baked
+      # into the published image.
+      - ../docker/viewer/nginx-prod.conf:/etc/nginx/conf.d/default.conf:ro
+      # The htpasswd file. Operator generates it on the host with:
+      #   htpasswd -bcB /srv/podcast-scraper/.htpasswd <user> <pass>
+      # See docs/guides/PROD_RUNBOOK.md "Basic-auth credentials" section.
+      - ${PODCAST_HTPASSWD_PATH:-/srv/podcast-scraper/.htpasswd}:/etc/nginx/.htpasswd:ro

--- a/docker/viewer/landing.html
+++ b/docker/viewer/landing.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <title>podcast_scraper</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --fg: #1a1a1a;
+      --fg-muted: #5a5a5a;
+      --bg: #fafafa;
+      --accent: #2c5282;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --fg: #f0f0f0;
+        --fg-muted: #b0b0b0;
+        --bg: #1a1a1a;
+        --accent: #63b3ed;
+      }
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      color: var(--fg);
+      background: var(--bg);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+    }
+    main {
+      max-width: 28rem;
+      text-align: center;
+    }
+    h1 {
+      font-size: 1.75rem;
+      font-weight: 600;
+      margin: 0 0 0.5rem;
+      letter-spacing: -0.01em;
+    }
+    p {
+      color: var(--fg-muted);
+      line-height: 1.5;
+      margin: 0 0 2rem;
+    }
+    a.cta {
+      display: inline-block;
+      padding: 0.75rem 1.5rem;
+      background: var(--accent);
+      color: white;
+      text-decoration: none;
+      border-radius: 0.5rem;
+      font-weight: 500;
+      transition: opacity 0.15s;
+    }
+    a.cta:hover { opacity: 0.85; }
+    .hint {
+      margin-top: 1.5rem;
+      font-size: 0.875rem;
+      color: var(--fg-muted);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>podcast_scraper</h1>
+    <p>Knowledge-graph viewer for podcast transcripts. Access requires credentials.</p>
+    <a class="cta" href="/">Open viewer →</a>
+    <p class="hint">You'll be prompted for a username and password.</p>
+  </main>
+</body>
+</html>

--- a/docker/viewer/nginx-prod.conf
+++ b/docker/viewer/nginx-prod.conf
@@ -1,0 +1,76 @@
+# Production nginx config for the always-on Hetzner VPS deploy (RFC-082 + #713).
+# Mounted by compose/docker-compose.vps-prod.yml over /etc/nginx/conf.d/default.conf,
+# so this only activates on prod — Codespaces (pre-prod) keeps the auth-free
+# default at docker/viewer/nginx.conf.
+#
+# Adds HTTP Basic Auth on the SPA + api with a public landing page at /welcome.
+
+upstream api_backend {
+    server api:8000;
+    keepalive 32;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json application/xml image/svg+xml;
+    gzip_min_length 256;
+
+    # === Public landing page (no auth) ===
+    # Operator hands non-tailnet visitors this URL; click-through to / prompts
+    # for basic-auth creds.
+    location = /welcome {
+        auth_basic off;
+        root /usr/share/nginx/html;
+        try_files /landing.html =404;
+    }
+
+    # Vite hashed assets — safe to cache aggressively, safe to leave un-gated.
+    # The bundle filenames don't leak any info beyond "this is a Vue app".
+    location ^~ /assets/ {
+        auth_basic off;
+        root /usr/share/nginx/html;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # Health endpoint left unauthed so deploy-prod.yml's external probe
+    # (#720) can hit it without sending Authorization headers.
+    location = /api/health {
+        auth_basic off;
+        proxy_pass http://api_backend/api/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
+    # === Authenticated zone — everything else needs basic-auth ===
+    # .htpasswd is bind-mounted from the host's /srv/podcast-scraper/.htpasswd
+    # by compose/docker-compose.vps-prod.yml. Generate with:
+    #   htpasswd -bcB /srv/podcast-scraper/.htpasswd <user> <pass>
+    # See PROD_RUNBOOK.md for the full operator runbook.
+
+    location /api/ {
+        auth_basic           "podcast_scraper";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+
+        proxy_pass http://api_backend/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 120s;
+        proxy_read_timeout 120s;
+    }
+
+    location / {
+        auth_basic           "podcast_scraper";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docs/guides/PROD_RUNBOOK.md
+++ b/docs/guides/PROD_RUNBOOK.md
@@ -1,0 +1,413 @@
+# Prod runbook (always-on Hetzner VPS)
+
+Operator-facing runbook for the production deploy defined in
+[RFC-082](../rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md). The RFC
+describes *what we decided*; this runbook describes *what to do today*.
+
+> **For the prerequisites checklist** (Hetzner account + Tailscale OAuth +
+> sops/age + GHA secrets), see [#714](https://github.com/chipi/podcast_scraper/issues/714).
+> All commands below assume those are done.
+
+## Sections
+
+1. [First-time bootstrap](#first-time-bootstrap)
+2. [Daily operations](#daily-operations)
+3. [Basic-auth credentials](#basic-auth-credentials)
+4. [Corpus migration from pre-prod (Codespace) to prod (VPS)](#corpus-migration)
+5. [Rollback (deploy went red mid-way)](#rollback)
+6. [Disaster recovery (VPS gone)](#disaster-recovery)
+7. [Credential rotation](#credential-rotation)
+
+---
+
+## First-time bootstrap
+
+One-shot setup that takes prod from "nothing" to "viewer reachable on the
+tailnet". ~30–45 min wall.
+
+### Pre-bootstrap (one-time, on operator's laptop)
+
+```bash
+# 1. Tools
+brew install opentofu sops age actionlint shellcheck
+gh auth login
+
+# 2. age keypair for sops state encryption
+age-keygen -o ~/.config/sops/age/keys.txt
+# Copy the public key (the `# public key:` line) into infra/.sops.yaml,
+# replacing the `age1PLACEHOLDER…` value. Save the PRIVATE key contents to
+# 1Password as `sops/podcast-scraper/tofu-state-age-key`.
+
+# 3. Stage GHA secrets (from #714)
+gh secret set HCLOUD_TOKEN          --repo chipi/podcast_scraper --app actions --body '<token>'
+gh secret set TS_OAUTH_CLIENT_ID    --repo chipi/podcast_scraper --app actions --body '<id>'
+gh secret set TS_OAUTH_CLIENT_SECRET --repo chipi/podcast_scraper --app actions --body '<secret>'
+gh secret set TFSTATE_AGE_KEY       --repo chipi/podcast_scraper --app actions --body "$(cat ~/.config/sops/age/keys.txt)"
+gh secret set BACKUP_REPO_TOKEN     --repo chipi/podcast_scraper --app actions --body '<backup-repo-pat>'
+
+# 4. Stage GHA repo variables
+gh variable set OPERATOR_SSH_PUBLIC_KEY --repo chipi/podcast_scraper --body "$(cat ~/.ssh/id_ed25519.pub)"
+gh variable set TAILNET_NAME            --repo chipi/podcast_scraper --body 'tail-xxxxx.ts.net'
+# PROD_TAILNET_FQDN is set after first apply (it depends on the assigned hostname);
+# default value is "prod-podcast.<TAILNET_NAME>".
+```
+
+### First `tofu apply` (operator's laptop)
+
+```bash
+cd infra
+export HCLOUD_TOKEN=$(op read 'op://Personal/Hetzner Cloud/podcast-scraper-prod/api-token')
+export TF_VAR_hcloud_token="$HCLOUD_TOKEN"
+export TF_VAR_tailscale_oauth_client_id=$(op read 'op://Personal/Tailscale/podcast-scraper/gha-deployer-oauth/client-id')
+export TF_VAR_tailscale_oauth_client_secret=$(op read 'op://Personal/Tailscale/podcast-scraper/gha-deployer-oauth/client-secret')
+export TF_VAR_tailscale_tailnet="tail-xxxxx.ts.net"   # your tailnet
+export TF_VAR_ssh_public_key="$(cat ~/.ssh/id_ed25519.pub)"
+
+./tofu init
+./tofu plan
+./tofu apply
+# Outputs: server_id, ipv4_address, tailnet_url, ssh_target.
+```
+
+**Expected resources (per [#716](https://github.com/chipi/podcast_scraper/issues/716)):**
+1 server + 1 firewall + 1 network + 1 SSH key + 1 Tailscale auth key, plus an
+optional Volume + attachment if `volume_size_gb > 0`.
+
+After apply, set the GHA variable:
+
+```bash
+gh variable set PROD_TAILNET_FQDN --repo chipi/podcast_scraper \
+  --body "prod-podcast.tail-xxxxx.ts.net"
+```
+
+### Stage the host-side `.env` (one-time, post-apply)
+
+The `.env` holds runtime secrets (provider API keys, Grafana credentials,
+Sentry DSN). Cloud-init drops a sentinel file `/srv/podcast-scraper/.bootstrap-needs-env`;
+the systemd unit refuses to start while it exists.
+
+```bash
+ssh deploy@prod-podcast.tail-xxxxx.ts.net   # over Tailscale
+sudo install -o deploy -g deploy -m 600 /dev/stdin /srv/podcast-scraper/.env <<'ENV'
+OPENAI_API_KEY=sk-...
+GEMINI_API_KEY=...
+ANTHROPIC_API_KEY=sk-ant-...
+GRAFANA_CLOUD_PROM_URL=...
+GRAFANA_CLOUD_LOKI_URL=...
+GRAFANA_CLOUD_USER=...
+GRAFANA_CLOUD_API_KEY=...
+PODCAST_SENTRY_DSN_API=...
+PODCAST_SENTRY_DSN_PIPELINE=...
+PODCAST_ENV=prod
+PODCAST_AVAILABLE_PROFILES=cloud_balanced,cloud_thin
+PODCAST_DEFAULT_PROFILE=cloud_balanced
+ENV
+
+# Stage the basic-auth password file too (see #Basic-auth credentials below).
+sudo htpasswd -bcB /srv/podcast-scraper/.htpasswd <user> <pass>
+sudo chown root:docker /srv/podcast-scraper/.htpasswd
+sudo chmod 640         /srv/podcast-scraper/.htpasswd
+
+# Release the systemd gate.
+sudo rm /srv/podcast-scraper/.bootstrap-needs-env
+sudo systemctl restart podcast-scraper.service
+```
+
+### Smoke validation
+
+```bash
+# 1. Tailnet reachability
+curl -fsS https://prod-podcast.tail-xxxxx.ts.net/api/health | jq .
+# Expected: {"status":"ok","feeds_api":true,...}
+
+# 2. Basic auth (closes #713 verification)
+curl -i https://prod-podcast.tail-xxxxx.ts.net/                     # expect 401
+curl -i https://prod-podcast.tail-xxxxx.ts.net/welcome              # expect 200 + landing.html
+curl -fsS -u user:pass https://prod-podcast.tail-xxxxx.ts.net/      # expect 200 + SPA HTML
+
+# 3. grafana-agent shipping
+ssh deploy@prod-podcast.tail-xxxxx.ts.net 'docker logs compose-grafana-agent-1 --tail 20'
+
+# 4. Sentry validation ping
+ssh deploy@prod-podcast.tail-xxxxx.ts.net \
+  'docker exec compose-api-1 python -c "
+from podcast_scraper.utils.sentry_init import init_sentry
+import sentry_sdk; init_sentry(\"api\")
+sentry_sdk.capture_message(\"prod bootstrap validation ping\", level=\"info\")
+"'
+# Check sentry.io within ~1 min for the event under environment=prod.
+
+# 5. Grafana Cloud query (~30 s after agent's first scrape)
+#    https://<org>.grafana.net → Explore → Prometheus
+#    Query:  up{component="api",env="prod"}
+#    Expected: 1 series, value=1
+```
+
+### Trigger the first deploy
+
+```bash
+gh workflow run deploy-prod.yml --repo chipi/podcast_scraper
+gh run watch --repo chipi/podcast_scraper
+```
+
+Once a few green deploys have passed and you trust the loop, file the
+follow-up PR that flips `deploy-prod.yml` to also auto-trigger on
+`workflow_run: ["Stack test"]` (RFC-082 Decision 6 GitOps loop).
+
+---
+
+## Daily operations
+
+### Where to look first
+
+| Symptom | Where |
+| --- | --- |
+| Viewer slow / unreachable | `gh run list --workflow deploy-prod.yml --limit 3` then Sentry → environment=prod |
+| Pipeline run failing | Sentry → environment=prod, component=pipeline; viewer Library → Job logs |
+| Deploy went red | GHA UI → Deploy to prod VPS → most recent run; api logs are dumped on health-check failure |
+| "Did the alert fire because of X?" | Grafana Cloud → podcast-scraper folder → filter `env=prod` |
+
+### Manual deploy
+
+```bash
+gh workflow run deploy-prod.yml --repo chipi/podcast_scraper \
+  -f override_image_sha=                       # blank = deploy current main
+# or pin to a specific image:
+gh workflow run deploy-prod.yml --repo chipi/podcast_scraper \
+  -f override_image_sha=abc1234
+```
+
+### Pipeline run via the viewer
+
+Standard flow — open the viewer, hit Configuration → Run pipeline. Same
+control plane as pre-prod. Profile dropdown is restricted to
+`cloud_balanced,cloud_thin` (no ML profiles in prod, per RFC-082).
+
+### Backup status
+
+```bash
+gh run list --workflow backup-corpus-prod.yml --repo chipi/podcast_scraper --limit 5
+gh release list --repo chipi/podcast_scraper-backup --limit 10 | grep snapshot-prod-
+```
+
+---
+
+## Basic-auth credentials
+
+The viewer is gated by HTTP Basic Auth (#713). Credentials are stored in
+`/srv/podcast-scraper/.htpasswd` on the VPS; nginx reads via the bind-mount
+in `compose/docker-compose.vps-prod.yml`.
+
+### Initial setup
+
+```bash
+ssh deploy@prod-podcast.tail-xxxxx.ts.net
+sudo htpasswd -bcB /srv/podcast-scraper/.htpasswd <user> <pass>
+sudo chown root:docker /srv/podcast-scraper/.htpasswd
+sudo chmod 640         /srv/podcast-scraper/.htpasswd
+sudo systemctl restart podcast-scraper.service   # picks up the new file
+```
+
+The `-c` flag CREATES the file (overwrites if present). Use `-b` only on
+subsequent invocations to add/update users without erasing existing ones.
+
+### Add a collaborator
+
+```bash
+ssh deploy@prod-podcast.tail-xxxxx.ts.net
+sudo htpasswd -bB /srv/podcast-scraper/.htpasswd <new-user> <new-pass>   # NO -c
+sudo systemctl restart podcast-scraper.service
+```
+
+### Remove a user
+
+```bash
+ssh deploy@prod-podcast.tail-xxxxx.ts.net
+sudo htpasswd -D /srv/podcast-scraper/.htpasswd <user>
+sudo systemctl restart podcast-scraper.service
+```
+
+### Programmatic callers
+
+Home Assistant, Slack→GHA→api, and other headless callers send standard
+HTTP Basic Auth headers:
+
+```bash
+curl -fsS -u "$HA_USER:$HA_PASS" https://prod-podcast.tail-xxxxx.ts.net/api/jobs
+```
+
+`/api/health` is intentionally left unauthed so the deploy workflow's external
+probe (#720) can hit it without juggling credentials.
+
+---
+
+## Corpus migration
+
+One-time migration on cutover day. Use the latest snapshot from the backup
+repo rather than streaming files between hosts (more reliable; matches RFC-082
+Decision 4).
+
+```bash
+ssh deploy@prod-podcast.tail-xxxxx.ts.net
+cd /srv/podcast-scraper
+make restore-corpus               # pulls latest snapshot.tgz from
+                                  # chipi/podcast_scraper-backup, untars
+                                  # into /srv/podcast-scraper/corpus/
+
+# Verify
+ls -la corpus/feeds/ | head
+find corpus -name '*.gi.json' | wc -l
+docker compose -f compose/docker-compose.stack.yml \
+               -f compose/docker-compose.prod.yml \
+               -f compose/docker-compose.vps-prod.yml \
+  restart api viewer
+
+# In the viewer (over Tailscale): Library tab should now show all
+# episodes from the snapshot.
+```
+
+After cutover, future backups come from the VPS via
+[`backup-corpus-prod.yml`](https://github.com/chipi/podcast_scraper/blob/main/.github/workflows/backup-corpus-prod.yml).
+
+---
+
+## Rollback
+
+`deploy-prod.yml` runs `infra/deploy/deploy.sh`, which does
+`git pull && docker compose pull && docker compose up -d`. Three failure modes:
+
+### Failure 1: image pull failed (network blip / GHCR auth issue)
+
+**Symptom:** workflow's deploy step exits non-zero on `compose pull`.
+**Recovery:** re-run the workflow. No state changed; old containers still
+running with old images.
+
+### Failure 2: pull succeeded but a container won't start
+
+**Symptom:** workflow exits non-zero on `compose up`. New images on disk; old
+container gone (compose recreates by default).
+**Recovery:** SSH in, manually pin the previous image:
+
+```bash
+ssh deploy@prod-podcast.tail-xxxxx.ts.net
+cd /srv/podcast-scraper
+PODCAST_IMAGE_TAG=sha-<previous-good-short-sha> \
+  docker compose -f compose/docker-compose.stack.yml \
+                 -f compose/docker-compose.prod.yml \
+                 -f compose/docker-compose.vps-prod.yml \
+    up -d --remove-orphans
+```
+
+The `:sha-<short>` tags from the publish job are the rollback target — they're
+never garbage-collected.
+
+### Failure 3: stack up but functionally broken
+
+**Symptom:** workflow green, but operator notices the bug from the viewer.
+**Recovery:** same as Failure 2. Then file a bug + ship a fix-forward via the
+hotfix path.
+
+---
+
+## Disaster recovery
+
+If the Hetzner instance is irrecoverable (account issue, hardware failure,
+accidental `tofu destroy`):
+
+```bash
+# 1. Re-provision (~5–10 min)
+cd infra
+./tofu apply              # same hostname, same Tailscale registration
+                          # (cloud-init re-runs the bootstrap)
+
+# 2. Restore corpus (~3–5 min for ~20 MB snapshot)
+ssh deploy@prod-podcast.tail-xxxxx.ts.net 'cd /srv/podcast-scraper && make restore-corpus'
+
+# 3. Re-stage host-side .env  + .htpasswd (operator's responsibility)
+#    See "First-time bootstrap → Stage the host-side .env"
+#    and "Basic-auth credentials → Initial setup".
+
+# 4. Verify (~5 min)
+#    See "Smoke validation".
+```
+
+**Total wall time: ~15–20 min** assuming the operator knows the runbook.
+Corpus is recoverable to within ~24 h of pre-disaster state (last
+`backup-corpus-prod.yml` run).
+
+[#724](https://github.com/chipi/podcast_scraper/issues/724) tracks the
+end-to-end DR drill that calibrates these numbers against reality.
+
+---
+
+## Credential rotation
+
+### Hetzner API token
+
+1. Hetzner console → Security → API Tokens → Generate new (Read+Write).
+2. `gh secret set HCLOUD_TOKEN --repo chipi/podcast_scraper --app actions --body '<new>'`
+3. Update 1Password entry `Hetzner Cloud / podcast-scraper-prod / api-token`.
+4. Revoke the old token in the Hetzner console.
+5. Trigger one workflow_dispatch run of `infra-apply.yml` to confirm the new
+   token works (will be a no-op apply if no infra changes).
+
+### Tailscale OAuth client
+
+1. Tailscale admin → Settings → OAuth clients → Generate new (scope:
+   `devices:write`, tag: `tag:gha-deployer`).
+2. `gh secret set TS_OAUTH_CLIENT_ID --repo chipi/podcast_scraper --app actions --body '<new-id>'`
+3. `gh secret set TS_OAUTH_CLIENT_SECRET --repo chipi/podcast_scraper --app actions --body '<new-secret>'`
+4. Update 1Password.
+5. Revoke the old client in the Tailscale admin.
+6. Trigger one workflow_dispatch run of `deploy-prod.yml` to confirm.
+
+### age key (sops state)
+
+> **Caution:** the age key encrypts the OpenTofu state. Losing it without a
+> backup means the encrypted state in `infra/terraform/terraform.tfstate.enc`
+> is unrecoverable; you'd need to import all live Hetzner resources into a
+> fresh state. Always back the new key up before retiring the old one.
+
+1. Generate new keypair: `age-keygen -o ~/.config/sops/age/keys.txt.new`
+2. Decrypt current state with the OLD key, re-encrypt with the NEW key:
+
+   ```bash
+   cd infra
+   ./tofu state pull > /tmp/state.json   # via the wrapper, OLD key
+   # Update infra/.sops.yaml to the NEW public key
+   sops -e /tmp/state.json > infra/terraform/terraform.tfstate.enc
+   shred /tmp/state.json
+   ```
+
+3. `gh secret set TFSTATE_AGE_KEY --repo chipi/podcast_scraper --app actions --body "$(cat ~/.config/sops/age/keys.txt.new)"`
+4. Update 1Password (keep the OLD key for ~30 days as a safety net).
+5. After ~30 days of green CI, delete the OLD key.
+
+### Host `.env` secrets (provider API keys, Sentry DSN, etc.)
+
+```bash
+ssh deploy@prod-podcast.tail-xxxxx.ts.net
+sudo sed -i 's|^OPENAI_API_KEY=.*|OPENAI_API_KEY=<new>|' /srv/podcast-scraper/.env
+sudo systemctl restart podcast-scraper.service
+```
+
+For multiple keys, edit the `.env` directly: `sudo -e /srv/podcast-scraper/.env`.
+
+### Basic-auth password
+
+See [Basic-auth credentials → Add a collaborator](#basic-auth-credentials):
+overwrite the user with `htpasswd -bB`, then restart the service.
+
+---
+
+## Cross-references
+
+- [RFC-082 — design](../rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md)
+- [`infra/`](https://github.com/chipi/podcast_scraper/tree/main/infra) — IaC code
+- [`tailscale/policy.hujson`](https://github.com/chipi/podcast_scraper/blob/main/tailscale/policy.hujson) — ACL
+- [`.github/workflows/deploy-prod.yml`](https://github.com/chipi/podcast_scraper/blob/main/.github/workflows/deploy-prod.yml)
+- [`.github/workflows/infra-apply.yml`](https://github.com/chipi/podcast_scraper/blob/main/.github/workflows/infra-apply.yml) — manual apply gate
+- [`.github/workflows/backup-corpus-prod.yml`](https://github.com/chipi/podcast_scraper/blob/main/.github/workflows/backup-corpus-prod.yml)
+- [#714](https://github.com/chipi/podcast_scraper/issues/714) — account prereqs checklist
+- [#723](https://github.com/chipi/podcast_scraper/issues/723) — Phase B cutover
+- [#724](https://github.com/chipi/podcast_scraper/issues/724) — DR drill

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,10 @@
+# Never commit plaintext OpenTofu state — only the .enc version belongs in git.
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup
+terraform/.terraform/
+terraform/*.tfplan
+terraform/*.tfplan.bin
+
+# Local operator overrides (host .env staging, scratch notes)
+.env.local
+.scratch/

--- a/infra/.sops.yaml
+++ b/infra/.sops.yaml
@@ -1,0 +1,9 @@
+# sops + age encryption config for OpenTofu state.
+# See infra/README.md for operator setup; full flow in docs/guides/PROD_RUNBOOK.md.
+
+creation_rules:
+  - path_regex: 'infra/terraform/.*\.tfstate$'
+    # OPERATOR: replace with the public key from `age-keygen` (starts with "age1").
+    # The matching PRIVATE key lives in 1Password as
+    # `sops/podcast-scraper/tofu-state-age-key`.
+    age: 'age1PLACEHOLDER0REPLACE0WITH0OPERATOR0AGE0PUBLIC0KEY00000000000000000'

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,72 @@
+# `infra/` — production VPS infrastructure-as-code
+
+OpenTofu configuration that provisions the always-on production Hetzner VPS,
+registers it with the operator's Tailscale tailnet, and prepares it to run the
+podcast_scraper stack. Implements [RFC-082](../docs/rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md).
+
+## Layout
+
+```text
+infra/
+├── .sops.yaml                  # age public-key config for state encryption
+├── .gitignore                  # excludes plaintext state, plans, .terraform/
+├── tofu                        # wrapper script — handles sops decrypt/encrypt
+├── README.md                   # this file
+├── terraform/
+│   ├── *.tf                    # OpenTofu config (server, network, Tailscale)
+│   └── terraform.tfstate.enc   # sops+age-encrypted state (committed; appears
+│                               # after first apply)
+├── cloud-init/
+│   └── prod.user-data          # first-boot bootstrap (Docker, Tailscale, repo pull)
+└── deploy/
+    └── deploy.sh               # called by .github/workflows/deploy-prod.yml
+```
+
+## Quickstart
+
+> **Full operator runbook:** see [PROD_RUNBOOK.md](../docs/guides/PROD_RUNBOOK.md).
+> Account-prerequisite checklist: [#714](https://github.com/chipi/podcast_scraper/issues/714).
+
+One-time setup (per operator):
+
+1. `brew install opentofu sops age`
+2. `age-keygen -o ~/.config/sops/age/keys.txt`
+3. Copy the public key (the `# public key:` comment) into [`.sops.yaml`](.sops.yaml), replacing the `age1PLACEHOLDER…` value.
+4. Save the **private** key to 1Password as `sops/podcast-scraper/tofu-state-age-key`.
+5. Stage `HCLOUD_TOKEN`, `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_CLIENT_SECRET`, `TFSTATE_AGE_KEY` in repo Actions secrets (see [#714](https://github.com/chipi/podcast_scraper/issues/714)).
+
+Per-operation:
+
+```bash
+cd infra
+export HCLOUD_TOKEN=$(op read 'op://Personal/Hetzner Cloud/podcast-scraper-prod/api-token')
+export TF_VAR_tailscale_oauth_client_id=$(op read 'op://Personal/Tailscale/podcast-scraper/gha-deployer-oauth/client-id')
+export TF_VAR_tailscale_oauth_client_secret=$(op read 'op://Personal/Tailscale/podcast-scraper/gha-deployer-oauth/client-secret')
+./tofu init
+./tofu plan
+./tofu apply
+```
+
+The `tofu` wrapper auto-decrypts state before invocation and re-encrypts after.
+
+## State encryption model
+
+State lives at `terraform/terraform.tfstate.enc` (sops+age, committed). Plaintext
+**never** touches the repo or shell history. The wrapper:
+
+1. Decrypts `.enc` → `terraform/terraform.tfstate` (plaintext, for tofu only).
+2. Runs the requested subcommand against that plaintext file.
+3. Re-encrypts back to `.enc` if state changed (sha256 comparison).
+4. Shreds the plaintext on any exit (trap, including Ctrl-C).
+
+If the wrapper crashes mid-flight, check `git status infra/terraform/` and
+confirm no plaintext `.tfstate` is staged. If it is, **do NOT commit** — re-run
+`cd infra && ./tofu version` (a no-op invocation) to re-trigger the trap and
+clean up.
+
+## Cross-references
+
+- [RFC-082 — Decision 5: IaC](../docs/rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md)
+- [PROD_RUNBOOK.md](../docs/guides/PROD_RUNBOOK.md) — full operator runbook
+- [#716](https://github.com/chipi/podcast_scraper/issues/716) — this scaffolding ticket
+- [#719](https://github.com/chipi/podcast_scraper/issues/719) — `infra-ci.yml` (PR plan) and `infra-apply.yml` (manual apply) workflows

--- a/infra/cloud-init/prod.user-data
+++ b/infra/cloud-init/prod.user-data
@@ -50,8 +50,8 @@ write_files:
       WorkingDirectory=/srv/podcast-scraper
       EnvironmentFile=/srv/podcast-scraper/.env
       ExecStartPre=/usr/bin/test ! -e /srv/podcast-scraper/.bootstrap-needs-env
-      ExecStart=/usr/bin/docker compose -f compose/docker-compose.stack.yml -f compose/docker-compose.prod.yml up -d --remove-orphans
-      ExecStop=/usr/bin/docker compose -f compose/docker-compose.stack.yml -f compose/docker-compose.prod.yml down
+      ExecStart=/usr/bin/docker compose -f compose/docker-compose.stack.yml -f compose/docker-compose.prod.yml -f compose/docker-compose.vps-prod.yml up -d --remove-orphans
+      ExecStop=/usr/bin/docker compose -f compose/docker-compose.stack.yml -f compose/docker-compose.prod.yml -f compose/docker-compose.vps-prod.yml down
 
       [Install]
       WantedBy=multi-user.target

--- a/infra/cloud-init/prod.user-data
+++ b/infra/cloud-init/prod.user-data
@@ -1,0 +1,98 @@
+#cloud-config
+# First-boot bootstrap for podcast-scraper-prod (RFC-082 Decision 5).
+# Runs once on first boot; idempotent re-runs require manual reset.
+
+hostname: ${tailnet_hostname}
+manage_etc_hosts: true
+
+users:
+  - name: deploy
+    groups: docker
+    shell: /bin/bash
+    sudo: false
+    ssh_authorized_keys:
+      - ${ssh_public_key}
+
+package_update: true
+package_upgrade: true
+
+packages:
+  - ca-certificates
+  - curl
+  - gnupg
+  - lsb-release
+  - unattended-upgrades
+  - jq
+  - git
+
+write_files:
+  # Operator drops .env into /srv/podcast-scraper/.env after first boot, then
+  # `sudo rm` this sentinel to release the systemd unit. start.sh is gated
+  # on the file's absence (ExecStartPre).
+  - path: /srv/podcast-scraper/.bootstrap-needs-env
+    content: |
+      Operator: stage /srv/podcast-scraper/.env (mode 600, owner deploy:deploy)
+      then `sudo rm /srv/podcast-scraper/.bootstrap-needs-env` to start the stack.
+      See docs/guides/PROD_RUNBOOK.md for the .env shape.
+    permissions: '0644'
+    owner: root:root
+
+  - path: /etc/systemd/system/podcast-scraper.service
+    content: |
+      [Unit]
+      Description=podcast_scraper compose stack
+      Requires=docker.service
+      After=docker.service network-online.target tailscaled.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      WorkingDirectory=/srv/podcast-scraper
+      EnvironmentFile=/srv/podcast-scraper/.env
+      ExecStartPre=/usr/bin/test ! -e /srv/podcast-scraper/.bootstrap-needs-env
+      ExecStart=/usr/bin/docker compose -f compose/docker-compose.stack.yml -f compose/docker-compose.prod.yml up -d --remove-orphans
+      ExecStop=/usr/bin/docker compose -f compose/docker-compose.stack.yml -f compose/docker-compose.prod.yml down
+
+      [Install]
+      WantedBy=multi-user.target
+    permissions: '0644'
+    owner: root:root
+
+runcmd:
+  # === Docker (official Docker repo) ===
+  - install -m 0755 -d /etc/apt/keyrings
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  - chmod a+r /etc/apt/keyrings/docker.asc
+  - echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list
+  - apt-get update
+  - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  - systemctl enable --now docker
+
+  # === Tailscale (official tailscale repo; supports both amd64 + arm64) ===
+  - curl -fsSL "https://pkgs.tailscale.com/stable/ubuntu/$(. /etc/os-release && echo "$VERSION_CODENAME").noarmor.gpg" -o /usr/share/keyrings/tailscale-archive-keyring.gpg
+  - curl -fsSL "https://pkgs.tailscale.com/stable/ubuntu/$(. /etc/os-release && echo "$VERSION_CODENAME").tailscale-keyring.list" -o /etc/apt/sources.list.d/tailscale.list
+  - apt-get update
+  - apt-get install -y tailscale
+  - tailscale up --auth-key='${tailscale_auth_key}' --hostname='${tailnet_hostname}' --advertise-tags='tag:prod' --ssh=false
+
+  # === Repo checkout to /srv/podcast-scraper ===
+  - install -d -o deploy -g deploy -m 0755 /srv/podcast-scraper
+  - sudo -u deploy git clone --branch main --depth 50 https://github.com/chipi/podcast_scraper.git /srv/podcast-scraper
+  - chown -R deploy:deploy /srv/podcast-scraper
+
+  # === Corpus mount: prefer attached Volume, fall back to boot-disk dir ===
+  - VOLUME_PATH=$(ls -d /mnt/HC_Volume_* 2>/dev/null | head -1); if [ -n "$VOLUME_PATH" ]; then mkdir -p "$VOLUME_PATH/corpus"; chown -R deploy:deploy "$VOLUME_PATH/corpus"; ln -sfn "$VOLUME_PATH/corpus" /srv/podcast-scraper/corpus; else install -d -o deploy -g deploy /srv/podcast-scraper/corpus; fi
+
+  # === Unattended security upgrades ===
+  - dpkg-reconfigure -plow -fnoninteractive unattended-upgrades
+
+  # === Enable systemd unit (will block on .bootstrap-needs-env) ===
+  - systemctl enable podcast-scraper.service
+  - systemctl start podcast-scraper.service || true
+
+  - echo "[$(date -u +%FT%TZ)] cloud-init complete; awaiting operator .env" >> /var/log/podcast-scraper-bootstrap.log
+
+final_message: |
+  podcast-scraper-prod cloud-init complete after $UPTIME seconds.
+  Next step (operator): SSH in via Tailscale, stage /srv/podcast-scraper/.env,
+  then `sudo rm /srv/podcast-scraper/.bootstrap-needs-env && sudo systemctl restart podcast-scraper.service`.

--- a/infra/deploy/deploy.sh
+++ b/infra/deploy/deploy.sh
@@ -12,7 +12,9 @@
 set -euo pipefail
 
 REPO_DIR=/srv/podcast-scraper
-STACK_FILES=(-f compose/docker-compose.stack.yml -f compose/docker-compose.prod.yml)
+# vps-prod overlay (#713) layers basic-auth nginx + .htpasswd bind-mount on
+# top of the stack + prod overlays. Codespaces deliberately omits it.
+STACK_FILES=(-f compose/docker-compose.stack.yml -f compose/docker-compose.prod.yml -f compose/docker-compose.vps-prod.yml)
 
 cd "$REPO_DIR"
 

--- a/infra/deploy/deploy.sh
+++ b/infra/deploy/deploy.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# infra/deploy/deploy.sh — invoked by .github/workflows/deploy-prod.yml after
+# the GHA runner has joined the tailnet. Runs ON the VPS as the deploy user.
+#
+# Pulls latest GHCR images, rolls the compose stack, smoke-tests /api/health.
+#
+# Exit codes:
+#   0  success — stack pulled + up + healthy
+#   1  pull failed
+#   2  compose up failed
+#   3  /api/health did not return 200 within the timeout
+set -euo pipefail
+
+REPO_DIR=/srv/podcast-scraper
+STACK_FILES=(-f compose/docker-compose.stack.yml -f compose/docker-compose.prod.yml)
+
+cd "$REPO_DIR"
+
+# Refresh repo so compose files (not the images) match the deployed tag.
+git fetch --depth=50 origin main
+git reset --hard origin/main
+
+echo "[$(date -u +%FT%TZ)] pulling latest images..."
+if ! docker compose "${STACK_FILES[@]}" pull; then
+  echo "ERROR: docker compose pull failed" >&2
+  exit 1
+fi
+
+echo "[$(date -u +%FT%TZ)] rolling stack..."
+if ! docker compose "${STACK_FILES[@]}" up -d --remove-orphans; then
+  echo "ERROR: docker compose up failed" >&2
+  exit 2
+fi
+
+# Local smoke check — the calling workflow also probes externally over Tailscale,
+# but a local fail here aborts the SSH session early so the workflow surfaces red
+# without waiting another timeout cycle.
+echo "[$(date -u +%FT%TZ)] waiting for /api/health (up to 60s)..."
+for i in $(seq 1 12); do
+  if curl -fsS http://127.0.0.1:8000/api/health >/dev/null 2>&1; then
+    echo "[$(date -u +%FT%TZ)] /api/health OK after $((i * 5))s"
+    exit 0
+  fi
+  sleep 5
+done
+
+echo "ERROR: /api/health did not return 200 within 60s. Last 50 api logs:" >&2
+docker logs --tail 50 compose-api-1 >&2 || true
+exit 3

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hetznercloud/hcloud" {
+  version     = "1.62.0"
+  constraints = "~> 1.51"
+  hashes = [
+    "h1:DxU9137L3RD43MlvGD+NQelGCnB02Mv8dtQsBtAzZlw=",
+    "zh:2077f1655b6a7e26ae6d8ce3b5f35a6a65728416deb16dbd5165115da7534f37",
+    "zh:2234db7b84efa489b8e5f29f756cfed4a5bab760985f62d38c4b9ed2b3d6b4b6",
+    "zh:4abee7212fd15bcbf22b156ff18933f3975f2b1153fd3e93a1cacf31b9d35137",
+    "zh:5d7a63a8d4c73babea715c0c7a5dc04a08b5076e2f1f59855bf61f2393017bf0",
+    "zh:5ef15b4367c139b18167b2169421cb1f760d485db42f05ef292bd63eadcfa802",
+    "zh:62b432d918815812ea35ceca252d0ea833a8e1dbbc72c6b2d410369d7b8b0d85",
+    "zh:63fd3d3803a86447f9a1c0c49bffe704168fbc907ea3688cfd847e1dd012e9ff",
+    "zh:6a84f7125dad475f939afb58a1f0ec089e835d1b30ca64f467d85565a89f7508",
+    "zh:834c2ddcaa986323ecb7aa2baa3fd7b1888c2aec249f296822e53a4bc46be66e",
+    "zh:887e503de3720894eb756bcfc67b3d8ceb68564f9f8bb2a115d7398f0b5990b7",
+    "zh:976216f9aa89a466a1d97ae776c4df2edbac4a9ab29ff9850884060d15024570",
+    "zh:c3d7fc02e0fdf1bbee3a07c9171281a59d79ad9df2ec04342a81f3875709171c",
+    "zh:e0165f404357f2c1f89524165f38c88f643fb518483adfbf7817a6033a83f4d8",
+  ]
+}
+
+provider "registry.opentofu.org/tailscale/tailscale" {
+  version     = "0.28.0"
+  constraints = "~> 0.18"
+  hashes = [
+    "h1:Cquej+BY4u2GJ90N1l7CCwP4aukIYHUvnlgQIkpLFbU=",
+    "zh:26dc44b865b055069fbada06d8fcf0d44c32a365823219db1c122458c377a2f0",
+    "zh:335d4d4e6293647ff1b9dd828aef14e8b3cdf6ffae22e63084308a0b051d5e23",
+    "zh:40e78f96ac9af15060a0b0fb2eee8d51b61b8d160f063e75c3af7b855d85367e",
+    "zh:410d0d11cf2abbb6b8a7117d833a4326b52ba0a0eb9717e623f3703bc6c6ebc1",
+    "zh:49b90c658eabfb26559704dcc4a4da3bc1895f1724b8ea80d031ee22826e9426",
+    "zh:511d87ece288524ed3601c636838f041dcb4bf5aa7cef532677b65767ae0dda3",
+    "zh:55cedf481b4a357f625ed785f685e46e3087955bd66750eeaf631836e992a6f4",
+    "zh:5f58fcbe3980e64e3423f851cf2b7efad06df7382a813b21c4c3d7ce6c41b378",
+    "zh:a831d89d7b0b8e9d609c68e026d2beb8aa2173831de0baee6739745e94b70aa6",
+    "zh:a91ee9291198b358e1e57772e55d3e5bd882d676be0238a21d39f26980d26a5d",
+    "zh:bbf1c42927b62bb787bf624dc6d2089b422e3fe28bb02f27d10da1b184904279",
+    "zh:e6c2116f2d9140e7d1487ab48f5fa55e53e8251018155ee59d867b54f8713a4d",
+    "zh:ebfd3caf5feda0b5251a9ba62be54456a257b4d1ac237d9cccee6487a3ba7581",
+    "zh:f39ceae695cac365708e9f0e866801322723c00a1447c398d6eba376817afbcf",
+  ]
+}

--- a/infra/terraform/backend.tf
+++ b/infra/terraform/backend.tf
@@ -1,0 +1,8 @@
+# Local backend. State file lives at terraform.tfstate (gitignored as plaintext);
+# the infra/tofu wrapper sops+age-encrypts it to terraform.tfstate.enc on exit.
+# See infra/README.md "State encryption model".
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,94 @@
+provider "hcloud" {
+  token = var.hcloud_token
+}
+
+# === SSH key registration (operator's laptop pubkey) ===
+resource "hcloud_ssh_key" "operator" {
+  name       = var.ssh_public_key_name
+  public_key = var.ssh_public_key
+}
+
+# === Private network ===
+resource "hcloud_network" "main" {
+  name     = "podcast-scraper-prod"
+  ip_range = "10.0.0.0/16"
+}
+
+resource "hcloud_network_subnet" "main" {
+  network_id   = hcloud_network.main.id
+  type         = "cloud"
+  network_zone = "eu-central"
+  ip_range     = "10.0.1.0/24"
+}
+
+# === Firewall: default-deny inbound except Tailscale + ICMP + outbound ===
+# Tailnet traffic tunnels through UDP 41641; SSH and viewer/api are reached
+# over the tailnet, NOT through the public firewall.
+resource "hcloud_firewall" "main" {
+  name = "podcast-scraper-prod"
+
+  rule {
+    direction  = "in"
+    protocol   = "udp"
+    port       = "41641"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "icmp"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+# === Optional detached Volume for corpus bind-mount ===
+resource "hcloud_volume" "corpus" {
+  count    = var.volume_size_gb > 0 ? 1 : 0
+  name     = "podcast-scraper-corpus"
+  size     = var.volume_size_gb
+  location = var.location
+  format   = "ext4"
+}
+
+# === The VPS itself ===
+resource "hcloud_server" "prod" {
+  name        = var.tailnet_hostname
+  image       = "ubuntu-24.04"
+  server_type = var.server_type
+  location    = var.location
+
+  ssh_keys     = [hcloud_ssh_key.operator.id]
+  firewall_ids = [hcloud_firewall.main.id]
+
+  network {
+    network_id = hcloud_network.main.id
+    ip         = "10.0.1.10"
+  }
+
+  user_data = templatefile("${path.module}/../cloud-init/prod.user-data", {
+    tailscale_auth_key = tailscale_tailnet_key.prod.key
+    tailnet_hostname   = var.tailnet_hostname
+    ssh_public_key     = var.ssh_public_key
+  })
+
+  labels = {
+    project     = "podcast-scraper"
+    environment = "prod"
+    managed-by  = "opentofu"
+  }
+
+  # Cloud-init only runs once. Re-applying with a rotated auth key would force
+  # server replacement (loses corpus, tailnet identity); ignore the diff so
+  # routine `tofu apply` for non-server resources stays cheap.
+  lifecycle {
+    ignore_changes = [user_data]
+  }
+}
+
+# === Attach optional Volume ===
+resource "hcloud_volume_attachment" "corpus" {
+  count     = var.volume_size_gb > 0 ? 1 : 0
+  volume_id = hcloud_volume.corpus[0].id
+  server_id = hcloud_server.prod.id
+  automount = true
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "server_id" {
+  description = "Hetzner Cloud server ID for the prod VPS."
+  value       = hcloud_server.prod.id
+}
+
+output "ipv4_address" {
+  description = "Public IPv4 (used for outbound only; no inbound services exposed publicly)."
+  value       = hcloud_server.prod.ipv4_address
+}
+
+output "tailnet_url" {
+  description = "Full HTTPS URL for the viewer over Tailscale MagicDNS."
+  value       = "https://${var.tailnet_hostname}.${var.tailscale_tailnet}/"
+}
+
+output "ssh_target" {
+  description = "SSH target for deploy-prod.yml (assumes the runner has joined the tailnet via OAuth)."
+  value       = "deploy@${var.tailnet_hostname}.${var.tailscale_tailnet}"
+}
+
+output "volume_id" {
+  description = "Attached Volume ID, or null if no Volume was provisioned."
+  value       = var.volume_size_gb > 0 ? hcloud_volume.corpus[0].id : null
+}

--- a/infra/terraform/tailscale.tf
+++ b/infra/terraform/tailscale.tf
@@ -16,4 +16,9 @@ resource "tailscale_tailnet_key" "prod" {
   description   = "podcast-scraper-prod VPS auth key (per-apply)"
 }
 
-# tailscale_acl resource (synced from tailscale/policy.hujson) lands in #717.
+# Sync the repo's ACL file to the tailnet. Source of truth = tailscale/policy.hujson;
+# every `tofu apply` overwrites the live policy. ACL changes ship as PRs per
+# RFC-082 Decision 2 + Decisions-made #4.
+resource "tailscale_acl" "main" {
+  acl = file("${path.module}/../../tailscale/policy.hujson")
+}

--- a/infra/terraform/tailscale.tf
+++ b/infra/terraform/tailscale.tf
@@ -1,0 +1,19 @@
+provider "tailscale" {
+  oauth_client_id     = var.tailscale_oauth_client_id
+  oauth_client_secret = var.tailscale_oauth_client_secret
+  tailnet             = var.tailscale_tailnet
+}
+
+# Per-server auth key. Rotated on every `tofu apply` so a leaked key only
+# affects the window between issuance and re-apply (typically minutes).
+# 1h expiry is enough for cloud-init's `tailscale up` on first boot.
+resource "tailscale_tailnet_key" "prod" {
+  reusable      = false
+  ephemeral     = false
+  preauthorized = true
+  expiry        = 3600
+  tags          = ["tag:prod"]
+  description   = "podcast-scraper-prod VPS auth key (per-apply)"
+}
+
+# tailscale_acl resource (synced from tailscale/policy.hujson) lands in #717.

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,72 @@
+variable "hcloud_token" {
+  type        = string
+  description = "Hetzner Cloud API token (env: HCLOUD_TOKEN). Read+Write scope, project-scoped to podcast-scraper-prod."
+  sensitive   = true
+}
+
+variable "tailscale_oauth_client_id" {
+  type        = string
+  description = "Tailscale OAuth client ID for the gha-deployer tag."
+  sensitive   = true
+}
+
+variable "tailscale_oauth_client_secret" {
+  type        = string
+  description = "Tailscale OAuth client secret."
+  sensitive   = true
+}
+
+variable "tailscale_tailnet" {
+  type        = string
+  description = "Tailscale tailnet name (e.g. 'example.com' or 'tail-xxxxx.ts.net')."
+}
+
+variable "server_type" {
+  type        = string
+  description = "Hetzner Cloud server type. CX33 (interim, amd64, EUR 6.49) or CAX31 (preferred, ARM, EUR 15.99, post-#712 multi-arch publish)."
+  default     = "cx33"
+
+  validation {
+    condition     = contains(["cx33", "cax31", "ccx13", "ccx23"], var.server_type)
+    error_message = "Supported types: cx33, cax31 (preferred once #712 lands), ccx13, ccx23. See RFC-082 Decision 1."
+  }
+}
+
+variable "location" {
+  type        = string
+  description = "Hetzner location: fsn1 (Falkenstein) or nbg1 (Nuremberg) for EU per RFC-082."
+  default     = "fsn1"
+
+  validation {
+    condition     = contains(["fsn1", "nbg1", "hel1"], var.location)
+    error_message = "Supported EU locations: fsn1, nbg1, hel1."
+  }
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "Operator's SSH public key. Cloud-init bakes it into deploy@<host>:~/.ssh/authorized_keys."
+}
+
+variable "ssh_public_key_name" {
+  type        = string
+  description = "Name to register the SSH key under in Hetzner."
+  default     = "operator-laptop"
+}
+
+variable "volume_size_gb" {
+  type        = number
+  description = "Optional detached Volume for corpus bind-mount. 0 = no Volume (boot disk used). RFC-082 'recommended once corpus grows past ~20 GB'."
+  default     = 0
+
+  validation {
+    condition     = var.volume_size_gb == 0 || (var.volume_size_gb >= 10 && var.volume_size_gb <= 1000)
+    error_message = "volume_size_gb must be 0 (disabled) or 10-1000."
+  }
+}
+
+variable "tailnet_hostname" {
+  type        = string
+  description = "Hostname the VPS registers with Tailscale. Final URL: https://<tailnet_hostname>.<tailscale_tailnet>/."
+  default     = "prod-podcast"
+}

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.51"
+    }
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "~> 0.18"
+    }
+  }
+}

--- a/infra/tofu
+++ b/infra/tofu
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# infra/tofu — sops-encrypted-state wrapper for OpenTofu.
+#
+# Decrypts terraform/terraform.tfstate.enc to terraform/terraform.tfstate
+# before invoking tofu, re-encrypts on exit if state changed, and shreds the
+# plaintext via a trap so a Ctrl-C mid-run doesn't leave decrypted state on
+# disk.
+#
+# Operator setup: see infra/README.md.
+#
+# Usage:
+#   cd infra && ./tofu init
+#   cd infra && ./tofu plan
+#   cd infra && ./tofu apply
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TF_DIR="$REPO_ROOT/infra/terraform"
+ENC_STATE="$TF_DIR/terraform.tfstate.enc"
+PLAIN_STATE="$TF_DIR/terraform.tfstate"
+BACKUP_STATE="$TF_DIR/terraform.tfstate.backup"
+
+# Verify required dependencies up-front so we fail fast rather than half-way
+# through a decrypt with no encryptor available.
+for cmd in tofu sops age; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: '$cmd' not in PATH. Install with: brew install opentofu sops age" >&2
+    exit 127
+  fi
+done
+
+# Cleanup: any plaintext state file (current or backup) is shredded on exit.
+# The encrypted blob is the source of truth; plaintext is ephemeral.
+cleanup() {
+  for f in "$PLAIN_STATE" "$BACKUP_STATE"; do
+    if [[ -f "$f" ]]; then
+      if command -v shred >/dev/null 2>&1; then
+        shred -u "$f" 2>/dev/null || rm -f "$f"
+      else
+        # macOS has no shred; overwrite with random + delete (best effort).
+        dd if=/dev/urandom of="$f" bs=4096 conv=notrunc 2>/dev/null || true
+        rm -f "$f"
+      fi
+    fi
+  done
+}
+trap cleanup EXIT INT TERM
+
+# Decrypt existing encrypted state, if any. (First-ever apply has none yet.)
+if [[ -f "$ENC_STATE" ]]; then
+  sops -d "$ENC_STATE" > "$PLAIN_STATE"
+fi
+
+# Hash of the plaintext before tofu runs — used to decide whether to re-encrypt.
+PRE_HASH=""
+[[ -f "$PLAIN_STATE" ]] && PRE_HASH=$(shasum -a 256 "$PLAIN_STATE" | awk '{print $1}')
+
+# Run tofu against the terraform dir. We don't `set -e` around tofu because
+# its non-zero exits (e.g. plan with diffs and -detailed-exitcode) are normal.
+cd "$TF_DIR"
+set +e
+tofu "$@"
+TOFU_EXIT=$?
+set -e
+
+# Re-encrypt iff state changed (or appeared for the first time).
+POST_HASH=""
+[[ -f "$PLAIN_STATE" ]] && POST_HASH=$(shasum -a 256 "$PLAIN_STATE" | awk '{print $1}')
+
+if [[ -n "$POST_HASH" && "$PRE_HASH" != "$POST_HASH" ]]; then
+  echo "[infra/tofu] state changed; re-encrypting -> $ENC_STATE" >&2
+  # Write to a sibling file then rename — atomic, never leaves a half-written
+  # encrypted blob if sops dies mid-write.
+  sops -e "$PLAIN_STATE" > "$ENC_STATE.new"
+  mv "$ENC_STATE.new" "$ENC_STATE"
+fi
+
+exit "$TOFU_EXIT"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
       - Quick Reference: guides/QUICK_REFERENCE.md
       - Development Guide: guides/DEVELOPMENT_GUIDE.md
       - Release Playbook: guides/RELEASE_PLAYBOOK.md
+      - Prod Runbook (always-on VPS): guides/PROD_RUNBOOK.md
       - Polyglot repository layout: guides/POLYGLOT_REPO_GUIDE.md
       - Server Guide: guides/SERVER_GUIDE.md
       - Pipeline and Workflow Guide: guides/PIPELINE_AND_WORKFLOW.md

--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -1,0 +1,40 @@
+# `tailscale/` — tailnet ACL as code
+
+Source-of-truth for the operator's Tailscale ACL. Synced to the live tailnet
+by [infra/terraform/tailscale.tf](../infra/terraform/tailscale.tf)'s
+`tailscale_acl` resource on every `tofu apply`. Implements
+[RFC-082 Decision 2](../docs/rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md).
+
+## Files
+
+- [`policy.hujson`](policy.hujson) — the tailnet ACL in HuJSON
+  (JSON with `//` comments + trailing-comma tolerance).
+
+## How a change ships
+
+1. Edit `policy.hujson` on a branch.
+2. Open a PR. The infra-CI workflow (#719) runs `tofu plan` and posts the diff
+   as a comment so you can preview which devices/rules change.
+3. Merge to main.
+4. Operator (or scheduled `infra-apply.yml`) runs `tofu apply`. The
+   `tailscale_acl` resource pushes the new policy to the tailnet API.
+
+## Local validation
+
+The file is HuJSON, not strict JSON. A quick syntax check (strip `//` comments,
+parse remainder as JSON) catches most mistakes:
+
+```bash
+python3 -c 'import json, re; t = open("tailscale/policy.hujson").read(); json.loads(re.sub(r"//.*", "", t))'
+```
+
+For a deeper check (resolves tag references, validates against Tailscale's
+schema), use the Tailscale CLI: `tailscale debug check-policy-file policy.hujson`
+— requires Tailscale login.
+
+## Cross-references
+
+- [RFC-082 — Decision 2: Tailscale](../docs/rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md)
+- [#717](https://github.com/chipi/podcast_scraper/issues/717) — this ticket
+- [#714](https://github.com/chipi/podcast_scraper/issues/714) — Tailscale OAuth client + tag prereqs
+- [Tailscale ACL syntax (HuJSON)](https://tailscale.com/kb/1018/acls)

--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -1,0 +1,57 @@
+// podcast_scraper-prod tailnet ACL.
+//
+// Synced to the live Tailscale ACL by infra/terraform/tailscale.tf's
+// tailscale_acl resource on every `tofu apply`.
+//
+// Owner: single operator. Add a collaborator by appending their tailnet
+// identity to acls below and opening a PR. RFC-082 Decision 2 + Decisions-made #4.
+
+{
+  // Tag ownership. Only listed owners can apply these tags to devices.
+  //   tag:prod         → the prod VPS (advertised by cloud-init's `tailscale up`)
+  //   tag:gha-deployer → ephemeral GHA runner during deploy-prod.yml
+  "tagOwners": {
+    "tag:prod":         ["autogroup:admin"],
+    "tag:gha-deployer": ["autogroup:admin"]
+  },
+
+  // Implicit-deny for everything else; only listed traffic is permitted.
+  "acls": [
+    // Operator's own devices (laptop, phone, iPad — anyone with admin role)
+    // reach the viewer + api over HTTPS / HTTP redirect.
+    {
+      "action": "accept",
+      "src":    ["autogroup:admin"],
+      "dst":    ["tag:prod:80,443"]
+    },
+
+    // Deploy workflow (ephemeral GHA runner under tag:gha-deployer) SSHes into
+    // the VPS to run `docker compose pull && up`. SSH only; no other ports.
+    {
+      "action": "accept",
+      "src":    ["tag:gha-deployer"],
+      "dst":    ["tag:prod:22"]
+    }
+
+    // (Future, for #714 + #723) Home Assistant subscribes to /api/jobs.
+    // Uncomment and add HA's tailnet identity once that integration lands.
+    // ,
+    // {
+    //   "action": "accept",
+    //   "src":    ["user:homeassistant@example.com"],
+    //   "dst":    ["tag:prod:443"]
+    // }
+  ],
+
+  // No auto-approvers — manual approval for any new tagged device, slowing
+  // down the bad-key compromise path.
+  "autoApprovers": {
+    "routes":   {},
+    "exitNode": []
+  }
+
+  // Tailscale SSH intentionally NOT enabled (no "ssh" block).
+  // We use plain key-based SSH so the ACL controls reach but not auth.
+  // Re-evaluate if Tailscale-SSH's audit-log + cert-rotation value outweighs
+  // the second-credential complexity.
+}


### PR DESCRIPTION
## Summary

Implements [RFC-082](docs/rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md) — the always-on Hetzner VPS prod stack on the operator's Tailscale tailnet, deployed via OpenTofu (state encrypted with sops+age in-repo) and a GitHub Actions deploy workflow. **10 commits, ~1,890 lines insertions, zero deletions, all-greenfield except a 1-line `mkdocs.yml` nav entry.** Codespaces pre-prod is unaffected.

## What this ships

| Layer | Files | Purpose |
| --- | --- | --- |
| **Infra-as-code** | `infra/terraform/*.tf`, `infra/cloud-init/prod.user-data`, `infra/deploy/deploy.sh`, `infra/tofu` (sops wrapper), `infra/.sops.yaml`, `infra/README.md` | Provisions 1 Hetzner server (default cx33) + private network + firewall + 1 Tailscale auth key (and an optional Volume). State encrypted at rest. |
| **Tailscale ACL** | `tailscale/policy.hujson` + `tailscale_acl` resource in `infra/terraform/tailscale.tf` | `tag:prod` (the VPS) + `tag:gha-deployer` (ephemeral runner). Operator devices reach `tag:prod:80,443`; the deployer reaches `tag:prod:22`. |
| **GHA deploy** | `.github/workflows/deploy-prod.yml` | Manual `workflow_dispatch` initially. Joins tailnet, SSHes the VPS, runs `compose pull && up`, wires `PODCAST_RELEASE=sha-<short>` into host `.env` for Sentry release grouping, probes `/api/health` over Tailscale (60s timeout, dumps last 50 api logs on failure). |
| **GHA infra loop** | `.github/workflows/infra-ci.yml`, `infra-apply.yml` | PR posts `tofu plan` as a comment; manual-dispatch apply with `APPLY` typed-input gate, sops-encrypted state artifact upload (30-day retention). |
| **Backup** | `.github/workflows/backup-corpus-prod.yml` | Sibling to existing `backup-corpus.yml` — pulls from VPS over Tailscale instead of codespace. Workflow_dispatch only; runs in parallel with codespace backup during cutover window (#722 Phase A). |
| **Auth wall + landing** | `docker/viewer/{nginx-prod.conf,landing.html}`, `compose/docker-compose.vps-prod.yml` | Basic-auth nginx config layered ONLY by VPS-prod overlay (Codespaces stays auth-free). Public `/welcome` landing page; SPA + `/api/*` gated; `/api/health` left unauthed for the deploy probe. |
| **Operator runbook** | `docs/guides/PROD_RUNBOOK.md` (414 lines) + `mkdocs.yml` nav | First-time bootstrap, daily ops, basic-auth creds, corpus migration, rollback (3 failure modes), DR, credential rotation. |
| **Process** | `CLAUDE.md` (+26 lines) | Permanent rule: every `make` invocation MUST end with an exit-code terminator from the start. Process improvement, not RFC-082. |

## Closes (9 issues — all RFC-082 v2.6 milestone)

- Closes #713 — basic auth + landing page
- Closes #716 — `infra/` IaC code (OpenTofu + cloud-init + deploy script)
- Closes #717 — Tailscale ACL as code
- Closes #718 — `deploy-prod.yml` workflow
- Closes #719 — `infra-ci.yml` + `infra-apply.yml`
- Closes #720 — post-deploy `/api/health` probe
- Closes #721 — `PODCAST_RELEASE=sha-<short>` Sentry release tag
- Closes #722 — `backup-corpus-prod.yml` (Phase A; Phase B cutover ships in #723)
- Closes #727 — `PROD_RUNBOOK.md`

## Stays open as follow-ups (do NOT close on merge)

| Issue | Why |
| --- | --- |
| #712 | Multi-arch publish — landed separately on `main` via #737. |
| #714 | **Operator account prereqs** (Hetzner, Tailscale OAuth, sops/age, GHA secrets). Prerequisite to first `tofu apply`. |
| #723 | Phase B cutover (operator-driven; flips deploy-prod + backup-prod from workflow_dispatch to auto-trigger after a week of green manual runs). |
| #724 | DR drill (operator-driven; calibrate RFC's claimed ~15-20 min recovery). |
| #725 | Sentry alert routing split — done in Sentry UI after prod ships events. |
| #726 | Grafana dashboard `env=` selector pass — done in Grafana UI after prod ships ~24h of metrics. |

## Test plan

### Pre-push (already done on the branch)

- [x] `tofu fmt -check && tofu init -backend=false && tofu validate` — green (no Hetzner creds needed)
- [x] HuJSON syntax check on `tailscale/policy.hujson` — green
- [x] `actionlint` on all 4 new workflows — green
- [x] `nginx -t` (with localhost upstream substitution) on `nginx-prod.conf` — syntax OK
- [x] `shellcheck` on `infra/tofu`, `infra/deploy/deploy.sh` — clean (only SC2329 false positive on trap-invoked function)
- [x] `make docs` — mkdocs strict, clean
- [x] `make ci-fast` — green (one shot at end, per CLAUDE rule)

### Post-merge

- [ ] `Stack test` runs once on main (~25 min); should be green.
- [ ] No deploy/backup workflows fire automatically (all are workflow_dispatch initially).
- [ ] `infra-ci.yml` does NOT fire on the merge commit (it triggers on PRs touching `infra/**`, not on `push`).

### Operator validation (separate from CI)

After merge + #714 prereqs done + first `tofu apply`:
- [ ] `curl https://prod-podcast.<tailnet>.ts.net/api/health` returns `{"status":"ok",...}`
- [ ] `curl /welcome` returns 200 + landing page; `curl /` returns 401; `curl -u user:pass /` returns SPA HTML
- [ ] `gh workflow run deploy-prod.yml` exits green
- [ ] One real podcast episode runs end-to-end on the VPS (per `CLAUDE.md` "real episodes" rule)

## What can possibly break

Nothing automatic. Greenfield directories (`infra/`, `tailscale/`) and brand-new workflow files have zero conflict surface. All new workflows are workflow_dispatch-only — they won't fire on PR or merge until the operator manually triggers them. The existing `backup-corpus.yml` (codespace), `deploy-codespace.yml`, `stack-test.yml`, viewer image, prod compose overlay, and api/pipeline source are all untouched. Codespaces pre-prod stays exactly as it is.

## Operator action list (post-merge — none of this happens automatically)

Brief recap. Full step-by-step in [`docs/guides/PROD_RUNBOOK.md`](docs/guides/PROD_RUNBOOK.md).

1. **§A — account prereqs (#714, ~45 min):** Hetzner project + API token; Tailscale OAuth client for `tag:gha-deployer`; `age-keygen` for sops state encryption; stage GHA secrets (`HCLOUD_TOKEN`, `TS_OAUTH_*`, `TFSTATE_AGE_KEY`, `BACKUP_REPO_TOKEN`) + variables (`OPERATOR_SSH_PUBLIC_KEY`, `TAILNET_NAME`).
2. **§B — first `tofu apply` (~5 min):** `cd infra && ./tofu init && ./tofu plan && ./tofu apply`. Outputs server IPv4 + tailnet URL.
3. **§C — stage host secrets (~5 min):** SSH to `deploy@prod-podcast.<tailnet>.ts.net`; create `/srv/podcast-scraper/.env` and `/srv/podcast-scraper/.htpasswd`; remove the `.bootstrap-needs-env` sentinel.
4. **§D — first deploy:** `gh workflow run deploy-prod.yml` and watch.
5. **§E — cutover follow-ups (over the next week):** trigger #723 cutover PR, run #724 DR drill, configure #725 Sentry routing + #726 Grafana selectors.

## Notes

- **Rebased onto current `main`** (`47d722c8`, includes #711 GIL evidence + #737 multi-arch publish). Zero conflicts.
- **CLAUDE.md commit (`78dc5a12` / now `d21d311b` post-rebase) is process-improvement only** — closes nothing; rides this branch incidentally because it landed mid-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
