### PR TITLE
fix(ci): prod GHA SSH via PROD_SSH_PRIVATE_KEY for deploy and backup

### DIFF
--- a/.github/actions/prod-ssh-key/action.yml
+++ b/.github/actions/prod-ssh-key/action.yml
@@ -1,0 +1,28 @@
+name: Prod deploy SSH identity
+description: |
+  Writes the GitHub Actions secret PROD_SSH_PRIVATE_KEY (full PEM) to a
+  runner-local file and exports SSH_PROD_IDENTITY for ssh -i … in workflows
+  that SSH as deploy@ on the prod VPS (after Tailscale join).
+
+inputs:
+  ssh_private_key:
+    description: Full PEM contents of the CI-only key trusted by deploy@ on prod.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Write PEM to isolated file
+      shell: bash
+      env:
+        KEY_MATERIAL: ${{ inputs.ssh_private_key }}
+      run: |
+        set -euo pipefail
+        if [ -z "${KEY_MATERIAL}" ]; then
+          echo "::error::prod-ssh-key: ssh_private_key input is empty"
+          exit 1
+        fi
+        key_file="${RUNNER_TEMP}/gha_prod_ssh_ed25519"
+        printenv KEY_MATERIAL > "$key_file"
+        chmod 600 "$key_file"
+        echo "SSH_PROD_IDENTITY=${key_file}" >> "${GITHUB_ENV}"

--- a/.github/workflows/backup-corpus-prod.yml
+++ b/.github/workflows/backup-corpus-prod.yml
@@ -12,8 +12,9 @@ name: Backup corpus snapshot (prod VPS)
 # Closes #722 (Phase A side). #744: resolve prod MagicDNS host after join.
 #
 # Operator prerequisites (#714):
-#   secrets: TS_AUTHKEY (Free-plan substitute for OAuth — see PROD_RUNBOOK.md
-#            "Tailscale credentials"), BACKUP_REPO_TOKEN
+#   secrets: TS_AUTHKEY (see PROD_RUNBOOK.md "Tailscale credentials");
+#            PROD_SSH_PRIVATE_KEY (Ed25519 PEM for deploy@ — see "GitHub Actions SSH to prod");
+#            BACKUP_REPO_TOKEN (required when dry_run is false)
 #   vars:    PROD_TAILNET_FQDN, PODCAST_BACKUP_REPO (defaults to chipi/podcast_scraper-backup)
 
 on:
@@ -38,14 +39,16 @@ jobs:
       - name: Pre-flight — required secrets/variables present?
         id: preflight
         env:
