### PR TITLE
fix(workflow): drop sudo from prod-failover freeze-ingestion SSH call

### DIFF
--- a/.github/workflows/prod-failover-stand-up.yml
+++ b/.github/workflows/prod-failover-stand-up.yml
@@ -151,9 +151,15 @@ jobs:
           SSH_TARGET: deploy@${{ steps.ts_host.outputs.resolved_fqdn }}
         run: |
           set -euo pipefail
+          # The freeze script edits /srv/podcast-scraper/corpus/viewer_operator.yaml
+          # (owned by deploy after drill-restore-corpus extracts the tarball there)
+          # and runs ``docker compose restart api`` (deploy is in the docker group).
+          # No sudo required — matches the contract of restore_corpus_from_tarball_host.sh
+          # which also runs unprivileged. The drill VPS row does not grant deploy
+          # passwordless sudo, so ``sudo -n`` would (and did) fail.
           ssh -i "$SSH_DRILL_IDENTITY" -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
-            'sudo -n bash /tmp/freeze_ingestion_on_spare.sh'
+            'bash /tmp/freeze_ingestion_on_spare.sh'
 
       - name: "Prod failover — verify: scheduler not running on spare"
         env:


### PR DESCRIPTION
## Summary

- Run [26309310419](https://github.com/chipi/podcast_scraper/actions/runs/26309310419) reached `freeze-ingestion` for the first time (post-#790) and failed at the SSH exec step with `sudo: a password is required`.
- The freeze script (`scripts/ops/failover/freeze_ingestion_on_spare.sh`) edits files in `/srv/podcast-scraper/corpus/` (owned by `deploy` after `drill-restore-corpus` extracts there) and runs `docker compose restart api` (`deploy` is in the docker group). No root needed.
- The drill VPS row's `deploy` user does not have passwordless sudo (matches the contract — only docker-group + ssh key + repo dir access). `sudo -n` was guaranteed to fail.
- Drop the `sudo -n` wrapper. Aligns with `scripts/ops/restore_corpus_from_tarball_host.sh`, which runs unprivileged.

## Operational state

Spare from run 26309310419 was again in dual-writer state (restore force-recreates api with prod `scheduled_jobs` loaded → APScheduler running on spare). Mitigated by `drill-infra-destroy` [run 26309695091](https://github.com/chipi/podcast_scraper/actions/runs/26309695091) before this PR was opened. Spare is down; no ongoing dual-writer.

## Test plan

- [ ] CI: pre-commit yaml/actionlint validated locally
- [ ] After merge: re-dispatch `prod-failover-stand-up.yml --ref main -f confirm=PROD_FAILOVER_STAND_UP`; expect freeze-ingestion to reach the verify step (poll `/api/scheduled-jobs` for empty list) and pass; smoke + stack-playwright run to completion; finalize prints "Spare validated"
- [ ] After validation: manual `drill-infra-destroy.yml -f confirm=DRILL_DESTROY` to clean up the spare

🤖 Generated with [Claude Code](https://claude.com/claude-code)