### PR TITLE
docs(rfc-082): flip Decision 1 to CX43 — corrected May 2026 Hetzner pricing

### DIFF
--- a/docs/rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md
+++ b/docs/rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md
@@ -116,7 +116,7 @@ IaC + a GitOps deploy loop**:
 
 [ New for prod ]
   1. infra/ directory: Terraform + cloud-init + deploy script
-  2. Hetzner CAX31 (or CX33 interim — see Decision 1) provisioned via Terraform
+  2. Hetzner CX43 provisioned via Terraform (see Decision 1)
   3. Tailscale daemon on the VPS, auto-joins tailnet via auth key
   4. GHA workflow deploy-prod.yml fires on stack-test success → main
   5. Host bind-mount: /srv/podcast-scraper/corpus
@@ -125,57 +125,69 @@ IaC + a GitOps deploy loop**:
 
 ### Decision 1 — Hosting target
 
-**Hetzner CAX31** (8 vCPU ARM Ampere, 16 GB RAM, 160 GB SSD, 20 TB
-traffic, **€15.99/mo**, EU). Operator-confirmed EU geography + want
-predictable flat billing.
+**Hetzner CX43** (8 vCPU shared Intel/AMD, 16 GB RAM, 160 GB SSD,
+20 TB traffic, **€15.11/mo** as of May 2026, EU). Operator-confirmed
+EU geography + want predictable flat billing.
 
-CAX31 wins on price/perf at the chosen budget tier: it's the same
-monthly cost as CCX13 (the dedicated-AMD option) but ships **4× the
-vCPUs (8 vs 2) and 2× the RAM (16 vs 8 GB)**. For a workload that's
-ffmpeg + cloud-LLM SDK calls + viewer + grafana-agent — none of which
-benefits from x86-specific instructions — that's a free headroom
-upgrade at the same euro spend.
+CX43 is the cheapest 8-core option in Hetzner's lineup — about **25 %
+less than the same-shape CAX31** (ARM Ampere, €19.95/mo) and roughly
+half the cost of the dedicated-AMD CCX23 (€31.49/mo, broke ceiling).
+CX43 + 50 GB Volume (~€2.86/mo) totals ~€18/mo, well under the $20
+ceiling.
 