-          TS_AUTHKEY:        ${{ secrets.TS_AUTHKEY }}
-          BACKUP_REPO_TOKEN: ${{ secrets.BACKUP_REPO_TOKEN }}
-          PROD_TAILNET_FQDN: ${{ vars.PROD_TAILNET_FQDN }}
+          TS_AUTHKEY:            ${{ secrets.TS_AUTHKEY }}
+          PROD_SSH_PRIVATE_KEY:  ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          BACKUP_REPO_TOKEN:     ${{ secrets.BACKUP_REPO_TOKEN }}
+          PROD_TAILNET_FQDN:     ${{ vars.PROD_TAILNET_FQDN }}
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ]        && MISSING="$MISSING TS_AUTHKEY"
-          [ -z "${PROD_TAILNET_FQDN:-}" ] && MISSING="$MISSING PROD_TAILNET_FQDN"
+          [ -z "${TS_AUTHKEY:-}" ]            && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${PROD_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING PROD_SSH_PRIVATE_KEY"
+          [ -z "${PROD_TAILNET_FQDN:-}" ]    && MISSING="$MISSING PROD_TAILNET_FQDN"
           if [ "${{ inputs.dry_run }}" = "false" ] && [ -z "${BACKUP_REPO_TOKEN:-}" ]; then
             MISSING="$MISSING BACKUP_REPO_TOKEN"
           fi
@@ -72,6 +75,12 @@ jobs:
           # Pinned — `version: latest` broke sha256 verification in GHA (May 2026).
           version: 1.96.4
 
+      - name: Install SSH identity for deploy@ (PROD_SSH_PRIVATE_KEY)
+        if: steps.preflight.outputs.skip != 'true'
+        uses: ./.github/actions/prod-ssh-key
+        with:
+          ssh_private_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+
       - name: Resolve prod MagicDNS host (GH-744)
         id: ts_host
         if: steps.preflight.outputs.skip != 'true'
@@ -97,7 +106,8 @@ jobs:
           # exit code propagates and we fail fast (no half-tarball that passes
           # naive size checks). The VPS bind-mount path is /srv/podcast-scraper/corpus
           # per RFC-082 Decision 4.
-          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+          ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
             'tar -czf - -C /srv/podcast-scraper corpus' > snapshot.tgz
 
           echo "Tarball created: $(du -h snapshot.tgz | cut -f1)"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,9 +12,9 @@ name: Deploy to prod VPS
 # #744 (resolve prod MagicDNS host after Tailscale join; suffix drift).
 #
 # Operator prerequisites (#714):
-#   - secrets: TS_AUTHKEY (Free-plan substitute for OAuth — see PROD_RUNBOOK.md
-#              "Tailscale credentials" for why two creds — TS_AUTHKEY for device
-#              join here, TS_API_KEY for terraform's tailscale provider)
+#   - secrets: TS_AUTHKEY (see PROD_RUNBOOK.md "Tailscale credentials");
+#              PROD_SSH_PRIVATE_KEY (Ed25519 PEM for deploy@ — see PROD_RUNBOOK
+#              "GitHub Actions SSH to prod")
 #   - vars:    PROD_TAILNET_FQDN (e.g. "prod-podcast.example.ts.net")
 
 on:
@@ -44,13 +44,15 @@ jobs:
       - name: Pre-flight — required secrets/variables present?
         id: preflight
         env:
-          TS_AUTHKEY:        ${{ secrets.TS_AUTHKEY }}
+          TS_AUTHKEY:              ${{ secrets.TS_AUTHKEY }}
+          PROD_SSH_PRIVATE_KEY:     ${{ secrets.PROD_SSH_PRIVATE_KEY }}
           PROD_TAILNET_FQDN: ${{ vars.PROD_TAILNET_FQDN }}
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ]        && MISSING="$MISSING TS_AUTHKEY"
-          [ -z "${PROD_TAILNET_FQDN:-}" ] && MISSING="$MISSING PROD_TAILNET_FQDN"
+          [ -z "${TS_AUTHKEY:-}" ]            && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${PROD_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING PROD_SSH_PRIVATE_KEY"
+          [ -z "${PROD_TAILNET_FQDN:-}" ]    && MISSING="$MISSING PROD_TAILNET_FQDN"
           if [ -n "$MISSING" ]; then
             echo "::warning::Missing prereqs:$MISSING"
             echo "::warning::Stage them per #714 then re-run this workflow."
@@ -85,6 +87,12 @@ jobs:
           # Pinned — `version: latest` broke sha256 verification in GHA (May 2026).
           version: 1.96.4
 
+      - name: Install SSH identity for deploy@ (PROD_SSH_PRIVATE_KEY)
+        if: steps.preflight.outputs.skip != 'true'
+        uses: ./.github/actions/prod-ssh-key
+        with:
+          ssh_private_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+
       - name: Resolve prod MagicDNS host (GH-744)
         id: ts_host
         if: steps.preflight.outputs.skip != 'true'
@@ -109,7 +117,8 @@ jobs:
           SHA_SHORT:  ${{ steps.sha.outputs.short }}
           SSH_TARGET: deploy@${{ steps.ts_host.outputs.resolved_fqdn }}
         run: |
-          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+          ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
             "sudo sed -i '/^PODCAST_RELEASE=/d' /srv/podcast-scraper/.env && \
              echo 'PODCAST_RELEASE=sha-${SHA_SHORT}' | sudo tee -a /srv/podcast-scraper/.env >/dev/null"
 
@@ -122,7 +131,8 @@ jobs:
         env:
           SSH_TARGET: deploy@${{ steps.ts_host.outputs.resolved_fqdn }}
         run: |
-          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+          ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
             '/srv/podcast-scraper/infra/deploy/deploy.sh'
 
       - name: External /api/health probe over Tailscale (#720)
@@ -143,7 +153,8 @@ jobs:
             sleep 5
           done
           echo "::error::/api/health did not return ok within 60s over tailnet"
-          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+          ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
             "deploy@${{ steps.ts_host.outputs.resolved_fqdn }}" \
             'docker logs --tail 50 compose-api-1' 2>&1 || true
           exit 1

--- a/docs/ci/WORKFLOWS.md
+++ b/docs/ci/WORKFLOWS.md
@@ -40,7 +40,7 @@ pipeline failures are diagnosable from the workflow log.
 
 **OpenTofu / DR drill (RFC-082 / #752):** `infra-ci.yml` posts the **default** workspace plan on PRs touching `infra/**`. `drill-infra-plan.yml` posts a second comment with the **`drill`** workspace plan (same path filters). Manual apply uses `infra-apply.yml` (environment **prod**) versus `drill-infra-apply.yml` (environment **drill**). `drill-e2e.yml` (environment **drill**, confirm **`DRILL_SMOKE`**) probes **`/api/health`** on the drill VPS over Tailscale. See `infra/README.md`.
 
-**Corpus backups (RFC-082):** `backup-corpus.yml` (**Backup corpus snapshot**) is **`workflow_dispatch` only** (start the codespace, then dispatch, or `make codespace-backup-cloud`). `backup-corpus-prod.yml` (**Backup corpus snapshot (prod VPS)**) pulls `/srv/podcast-scraper/corpus` over Tailscale; also manual until issue **#723** enables a prod schedule. Release tags: `snapshot-YYYYMMDD` (codespace) vs `snapshot-prod-YYYYMMDD` (VPS).
+**Corpus backups (RFC-082):** `backup-corpus.yml` (**Backup corpus snapshot**) is **`workflow_dispatch` only** (start the codespace, then dispatch, or `make codespace-backup-cloud`). `backup-corpus-prod.yml` (**Backup corpus snapshot (prod VPS)**) pulls `/srv/podcast-scraper/corpus` over Tailscale SSH as `deploy@` using **`PROD_SSH_PRIVATE_KEY`** (same as **`deploy-prod.yml`**; see `docs/guides/PROD_RUNBOOK.md` **GitHub Actions SSH to prod**); also manual until issue **#723** enables a prod schedule. Release tags: `snapshot-YYYYMMDD` (codespace) vs `snapshot-prod-YYYYMMDD` (VPS).
 
 ---
 

--- a/docs/guides/PROD_RUNBOOK.md
+++ b/docs/guides/PROD_RUNBOOK.md
@@ -27,7 +27,7 @@ Need the short version for daily ops? Use
 10. [Tailscale operations](#tailscale-operations)
 11. [Hetzner operations](#hetzner-operations)
 12. [Operator hot-fix workflow](#operator-hot-fix-workflow)
-13. [FAQ / Troubleshooting](#faq-troubleshooting)
+13. [FAQ / Troubleshooting](#faq-troubleshooting) — includes [Cursor or automation cannot `ssh deploy@prod`](#cursor-or-automation-cannot-ssh-deployprod)
 14. [Constraints to know](#constraints-to-know)
 
 ---
@@ -58,6 +58,7 @@ gh secret set TS_AUTHKEY            --repo chipi/podcast_scraper --app actions -
 gh secret set TS_API_KEY            --repo chipi/podcast_scraper --app actions --body '<tskey-api-...>'
 gh secret set TFSTATE_AGE_KEY       --repo chipi/podcast_scraper --app actions --body "$(cat ~/.config/sops/age/keys.txt)"
 gh secret set BACKUP_REPO_TOKEN     --repo chipi/podcast_scraper --app actions --body '<backup-repo-pat>'
+# PROD_SSH_PRIVATE_KEY — see [GitHub Actions SSH to prod](#github-actions-ssh-to-prod-prod_ssh_private_key)
 
 # 4. Stage GHA repo variables
 gh variable set OPERATOR_SSH_PUBLIC_KEY --repo chipi/podcast_scraper --body "$(cat ~/.ssh/id_ed25519.pub)"
@@ -65,6 +66,53 @@ gh variable set TAILNET_NAME            --repo chipi/podcast_scraper --body 'tai
 # PROD_TAILNET_FQDN is set after first apply (it depends on the assigned hostname);
 # default value is "prod-podcast.<TAILNET_NAME>".
 ```
+
+### GitHub Actions SSH to prod (`PROD_SSH_PRIVATE_KEY`) {#github-actions-ssh-to-prod-prod_ssh_private_key}
+
+`deploy-prod.yml` and `backup-corpus-prod.yml` run OpenSSH as `deploy@<prod>` **after**
+the runner joins the tailnet. The Tailscale ACL allows **reachability** to port 22;
+OpenSSH still requires a private key whose **public** half is listed in
+`~deploy/.ssh/authorized_keys` on the VPS (Tailscale SSH is intentionally not used;
+see `tailscale/policy.hujson` comments).
+
+**One-time setup**
+
+1. On a trusted machine, generate a **CI-only** Ed25519 key (empty passphrase):
+
+   ```bash
+   ssh-keygen -t ed25519 -f ./gha-prod-deploy -N "" -C "github-actions-prod-deploy"
+   ```
+
+2. SSH to prod using your **operator** key (the same public key OpenTofu passed as
+   `TF_VAR_ssh_public_key` / `vars.OPERATOR_SSH_PUBLIC_KEY`). As `deploy`, append **exactly one line**
+   (the contents of `gha-prod-deploy.pub`) to `~/.ssh/authorized_keys`. Directory `~/.ssh` should be
+   mode `700` and `authorized_keys` mode `600`.
+
+3. Verify key auth before touching GitHub:
+
+   ```bash
+   ssh -i ./gha-prod-deploy -o BatchMode=yes deploy@<prod-tailnet-host> 'echo ok'
+   ```
+
+   Use the same hostname the workflows resolve (see [suffix drift](#tailscale-suffix-drift) if unsure).
+
+4. Store the **private** PEM in a repo Actions secret (entire file, including `BEGIN OPENSSH PRIVATE KEY`
+   / `END` lines):
+
+   ```bash
+   gh secret set PROD_SSH_PRIVATE_KEY --repo chipi/podcast_scraper --app actions < ./gha-prod-deploy
+   ```
+
+5. Remove or securely archive `gha-prod-deploy` on disk; do not commit it.
+
+Workflows load this via the composite action `.github/actions/prod-ssh-key`, which exports
+`SSH_PROD_IDENTITY` for `ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes …`. Any **future** workflow
+that SSHes to prod as `deploy@` should reuse `secrets.PROD_SSH_PRIVATE_KEY` and the same flags so
+GitHub never relies on keys baked into the runner image.
+
+**Rotating the CI key:** generate a new keypair, append the new public key to `authorized_keys` (keep
+the old line until one green workflow run), update `PROD_SSH_PRIVATE_KEY`, re-run `deploy-prod.yml` or
+`backup-corpus-prod.yml`, then delete the superseded public key line on the VPS.
 
 ### First `tofu apply` (operator's laptop)
 
@@ -988,6 +1036,68 @@ Diagnose with:
 ssh deploy@prod-podcast.<tailnet> \
   'docker logs --tail 50 compose-grafana-agent-1 | grep -iE "error|401|403|forbidden"'
 ```
+
+### "Cursor or automation cannot `ssh deploy@prod`"
+
+First confirm **Tailscale** on the machine that runs the command:
+
+```bash
+tailscale status | head -5
+```
+
+You should see `prod-podcast-1` (or similar) as **active**. SSH to the VPS is
+intended **over the tailnet** only; inbound SSH on the public Hetzner IPv4 is
+not exposed in the default firewall.
+
+Then confirm **OpenSSH has a usable key** for that shell:
+
+```bash
+ssh-add -l
+```
+
+If this prints **"The agent has no identities."**, no key is loaded for that
+process. Keys added only in another app (for example Terminal.app) do not
+always end up on the **same** `SSH_AUTH_SOCK` that a Cursor agent subprocess
+inherits.
+
+**Time-limited agent load (recommended for IDE / agent `ssh` to prod):** in
+**Cursor’s integrated terminal** for this workspace, load the operator private
+key into `ssh-agent` with a lifetime so it is not left loaded indefinitely:
+
+```bash
+ssh-add -t 30m ~/.ssh/id_ed25519
+ssh-add -l
+```
+
+After **30 minutes** the key is removed from the agent again; `ssh-add -l` will
+go back to empty and agent-driven `ssh` will fail until you re-run `ssh-add
+-t …`. That matches “it worked earlier today, then stopped.”
+
+If your operator key is not `~/.ssh/id_ed25519`, substitute the path that
+matches `TF_VAR_ssh_public_key` / `vars.OPERATOR_SSH_PUBLIC_KEY`.
+
+**macOS Keychain persistence (optional):** if you prefer the key to survive
+agent restarts until reboot:
+
+```bash
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+ssh-add -l
+```
+
+Sanity check:
+
+```bash
+ssh -o IdentitiesOnly=yes -i ~/.ssh/<operator-private-key> \
+  deploy@prod-podcast-1.<tailnet> 'echo ok'
+```
+
+Replace `<tailnet>` with your MagicDNS suffix (for example `tail6d0ed4.ts.net`).
+If this fails but `tailscale status` shows prod as active, you are using the
+wrong private key file for `deploy@`.
+
+**GitHub Actions** does not use your laptop `ssh-agent`; it uses
+**`PROD_SSH_PRIVATE_KEY`** and `.github/actions/prod-ssh-key` (see
+[GitHub Actions SSH to prod](#github-actions-ssh-to-prod-prod_ssh_private_key)).
 
 ### "Tailnet hostname won't resolve from my laptop"
 


### PR DESCRIPTION
Adds composite action `.github/actions/prod-ssh-key` and requires `secrets.PROD_SSH_PRIVATE_KEY` for `deploy-prod.yml` and `backup-corpus-prod.yml` (ssh -i + IdentitiesOnly). Updates PROD_RUNBOOK (GitHub Actions SSH setup, Cursor/agent `ssh-add -t 30m` FAQ) and WORKFLOWS.md.

Made with [Cursor](https://cursor.com)