### PR TITLE
fix(failover): freeze script needs --env-file + full compose overlay

### DIFF
--- a/scripts/ops/failover/freeze_ingestion_on_spare.sh
+++ b/scripts/ops/failover/freeze_ingestion_on_spare.sh
@@ -14,7 +14,6 @@ set -euo pipefail
 
 REPO_DIR="${PODCAST_REPO_DIR:-/srv/podcast-scraper}"
 OPERATOR_YAML="${REPO_DIR}/corpus/viewer_operator.yaml"
-COMPOSE_FILE="${REPO_DIR}/compose/docker-compose.prod.yml"
 
 if [ ! -f "$OPERATOR_YAML" ]; then
   echo "freeze-ingestion: $OPERATOR_YAML missing — scheduler cannot start without it; nothing to freeze."
@@ -38,8 +37,15 @@ count = len(removed) if isinstance(removed, list) else (1 if removed else 0)
 print(f"freeze-ingestion: removed {count} scheduled_jobs entries from {path}")
 PY
 
-if [ -f "$COMPOSE_FILE" ]; then
-  docker compose -f "$COMPOSE_FILE" restart api 2>&1 | tail -10
-else
-  echo "freeze-ingestion: $COMPOSE_FILE missing — skipping api restart (deploy step should have created it)."
-fi
+# Restart api with the same compose stack + env-file as drill-restore-corpus
+# (restore_corpus_from_tarball_host.sh). docker compose validates volume
+# interpolation even on ``restart``, so PODCAST_CORPUS_HOST_PATH from
+# ${REPO_DIR}/.env must be present; --env-file is required.
+cd "$REPO_DIR"
+COMPOSE=(
+  docker compose --env-file .env
+  -f compose/docker-compose.stack.yml
+  -f compose/docker-compose.prod.yml
+  -f compose/docker-compose.vps-prod.yml
+)
+"${COMPOSE[@]}" restart api 2>&1 | tail -10


### PR DESCRIPTION
## Summary

3rd dispatch of `prod-failover-stand-up.yml` ([run 26311206682](https://github.com/chipi/podcast_scraper/actions/runs/26311206682)) reached the freeze script for the first time (post-#791), removed the `scheduled_jobs` key from `viewer_operator.yaml` successfully, then failed at `docker compose -f compose/docker-compose.prod.yml restart api`:

```
error while interpolating volumes.corpus_data.driver_opts.device:
required variable PODCAST_CORPUS_HOST_PATH is missing a value
```

`docker compose` validates volume interpolation even on `restart`. The single-file invocation skipped the same `.env` + compose overlay that `scripts/ops/restore_corpus_from_tarball_host.sh:36-42` uses. Aligning with that contract:

- `cd` to `REPO_DIR` so relative paths resolve
- `docker compose --env-file .env`
- three-file overlay: `stack.yml` + `prod.yml` + `vps-prod.yml`

## Side observation

The python step reported `removed 0 scheduled_jobs entries` — the restored `viewer_operator.yaml` already had no `scheduled_jobs` key. The dual-writer guard is still useful belt-and-braces, but practical exposure on this snapshot shape was lower than we feared; the verify step (`GET /api/scheduled-jobs` returns empty) was never reached because restart failed.

Spare from run 26311206682 was torn down via drill-infra-destroy [26312516434](https://github.com/chipi/podcast_scraper/actions/runs/26312516434).

## Test plan

- [ ] CI: pre-commit / actionlint validated locally
- [ ] After merge: 4th dispatch `prod-failover-stand-up.yml --ref main`; expect freeze step to complete the api restart and pass `/api/scheduled-jobs` verify; smoke + stack-playwright run to completion; finalize prints "Spare validated"
- [ ] After validation: manual `drill-infra-destroy.yml -f confirm=DRILL_DESTROY` cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)