-**Why ARM is low-risk for this stack.** Prod runs the cloud-thin
-profile (`INSTALL_EXTRAS=llm`): no torch / spaCy / FAISS / Whisper /
-llama-cpp. The arm64 dependency surface reduces to
-`python:3.12-slim-bookworm` (official multi-arch), `nginx:alpine`
-(viewer; official multi-arch), debian-package ffmpeg (first-class on
-Ampere), pure-Python provider SDKs, and grafana-agent (official ARM
-build). None of the typical "port to ARM" pain points (compiled ML
-wheels, CUDA, native llama.cpp) are in the prod image set.
+> **Pricing volatility caveat.** Hetzner pushed a 30–37 % hike on
+> 2026-04-01 and renames the CX line periodically (CX22 / CX32 /
+> CX42 → CX23 / CX33 / CX43 in 2024). The Hetzner pricing page
+> renders prices client-side so cached/scraped figures (e.g.
+> costgoat) lag reality. **Re-check at
+> [hetzner.com/cloud/cost-optimized](https://www.hetzner.com/cloud/cost-optimized)
+> before every apply.** Earlier RFC drafts referenced stale
+> €15.99 CAX31 and €11.99 CX43 figures; both have since increased.
 
-**Prerequisite.** GHCR publish currently emits amd64-only manifests.
-Moving to CAX is gated on
-[#712 — Multi-arch (amd64+arm64) GHCR publish](https://github.com/chipi/podcast_scraper/issues/712),
-which adds `--platform linux/amd64,linux/arm64` to the three
-`docker buildx build` invocations in `stack-test.yml` and validates
-one real episode end-to-end on a throwaway CAX21 before the prod
-flip. Until #712 lands, the **interim deploy target is CX33**
-(4 vCPU shared Intel/AMD, 8 GB, 80 GB, €6.49/mo) so prod isn't
-blocked on the publish change.
+**CX (shared Intel/AMD) vs. CAX (ARM Ampere) for this stack.** The
+prod image set is cloud-thin (`INSTALL_EXTRAS=llm`): no torch /
+spaCy / FAISS / Whisper / llama-cpp. The arm64-native-wheel concern
+is therefore irrelevant — both architectures work. The trade-off
+collapses to:
 
-> **Naming note.** Hetzner renamed the CX line in 2024 (CX22 / CX32 /
-> CX42 → CX23 / CX33 / CX43) and pushed a 30–37% price hike on
-> 2026-04-01. Earlier drafts of this RFC referenced "CX32 at €7.89" —
-> that SKU no longer exists; CX33 is the same shape post-rename. EUR
-> figures throughout reflect Hetzner's post-2026-04-01 list price.
+| Dimension | CX43 (chosen) | CAX31 (alternative) |
+| --- | --- | --- |
+| Monthly price (May 2026) | **€15.11** | €19.95 (~25 % more) |
+| Per-core perf for ffmpeg | OK; depends on noisy-neighbor luck | Roughly equal; Ampere has good codec instructions |
+| Per-core perf for Python / HTTP | Roughly equal | Roughly equal |
+| Native Python wheels | All amd64-native (zero risk) | All arm64 wheels exist; multi-arch publish required (#712 / #737, already merged) |
+| Noisy-neighbor risk | Higher — x86 shared cloud is in heavier demand | Lower — ARM cloud demand has historically been quieter |
+| GHCR storage | Single-arch | Multi-arch ≈ 2× (free for public repos, no impact) |
+| CI publish wall-time | Native | ~2× longer under QEMU emulation on amd64 runners (already paid by #737) |
 
-**Alternatives kept on the bench (in order, only if CAX31 falls
-short):**
+The two genuine reasons to prefer CAX31 over CX43:
 
-| Trigger | Move to | Specs | Price |
+1. **Anti-jitter premium** — €4.84/mo (~25 %) for less variability
+   from noisy x86 neighbors. Worth it only if shared-CPU jitter
+   actually shows up in measured ffmpeg / Whisper wall-times.
+2. **Energy efficiency / philosophy** — Ampere is more
+   power-efficient and Hetzner's ARM fleet runs greener. Real but
+   soft factor.
+
+For a single-operator hobby workload (ffmpeg, cloud-LLM SDK calls,
+static viewer, grafana-agent), neither outweighs the 25 % cost
+delta. **Pick CX43; escalate only on measured signal.**
+
+**Alternatives kept on the bench (only if CX43 falls short):**
+
+| Trigger | Move to | Specs | Price (May 2026) |
 | --- | --- | --- | --- |
-| #712 not yet landed; need to ship prod now on amd64 | **CX33** (interim) | 4 vCPU shared Intel/AMD, 8 GB, 80 GB | €6.49/mo |
-| #712 not yet landed AND shared-CPU jitter visible | **CCX13** (interim, dedicated) | 2 dedicated AMD vCPU, 8 GB, 80 GB | €15.99/mo |
-| ARM perf surprise — Ampere wall-time materially worse than amd64 baseline | **CCX23** | 4 dedicated AMD vCPU, 16 GB, 160 GB | €31.49/mo |
+| Want the anti-jitter premium of ARM Ampere | **CAX31** | 8 vCPU ARM Ampere, 16 GB, 160 GB | €19.95/mo |
+| Shared-CPU jitter visible in measured ffmpeg / Whisper wall-times on CX43 | **CCX23** | 4 dedicated AMD vCPU, 16 GB, 160 GB | ~€31.49/mo (re-verify) |
 
-CAX31 sits at $17/mo (~$3 under the $20 ceiling). The CCX23 fallback
-breaks the ceiling and would need an explicit budget revision.
+Switching CX43 → CAX31 is a single Terraform variable change
+(`server_type = "cax31"`) — multi-arch publish is already merged
+in #712 / #737, so no CI work is needed. CCX23 breaks the $20
+ceiling and should only be picked if measured numbers demand it.
 
-**Storage add-on:** a separate Hetzner Volume (€0.0572/GB/month, post
-April-2026 pricing) for the corpus bind-mount, so the VPS image can
-be replaced without touching corpus data. ~€2.86/mo for 50 GB.
+**Storage add-on:** a separate Hetzner Volume (~€0.057/GB/month;
+re-verify) for the corpus bind-mount, so the VPS image can be
+replaced without touching corpus data. ~€2.86/mo for 50 GB.
 Recommended once corpus grows past ~20 GB on the boot disk.
 
 ### Decision 2 — Auth wall: Tailscale
@@ -299,8 +311,7 @@ infra/
   with the `hetznercloud/hcloud` provider, also supports the
   `tailscale/tailscale` provider. Avoids the BSL-license question on
   HashiCorp Terraform.
-- **`hetznercloud/hcloud` provider** — declares the CAX31 server
-  (or CX33 during the #712 interim window),
+- **`hetznercloud/hcloud` provider** — declares the CX43 server,
   attached Volume, firewall rules (default-deny inbound; allow
   outbound), SSH key registration.
 - **`tailscale/tailscale` provider** — declares the auth key (so
@@ -351,7 +362,7 @@ changed" signal. If we ever go multi-operator, swap to Object Storage
 **Bootstrap flow:**
 
 1. Operator clones repo locally, runs `cd infra/terraform && tofu apply`.
-2. OpenTofu provisions Hetzner CAX31 (or CX33 interim) + attaches Volume + registers
+2. OpenTofu provisions Hetzner CX43 + attaches Volume + registers
    tailscale auth key.
 3. cloud-init runs on first boot: installs Docker, Tailscale, joins
    tailnet, pulls repo, copies operator-staged `.env`, runs
@@ -629,7 +640,7 @@ exactly as in pre-prod.
 
 First-deploy image pull on a fresh VPS is ~3 GB total (~1.5 GB
 pipeline-llm + ~700 MB api + ~50 MB viewer + ~250 MB grafana-agent).
-Bandwidth allowance on Hetzner CAX31 / CX33 is 20 TB/mo; first-deploy pull
+Bandwidth allowance on Hetzner CX43 is 20 TB/mo; first-deploy pull
 is negligible against that. Subsequent deploys reuse layers and pull
 ~50-200 MB per release.
 
@@ -661,12 +672,13 @@ is negligible against that. Subsequent deploys reuse layers and pull
 
 ## Costs
 
-All EUR figures reflect Hetzner's post-2026-04-01 price list.
+All EUR figures reflect Hetzner's May 2026 list price; re-verify
+against [hetzner.com/cloud](https://www.hetzner.com/cloud/) before
+every apply (cached / scraped figures lag the live page).
 
 | Component | Plan | Cost / mo |
 | --- | --- | --- |
-| Hetzner CAX31 (chosen, post-#712) | flat | €15.99 (~$17) |
-| Hetzner CX33 (interim until #712 lands) | flat | €6.49 (~$7) |
+| Hetzner CX43 (chosen, 8 vCPU shared Intel/AMD, 16 GB) | flat | €15.11 (~$16) |
 | Hetzner Volume 50 GB (optional) | flat | ~€2.86 (~$3) |
 | sops + age state storage (in-repo, no vendor) | — | $0 |
 | Tailscale Personal | up to 100 devices | $0 |
@@ -674,13 +686,13 @@ All EUR figures reflect Hetzner's post-2026-04-01 price list.
 | Grafana Cloud Free | unchanged | $0 |
 | Sentry Free | unchanged | $0 |
 | **Pipeline LLM calls** | metered (operator's keys) | varies — same as pre-prod |
-| **Total fixed (CAX31 + 50 GB Volume)** | | **~$20/mo** |
-| **Total fixed (CX33 interim, no Volume)** | | **~$7/mo** |
+| **Total fixed (CX43, no Volume)** | | **~$16/mo** |
+| **Total fixed (CX43 + 50 GB Volume)** | | **~$19/mo** |
 
-CAX31 + 50 GB Volume sits right at the $20 ceiling. The CX33 interim
-target sits well under, leaving headroom for the Volume add-on
-during the gap before #712 lands. Any further upgrade (CCX23, larger
-Volume) breaks the ceiling and needs an explicit budget revision.
+CX43 + 50 GB Volume sits comfortably under the $20 ceiling with ~$1
+of headroom. Any further upgrade — CAX31 (€19.95 ARM premium),
+CCX23 (€31.49 dedicated AMD), or a larger Volume — breaks the
+ceiling and needs an explicit budget revision.
 
 ## Phased Rollout
 
@@ -728,15 +740,18 @@ The original "Open Questions" set has been resolved (see RFC-082
 discussion thread). Recording here so the implementation has explicit
 direction:
 
-1. **Hetzner CAX31** (€15.99, 8 vCPU ARM Ampere, 16 GB) is the chosen
-   target — best price/perf at the $20 ceiling. Gated on
-   [#712](https://github.com/chipi/podcast_scraper/issues/712)
-   (multi-arch GHCR publish). Until #712 lands, deploy on **CX33**
-   (€6.49, shared Intel/AMD, 8 GB; the 2024-renamed successor to the
-   old CX32) as the amd64 interim. Fall back to CCX13 (€15.99,
-   dedicated AMD) if the interim shows shared-CPU jitter, or CCX23
-   (€31.49, breaks the ceiling) only if ARM perf surprises us. EUR
-   figures are post-2026-04-01 list price.
+1. **Hetzner CX43** (€15.11/mo, 8 vCPU shared Intel/AMD, 16 GB,
+   160 GB) is the chosen target — cheapest 8-core option in the
+   lineup, ~25 % less than the same-shape CAX31 (ARM Ampere,
+   €19.95/mo). Multi-arch GHCR publish (#712 / #737) is already
+   merged, so a future flip to CAX31 is just a Terraform variable
+   change (`server_type = "cax31"`) if the anti-jitter premium
+   ever justifies the €5/mo. Fall back to CCX23 (4 dedicated AMD
+   vCPU, ~€31.49 — breaks the $20 ceiling) only if measured
+   shared-CPU jitter on CX43 demands it. **Earlier RFC drafts
+   referenced stale €15.99 CAX31 / €11.99 CX43 figures from
+   cached costgoat data** — the live Hetzner pricing page is
+   authoritative; re-verify before each apply.
 2. **No detached Volume on day one.** 80 GB boot disk is enough for
    early use. Add a Volume on first VPS replacement when we already
    need to migrate the corpus anyway.


### PR DESCRIPTION
## Summary

The CAX31 recommendation in the prior RFC-082 amendment was based on a stale costgoat figure (€15.99/mo). Hetzner's live pricing page shows CAX31 at **€19.95/mo** — about 25 % more than the same-shape **CX43 at €15.11/mo**. Re-verifying inverts the recommendation: CX43 is now the chosen target.

## What changed

| | Before this PR | After this PR |
| --- | --- | --- |
| Decision 1 chosen target | CAX31 (ARM Ampere, €15.99 — stale) | **CX43 (shared Intel/AMD, €15.11)** |
| Justification | "same cost as CCX13, 4× the cores" (true at stale price) | "cheapest 8-core option, 25 % less than same-shape CAX31" (true at live price) |
| Anti-jitter swap to CAX31 | (was the chosen target) | New alternative — €4.84/mo premium, only worth it on measured jitter |
| Dedicated-CPU escalation | CCX23 | CCX23 (unchanged) |
| #712 multi-arch dependency | Hard prereq | Already merged in #737 — switching CX → CAX later is a single Terraform var change |
| Costs total (no Volume) | $7 (CX33 interim) / $20 (CAX31+Volume) | $16 (CX43) / $19 (CX43+Volume) — comfortably under ceiling |

## Sections touched in `docs/rfc/RFC-082-always-on-pre-prod-and-prod-hosting.md`

- **Decision 1 — Hosting target** (full rewrite): new CX vs CAX trade-off table, explicit "two reasons to prefer CAX" call-out (anti-jitter, energy efficiency), refreshed "alternatives kept on the bench" table.
- **Design block** "[New for prod]" item 2: CAX31/CX33 → CX43.
- **Decision 5** narrative + **Bootstrap flow**: CAX31/CX33 → CX43.
- **Image-set / pull behavior**: bandwidth note → CX43.
- **Costs table**: CX43 line + new CX43-only and CX43+Volume totals; explicit pricing-volatility caveat at the top.
- **Decisions made #1**: rewrite to CX43-as-chosen; explicitly names the stale costgoat figures so future readers don't repeat the mistake.

## Pricing-volatility caveat (added in two places)

Hetzner's pricing page renders prices client-side, so cached/scraped figures (costgoat, anything that scraped HTML) lag the live page. The RFC now instructs the operator to re-verify against [hetzner.com/cloud/cost-optimized](https://www.hetzner.com/cloud/cost-optimized) before every apply, and the cost table is annotated "May 2026 list price; re-verify".

## Test plan

- [x] `make docs` (mkdocs strict): clean.
- [x] `grep` confirms zero residual "CAX31 (or CX33)" / "interim" / "gated on #712" language.
- [x] All 22 occurrences of CX43 read coherently in context.

## Closes

Nothing — the issues that drove the prior amendment (#716, etc.) are already closed via #738. This PR only updates docs to reflect the correct live price the operator will actually pay.

## Notes

- Docs-only PR, no code changes. CI surface limited to mkdocs strict + markdownlint (both green).
- If you want to ship the corresponding Terraform default change too (`var.server_type` default `"cx33"` → `"cx43"` in [`infra/terraform/variables.tf`](infra/terraform/variables.tf)), that's a separate small PR — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)