### PR TITLE
fix(workflow): pass DRILL_TAILNET_FQDN to prod-failover freeze-ingestion resolve step

### DIFF
--- a/.github/workflows/prod-failover-stand-up.yml
+++ b/.github/workflows/prod-failover-stand-up.yml
@@ -129,6 +129,8 @@ jobs:
 
       - name: "Prod failover — resolve: tailnet host (MagicDNS)"
         id: ts_host
+        env:
+          DRILL_TAILNET_FQDN: ${{ vars.DRILL_TAILNET_FQDN }}
         run: |
           set -euo pipefail
           R=$(bash scripts/ops/resolve_drill_tailnet_host.sh)


### PR DESCRIPTION
## Summary

- The new `freeze-ingestion` job in `prod-failover-stand-up.yml` (shipped in #788) omits `DRILL_TAILNET_FQDN` env on its tailnet-host resolve step.
- `scripts/ops/resolve_drill_tailnet_host.sh` exits 1 when that var is missing, bailing the job before any SSH/freeze action runs.
- Every other drill job (`drill-deploy`, `drill-restore-corpus`) wires `${{ vars.DRILL_TAILNET_FQDN }}` on the equivalent step; this PR aligns `freeze-ingestion` with that pattern.

## Operational impact discovered on first real run

Run [26306877079](https://github.com/chipi/podcast_scraper/actions/runs/26306877079) reached:

- phases A–C (plan / apply / deploy / restore) ✓
- **freeze-ingestion ✗** at resolve step
- smoke + stack-playwright skipped

`scripts/ops/restore_corpus_from_tarball_host.sh:42` runs `docker compose up -d --force-recreate api viewer`, so the spare api container restarted **after** restore with the full prod `scheduled_jobs` loaded into APScheduler — the dual-writer state RFC-083 §6 specifically guards against.

Mitigation already taken: `drill-infra-destroy.yml` dispatched immediately ([run 26309064946](https://github.com/chipi/podcast_scraper/actions/runs/26309064946) — success). Spare is down; no ongoing dual-writer.

With this fix the freeze step runs before smoke, scheduler is verified empty (via `/api/scheduled-jobs`), and the spare reaches the validated, ingestion-frozen state per ADR-091.

## Test plan

- [ ] CI: workflow lint / yaml syntax pre-commit hooks pass (validated locally with `actionlint`)
- [ ] After merge: re-dispatch `prod-failover-stand-up.yml --ref main -f confirm=PROD_FAILOVER_STAND_UP`; expect freeze-ingestion job to reach the SSH/verify steps and pass; smoke + stack-playwright run to completion; finalize prints the "Spare validated" notice
- [ ] After that validation: manual `drill-infra-destroy.yml -f confirm=DRILL_DESTROY` to clean up the spare

🤖 Generated with [Claude Code](https://claude.com/claude-code)