### PR TITLE
feat(audio): Wave 1 — speaker refactor, chunking, commercial Phase 1, progress fix, Deepgram

### DIFF
--- a/config/examples/config.example.yaml
+++ b/config/examples/config.example.yaml
@@ -23,7 +23,7 @@ append: true
 # episode_until: "2024-12-31"
 
 # Provider configuration - mixed example (can use different providers for different capabilities)
-# Options: openai, gemini, mistral, deepseek, grok, ollama (API-based), whisper (local Whisper), spacy (local spaCy), transformers (local HuggingFace)
+# Options: openai, gemini, mistral, deepgram, deepseek, grok, ollama (API-based), whisper (local Whisper), spacy (local spaCy), transformers (local HuggingFace)
 transcription_provider: whisper  # Options: whisper, openai, gemini, mistral, deepgram (Note: deepseek, grok, and ollama do NOT support transcription)
 speaker_detector_provider: spacy  # Options: spacy, openai, gemini, mistral, deepseek, grok, ollama
 summary_provider: transformers  # Options: transformers, openai, gemini, mistral, deepseek, grok, ollama

--- a/config/examples/config.example.yaml
+++ b/config/examples/config.example.yaml
@@ -24,7 +24,7 @@ append: true
 
 # Provider configuration - mixed example (can use different providers for different capabilities)
 # Options: openai, gemini, mistral, deepseek, grok, ollama (API-based), whisper (local Whisper), spacy (local spaCy), transformers (local HuggingFace)
-transcription_provider: whisper  # Options: whisper, openai, gemini, mistral (Note: deepseek, grok, and ollama do NOT support transcription)
+transcription_provider: whisper  # Options: whisper, openai, gemini, mistral, deepgram (Note: deepseek, grok, and ollama do NOT support transcription)
 speaker_detector_provider: spacy  # Options: spacy, openai, gemini, mistral, deepseek, grok, ollama
 summary_provider: transformers  # Options: transformers, openai, gemini, mistral, deepseek, grok, ollama
 
@@ -177,6 +177,10 @@ metadata_format: json  # json or yaml (json recommended for database ingestion)
 # mistral_summary_model: mistral-large-latest  # Default: environment-based (mistral-small-latest for test, mistral-large-latest for prod)
 # mistral_temperature: 0.3  # Default: 0.3 (0.0-1.0, lower = more deterministic)
 # mistral_max_tokens: null  # Default: null (use model default)
+
+# Deepgram transcription (optional - requires pip install -e '.[llm]' for deepgram-sdk)
+# deepgram_api_key: your-key-here  # Not recommended - use .env file instead
+# deepgram_model: nova-3  # Default: nova-3
 
 # DeepSeek model configuration (optional - defaults are used if not specified)
 # Environment-based defaults:

--- a/config/pricing_assumptions.yaml
+++ b/config/pricing_assumptions.yaml
@@ -39,6 +39,7 @@ metadata:
     gemini: https://ai.google.dev/pricing
     anthropic: https://www.anthropic.com/pricing
     mistral: https://docs.mistral.ai/pricing/
+    deepgram: https://deepgram.com/pricing
     deepseek: https://platform.deepseek.com/pricing
     grok: https://docs.x.ai
 
@@ -146,6 +147,13 @@ providers:
       default:
         input_cost_per_1m_tokens: 0.20
         output_cost_per_1m_tokens: 0.60
+
+  deepgram:
+    transcription:
+      nova-3:
+        cost_per_minute: 0.0043
+      default:
+        cost_per_minute: 0.0043
 
   deepseek:
     # Source: https://api-docs.deepseek.com/quick_start/pricing (verified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ llm = [
   # files on https://pypi.org/simple/mistralai/ as of 2026-05). Pin the official v2.4.5
   # tree (commit matches tag v2.4.5) until PyPI restores the project.
   "mistralai @ https://github.com/mistralai/client-python/archive/7ebe84b5a9eee0714f81c687c8cf636eaa12476f.tar.gz",
+  "deepgram-sdk>=3.0.0,<8.0.0",
   "httpx>=0.28.1,<1.0.0",  # Ollama provider (Issue #196) - for health checks
 ]
 # Minimum local ML to build the FAISS vector index when running an otherwise cloud-only

--- a/src/podcast_scraper/cleaning/commercial/__init__.py
+++ b/src/podcast_scraper/cleaning/commercial/__init__.py
@@ -1,0 +1,12 @@
+"""Commercial detection and cleaning (Phase 1)."""
+
+from __future__ import annotations
+
+from .detector import CommercialCandidate, CommercialDetector
+from .patterns import DEFAULT_CONFIDENCE_THRESHOLD
+
+__all__ = [
+    "CommercialCandidate",
+    "CommercialDetector",
+    "DEFAULT_CONFIDENCE_THRESHOLD",
+]

--- a/src/podcast_scraper/cleaning/commercial/detector.py
+++ b/src/podcast_scraper/cleaning/commercial/detector.py
@@ -1,0 +1,183 @@
+"""Confidence-scored commercial segment detection and removal."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from .patterns import (
+    BLOCK_END_PATTERNS,
+    BLOCK_START_PATTERNS,
+    BRAND_NAMES,
+    DEFAULT_CONFIDENCE_THRESHOLD,
+    SPONSOR_PATTERNS,
+    SponsorPattern,
+)
+from .positions import position_score
+
+_BACKSCAN_CHARS = 500
+_FORWARD_SCAN_CHARS = 2000
+_MAX_LOW_CONFIDENCE_BLOCK_RATIO = 0.4
+_HIGH_CONFIDENCE_FOR_LARGE_BLOCK = 0.85
+
+
+@dataclass(frozen=True)
+class CommercialCandidate:
+    """One detected sponsor region."""
+
+    start: int
+    end: int
+    confidence: float
+    matched_pattern: str
+
+
+class CommercialDetector:
+    """Multi-signal commercial detection (Phase 1: patterns + position)."""
+
+    def __init__(
+        self,
+        *,
+        confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+    ) -> None:
+        self.confidence_threshold = confidence_threshold
+
+    def detect(self, text: str) -> List[CommercialCandidate]:
+        """Return sponsor candidates above threshold after boundary expansion."""
+        if not text:
+            return []
+
+        candidates: List[CommercialCandidate] = []
+        seen_spans: set[Tuple[int, int]] = set()
+        text_len = len(text)
+
+        for sponsor_pattern in SPONSOR_PATTERNS:
+            for match in sponsor_pattern.pattern.finditer(text):
+                base_conf = sponsor_pattern.confidence
+                base_conf += position_score(match.start(), text_len)
+                if _text_mentions_brand(text, match.start(), match.end()):
+                    base_conf += 0.1
+                if base_conf < self.confidence_threshold:
+                    continue
+                start, end = _detect_sponsor_boundaries(
+                    text, match.start(), match.end(), sponsor_pattern
+                )
+                if _span_too_large_for_confidence(start, end, text_len, base_conf):
+                    continue
+                span = (start, end)
+                if span in seen_spans or start >= end:
+                    continue
+                seen_spans.add(span)
+                candidates.append(
+                    CommercialCandidate(
+                        start=start,
+                        end=end,
+                        confidence=min(base_conf, 1.0),
+                        matched_pattern=sponsor_pattern.pattern.pattern,
+                    )
+                )
+
+        candidates.sort(key=lambda c: c.start)
+        return _merge_overlapping_candidates(candidates)
+
+    def remove(self, text: str) -> str:
+        """Remove detected commercial regions from text."""
+        cleaned = text
+        for candidate in reversed(self.detect(text)):
+            cleaned = cleaned[: candidate.start] + cleaned[candidate.end :]
+        return cleaned
+
+
+def _span_too_large_for_confidence(start: int, end: int, text_len: int, confidence: float) -> bool:
+    """Reject low-confidence detections that would excise most of the transcript."""
+    if text_len <= 0 or end <= start:
+        return True
+    if confidence >= _HIGH_CONFIDENCE_FOR_LARGE_BLOCK:
+        return False
+    span_ratio = (end - start) / text_len
+    return span_ratio > _MAX_LOW_CONFIDENCE_BLOCK_RATIO
+
+
+def _text_mentions_brand(text: str, start: int, end: int) -> bool:
+    window = text[max(0, start - 200) : min(len(text), end + 400)].lower()
+    return any(brand in window for brand in BRAND_NAMES)
+
+
+def _paragraph_start(text: str, index: int) -> int:
+    prev_break = text.rfind("\n\n", 0, index)
+    return 0 if prev_break == -1 else prev_break + 2
+
+
+def _paragraph_end(text: str, index: int) -> int:
+    next_break = text.find("\n\n", index)
+    if next_break == -1:
+        return len(text)
+    return next_break
+
+
+def _scan_for_pattern(
+    text: str,
+    patterns: List[SponsorPattern],
+    start: int,
+    end: int,
+    *,
+    reverse: bool,
+) -> Optional[int]:
+    segment = text[start:end]
+    if reverse:
+        segment = segment[::-1]
+    for sponsor_pattern in patterns:
+        match = sponsor_pattern.pattern.search(segment)
+        if match:
+            if reverse:
+                return end - match.end()
+            return start + match.start()
+    return None
+
+
+def _detect_sponsor_boundaries(
+    text: str,
+    match_start: int,
+    match_end: int,
+    matched: SponsorPattern,
+) -> Tuple[int, int]:
+    """Find block start/end using boundary patterns with paragraph fallback."""
+    back_start = max(0, match_start - _BACKSCAN_CHARS)
+    block_start = _scan_for_pattern(
+        text, BLOCK_START_PATTERNS, back_start, match_start, reverse=True
+    )
+    if block_start is None:
+        block_start = _paragraph_start(text, match_start)
+    else:
+        block_start = max(back_start, block_start)
+
+    forward_end = min(len(text), match_end + _FORWARD_SCAN_CHARS)
+    block_end = _scan_for_pattern(text, BLOCK_END_PATTERNS, match_end, forward_end, reverse=False)
+    if block_end is None:
+        block_end = _paragraph_end(text, match_end)
+    else:
+        block_end = min(len(text), block_end)
+
+    if matched.boundary_hint == "inline" and block_end - block_start > 2000:
+        block_end = min(block_start + 2000, len(text))
+
+    return block_start, max(block_end, match_end)
+
+
+def _merge_overlapping_candidates(
+    candidates: List[CommercialCandidate],
+) -> List[CommercialCandidate]:
+    if not candidates:
+        return []
+    merged: List[CommercialCandidate] = [candidates[0]]
+    for candidate in candidates[1:]:
+        prev = merged[-1]
+        if candidate.start <= prev.end:
+            merged[-1] = CommercialCandidate(
+                start=prev.start,
+                end=max(prev.end, candidate.end),
+                confidence=max(prev.confidence, candidate.confidence),
+                matched_pattern=prev.matched_pattern,
+            )
+        else:
+            merged.append(candidate)
+    return merged

--- a/src/podcast_scraper/cleaning/commercial/patterns.py
+++ b/src/podcast_scraper/cleaning/commercial/patterns.py
@@ -1,0 +1,124 @@
+"""Categorized sponsor/ad patterns for commercial detection."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Set
+
+DEFAULT_CONFIDENCE_THRESHOLD = 0.65
+
+
+@dataclass(frozen=True)
+class SponsorPattern:
+    """One detectable sponsor phrase with metadata."""
+
+    pattern: re.Pattern[str]
+    category: str
+    confidence: float
+    boundary_hint: str
+
+
+SPONSOR_PATTERNS: List[SponsorPattern] = [
+    SponsorPattern(
+        re.compile(r"this episode is (?:brought to you|sponsored|powered) by", re.I),
+        "intro",
+        0.9,
+        "block_start",
+    ),
+    SponsorPattern(
+        re.compile(r"today'?s (?:episode|show|podcast) is (?:brought|sponsored|supported)", re.I),
+        "intro",
+        0.9,
+        "block_start",
+    ),
+    SponsorPattern(
+        re.compile(
+            r"(?:a )?(?:quick )?(?:word|message|shout.?out) from (?:our|today'?s) sponsor",
+            re.I,
+        ),
+        "intro",
+        0.85,
+        "block_start",
+    ),
+    SponsorPattern(
+        re.compile(r"(?:let me|I want to) tell you about", re.I),
+        "intro",
+        0.6,
+        "block_start",
+    ),
+    SponsorPattern(
+        re.compile(r"before we (?:continue|get back|go on|dive in)", re.I),
+        "intro",
+        0.5,
+        "block_start",
+    ),
+    SponsorPattern(
+        re.compile(r"our sponsors today are", re.I),
+        "intro",
+        0.85,
+        "block_start",
+    ),
+    SponsorPattern(
+        re.compile(r"(?:visit|go to|head to|check out) \S+\.com(?:/\S+)?", re.I),
+        "cta",
+        0.5,
+        "inline",
+    ),
+    SponsorPattern(
+        re.compile(r"use (?:code|promo|coupon) [A-Z0-9]+", re.I),
+        "cta",
+        0.7,
+        "inline",
+    ),
+    SponsorPattern(
+        re.compile(r"(?:free trial|sign up|get started) (?:at|today)", re.I),
+        "cta",
+        0.5,
+        "inline",
+    ),
+    SponsorPattern(
+        re.compile(r"(?:now )?(?:back to|let'?s get back to|returning to) (?:the|our)", re.I),
+        "outro",
+        0.7,
+        "block_end",
+    ),
+    SponsorPattern(
+        re.compile(
+            r"(?:welcome back to (?:the|our) (?:show|episode|podcast)"
+            r"|we'?re back(?: to the show)?|okay,? so)",
+            re.I,
+        ),
+        "outro",
+        0.5,
+        "block_end",
+    ),
+    SponsorPattern(
+        re.compile(r"thanks (?:again )?to (?:our )?(?:friends|partners|sponsor)", re.I),
+        "outro",
+        0.85,
+        "block_end",
+    ),
+]
+
+BLOCK_START_PATTERNS = [p for p in SPONSOR_PATTERNS if p.boundary_hint == "block_start"]
+BLOCK_END_PATTERNS = [p for p in SPONSOR_PATTERNS if p.boundary_hint == "block_end"]
+
+BRAND_NAMES: Set[str] = {
+    "stripe",
+    "figma",
+    "notion",
+    "linear",
+    "vanta",
+    "miro",
+    "zapier",
+    "hubspot",
+    "squarespace",
+    "shopify",
+    "mailchimp",
+    "convertkit",
+    "airtable",
+    "wix",
+    "justworks",
+    "lenny",
+}

--- a/src/podcast_scraper/cleaning/commercial/positions.py
+++ b/src/podcast_scraper/cleaning/commercial/positions.py
@@ -1,0 +1,24 @@
+"""Positional heuristics for commercial segment detection."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+POSITION_WINDOWS: Dict[str, Tuple[float, float]] = {
+    "pre_roll": (0.00, 0.15),
+    "mid_roll": (0.35, 0.65),
+    "post_roll": (0.80, 1.00),
+}
+
+POSITION_BOOST = 0.15
+
+
+def position_score(char_index: int, text_length: int) -> float:
+    """Return positional confidence boost when match falls in an ad-break window."""
+    if text_length <= 0:
+        return 0.0
+    ratio = char_index / text_length
+    for _name, (start, end) in POSITION_WINDOWS.items():
+        if start <= ratio <= end:
+            return POSITION_BOOST
+    return 0.0

--- a/src/podcast_scraper/cli.py
+++ b/src/podcast_scraper/cli.py
@@ -1123,7 +1123,7 @@ def _add_transcription_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--transcription-provider",
-        choices=["whisper", "openai", "gemini", "mistral"],
+        choices=["whisper", "openai", "gemini", "mistral", "deepgram"],
         default="whisper",
         help=(
             "Transcription provider to use (default: whisper). "
@@ -1695,6 +1695,22 @@ def _add_mistral_arguments(parser: argparse.ArgumentParser) -> None:
         type=float,
         default=None,
         help="Temperature for Mistral cleaning (0.0-1.0, default: 0.2, lower = more deterministic)",
+    )
+
+
+def _add_deepgram_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add Deepgram API-related arguments to parser."""
+    parser.add_argument(
+        "--deepgram-api-key",
+        type=str,
+        default=None,
+        help="Deepgram API key (or set DEEPGRAM_API_KEY env var)",
+    )
+    parser.add_argument(
+        "--deepgram-model",
+        type=str,
+        default=None,
+        help="Deepgram transcription model (default: nova-3)",
     )
 
 
@@ -3562,6 +3578,7 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     _add_gemini_arguments(parser)
     _add_anthropic_arguments(parser)
     _add_mistral_arguments(parser)
+    _add_deepgram_arguments(parser)
     _add_deepseek_arguments(parser)
     _add_grok_arguments(parser)
     _add_ollama_arguments(parser)
@@ -3850,6 +3867,10 @@ def _build_config(args: argparse.Namespace) -> config.Config:  # noqa: C901
     # The field validator will load it from MISTRAL_API_KEY env var if available
     # But allow CLI override if provided
     payload["mistral_api_key"] = getattr(args, "mistral_api_key", None)
+    # Add Deepgram API configuration
+    if hasattr(args, "deepgram_model") and args.deepgram_model is not None:
+        payload["deepgram_model"] = args.deepgram_model
+    payload["deepgram_api_key"] = getattr(args, "deepgram_api_key", None)
     # Add DeepSeek API configuration
     payload["deepseek_api_base"] = getattr(args, "deepseek_api_base", None)
     if hasattr(args, "deepseek_speaker_model") and args.deepseek_speaker_model is not None:

--- a/src/podcast_scraper/config.py
+++ b/src/podcast_scraper/config.py
@@ -1132,21 +1132,21 @@ class Config(BaseModel):
         description="Speaker detection provider type (default: 'spacy' for spaCy NER).",
     )
     transcription_provider: Literal[
-        "whisper", "openai", "gemini", "mistral", "tailnet_dgx_whisper"
+        "whisper", "openai", "gemini", "mistral", "deepgram", "tailnet_dgx_whisper"
     ] = Field(
         default="whisper",
         alias="transcription_provider",
         description="Transcription provider type (default: 'whisper' for local Whisper)",
     )
-    transcription_fallback_provider: Optional[Literal["whisper", "openai", "gemini", "mistral"]] = (
-        Field(
-            default=None,
-            alias="transcription_fallback_provider",
-            description=(
-                "Cloud/local fallback when transcription_provider is tailnet_dgx_whisper "
-                "(mandatory for DGX-primary prod profiles per ADR-096)."
-            ),
-        )
+    transcription_fallback_provider: Optional[
+        Literal["whisper", "openai", "gemini", "mistral", "deepgram"]
+    ] = Field(
+        default=None,
+        alias="transcription_fallback_provider",
+        description=(
+            "Cloud/local fallback when transcription_provider is tailnet_dgx_whisper "
+            "(mandatory for DGX-primary prod profiles per ADR-096)."
+        ),
     )
     dgx_tailnet_host: Optional[str] = Field(
         default=None,
@@ -1769,6 +1769,16 @@ class Config(BaseModel):
         default=None,
         alias="mistral_api_key",
         description="Mistral API key (prefer MISTRAL_API_KEY env var or .env file)",
+    )
+    deepgram_api_key: Optional[str] = Field(
+        default=None,
+        alias="deepgram_api_key",
+        description="Deepgram API key (prefer DEEPGRAM_API_KEY env var or .env file)",
+    )
+    deepgram_model: str = Field(
+        default="nova-3",
+        alias="deepgram_model",
+        description="Deepgram model for transcription (default: nova-3)",
     )
     mistral_api_base: Optional[str] = Field(
         default=None,
@@ -3341,6 +3351,7 @@ class Config(BaseModel):
         cls._load_string_env_var(data, "anthropic_api_key", "ANTHROPIC_API_KEY")
         cls._load_string_env_var(data, "anthropic_api_base", "ANTHROPIC_API_BASE")
         cls._load_string_env_var(data, "mistral_api_key", "MISTRAL_API_KEY")
+        cls._load_string_env_var(data, "deepgram_api_key", "DEEPGRAM_API_KEY")
         cls._load_string_env_var(data, "mistral_api_base", "MISTRAL_API_BASE")
         cls._load_string_env_var(data, "deepseek_api_key", "DEEPSEEK_API_KEY")
         cls._load_string_env_var(data, "deepseek_api_base", "DEEPSEEK_API_BASE")
@@ -3827,9 +3838,15 @@ class Config(BaseModel):
 
     @field_validator("transcription_provider", mode="before")
     @classmethod
-    def _validate_transcription_provider(
-        cls, value: Any
-    ) -> Literal["whisper", "openai", "gemini", "mistral", "anthropic", "tailnet_dgx_whisper"]:
+    def _validate_transcription_provider(cls, value: Any) -> Literal[
+        "whisper",
+        "openai",
+        "gemini",
+        "mistral",
+        "deepgram",
+        "anthropic",
+        "tailnet_dgx_whisper",
+    ]:
         """Validate transcription provider."""
         if value is None or value == "":
             return "whisper"
@@ -3839,12 +3856,13 @@ class Config(BaseModel):
             "openai",
             "gemini",
             "mistral",
+            "deepgram",
             "anthropic",
             "tailnet_dgx_whisper",
         ):
             raise ValueError(
                 "transcription_provider must be 'whisper', 'openai', 'gemini', "
-                "'mistral', 'anthropic', or 'tailnet_dgx_whisper'"
+                "'mistral', 'deepgram', 'anthropic', or 'tailnet_dgx_whisper'"
             )
         return value_str  # type: ignore[return-value]
 
@@ -4466,6 +4484,25 @@ class Config(BaseModel):
                 "Set MISTRAL_API_KEY environment variable or mistral_api_key in config."
             )
 
+        return self
+
+    @model_validator(mode="after")
+    def _validate_deepgram_provider_requirements(self) -> "Config":
+        """Validate Deepgram API key when Deepgram transcription is selected."""
+        if self.transcription_provider == "deepgram" and not self.deepgram_api_key:
+            raise ValueError(
+                "Deepgram API key required for transcription_provider='deepgram'. "
+                "Set DEEPGRAM_API_KEY environment variable or deepgram_api_key in config."
+            )
+        if (
+            self.transcription_provider == "tailnet_dgx_whisper"
+            and self.transcription_fallback_provider == "deepgram"
+            and not self.deepgram_api_key
+        ):
+            raise ValueError(
+                "Deepgram API key required for transcription_fallback_provider='deepgram'. "
+                "Set DEEPGRAM_API_KEY environment variable or deepgram_api_key in config."
+            )
         return self
 
     @field_validator("summary_model", mode="before")

--- a/src/podcast_scraper/data/pricing_assumptions.yaml
+++ b/src/podcast_scraper/data/pricing_assumptions.yaml
@@ -39,6 +39,7 @@ metadata:
     gemini: https://ai.google.dev/pricing
     anthropic: https://www.anthropic.com/pricing
     mistral: https://docs.mistral.ai/pricing/
+    deepgram: https://deepgram.com/pricing
     deepseek: https://platform.deepseek.com/pricing
     grok: https://docs.x.ai
 
@@ -146,6 +147,13 @@ providers:
       default:
         input_cost_per_1m_tokens: 0.20
         output_cost_per_1m_tokens: 0.60
+
+  deepgram:
+    transcription:
+      nova-3:
+        cost_per_minute: 0.0043
+      default:
+        cost_per_minute: 0.0043
 
   deepseek:
     # Source: https://api-docs.deepseek.com/quick_start/pricing (verified

--- a/src/podcast_scraper/preprocessing/audio/chunker.py
+++ b/src/podcast_scraper/preprocessing/audio/chunker.py
@@ -1,0 +1,216 @@
+"""Split oversized audio files for API transcription providers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from podcast_scraper.preprocessing.audio.ffmpeg_processor import _run_text_subprocess
+from podcast_scraper.rss.downloader import OPENAI_MAX_FILE_SIZE_BYTES
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OVERLAP_SECONDS = 5.0
+DEFAULT_MAX_BYTES = OPENAI_MAX_FILE_SIZE_BYTES - (1024 * 1024)
+
+
+@dataclass(frozen=True)
+class AudioChunk:
+    """One segment of a split audio file."""
+
+    path: str
+    start_seconds: float
+    index: int
+
+
+def _probe_duration_seconds(audio_path: str) -> Optional[float]:
+    """Return media duration in seconds via ffprobe."""
+    if not shutil.which("ffprobe"):
+        logger.warning("ffprobe not available; cannot chunk audio")
+        return None
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "json",
+        audio_path,
+    ]
+    try:
+        result = _run_text_subprocess(cmd, timeout=30.0, check=True)
+        data = json.loads(result.stdout)
+        duration = float(data.get("format", {}).get("duration", 0))
+        return duration if duration > 0 else None
+    except (subprocess.CalledProcessError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to probe audio duration for chunking: %s", exc)
+        return None
+
+
+def _dedupe_overlap_text(prev_text: str, next_text: str, *, overlap_seconds: float) -> str:
+    """Remove duplicated words at chunk boundary using suffix/prefix overlap."""
+    if not prev_text or not next_text:
+        return next_text
+
+    prev_words = prev_text.split()
+    next_words = next_text.split()
+    max_overlap_words = max(3, int(overlap_seconds * 2.5))
+    best = 0
+    for size in range(min(max_overlap_words, len(prev_words), len(next_words)), 0, -1):
+        if prev_words[-size:] == next_words[:size]:
+            best = size
+            break
+    if best:
+        return " ".join(next_words[best:])
+    return next_text
+
+
+class AudioChunker:
+    """Split long audio files into provider-sized chunks with overlap."""
+
+    def __init__(
+        self,
+        *,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        overlap_seconds: float = DEFAULT_OVERLAP_SECONDS,
+    ) -> None:
+        self.max_bytes = max_bytes
+        self.overlap_seconds = overlap_seconds
+
+    def needs_chunking(self, audio_path: str) -> bool:
+        """Return True when file exceeds configured byte limit."""
+        try:
+            return os.path.getsize(audio_path) > self.max_bytes
+        except OSError:
+            return False
+
+    def split(self, audio_path: str, work_dir: Optional[str] = None) -> List[AudioChunk]:
+        """Split audio into chunks using ffmpeg stream copy."""
+        if not shutil.which("ffmpeg"):
+            raise RuntimeError("ffmpeg not available for audio chunking")
+
+        file_size = os.path.getsize(audio_path)
+        duration = _probe_duration_seconds(audio_path)
+        if duration is None or duration <= 0:
+            raise RuntimeError(f"Could not determine duration for chunking: {audio_path}")
+
+        chunk_duration = duration * (self.max_bytes / file_size) * 0.95
+        chunk_duration = max(chunk_duration, self.overlap_seconds + 1.0)
+        step = max(chunk_duration - self.overlap_seconds, 1.0)
+        num_chunks = max(1, math.ceil((duration - self.overlap_seconds) / step))
+
+        out_dir = work_dir or tempfile.mkdtemp(prefix="audio_chunks_")
+        os.makedirs(out_dir, exist_ok=True)
+        chunks: List[AudioChunk] = []
+
+        for index in range(num_chunks):
+            start = index * step
+            if start >= duration:
+                break
+            end = min(duration, start + chunk_duration)
+            out_path = os.path.join(out_dir, f"chunk_{index:03d}.mp3")
+            cmd = [
+                "ffmpeg",
+                "-y",
+                "-ss",
+                str(start),
+                "-to",
+                str(end),
+                "-i",
+                audio_path,
+                "-c",
+                "copy",
+                out_path,
+            ]
+            _run_text_subprocess(cmd, timeout=120.0, check=True)
+            if os.path.exists(out_path) and os.path.getsize(out_path) > 0:
+                chunks.append(AudioChunk(path=out_path, start_seconds=start, index=index))
+
+        if not chunks:
+            raise RuntimeError(f"ffmpeg produced no audio chunks for {audio_path}")
+        return chunks
+
+    def merge_transcript_results(
+        self,
+        chunk_results: Sequence[Tuple[Dict[str, Any], float]],
+        chunks: Sequence[AudioChunk],
+    ) -> Tuple[Dict[str, Any], float]:
+        """Merge per-chunk transcription dicts into one result with time offsets."""
+        if not chunk_results:
+            return {"text": "", "segments": []}, 0.0
+
+        merged_segments: List[Dict[str, Any]] = []
+        merged_text_parts: List[str] = []
+        total_elapsed = 0.0
+
+        for (result, elapsed), chunk in zip(chunk_results, chunks):
+            total_elapsed += elapsed
+            offset = chunk.start_seconds
+            text = str(result.get("text") or "").strip()
+            if merged_text_parts and text:
+                text = _dedupe_overlap_text(
+                    merged_text_parts[-1], text, overlap_seconds=self.overlap_seconds
+                )
+            if text:
+                merged_text_parts.append(text)
+
+            segments = result.get("segments")
+            if not isinstance(segments, list):
+                continue
+            for seg in segments:
+                if not isinstance(seg, dict):
+                    continue
+                start = float(seg.get("start", 0)) + offset
+                end = float(seg.get("end", start)) + offset
+                seg_text = str(seg.get("text") or "").strip()
+                if not seg_text:
+                    continue
+                merged: Dict[str, Any] = {
+                    "start": start,
+                    "end": end,
+                    "text": seg_text,
+                }
+                if "speaker" in seg:
+                    merged["speaker"] = seg["speaker"]
+                merged_segments.append(merged)
+
+        merged_segments.sort(key=lambda s: (float(s["start"]), float(s["end"])))
+        full_text = " ".join(merged_text_parts).strip()
+        if not full_text and merged_segments:
+            full_text = " ".join(str(s.get("text", "")) for s in merged_segments).strip()
+
+        return {"text": full_text, "segments": merged_segments}, total_elapsed
+
+
+def transcribe_file_in_chunks(
+    audio_path: str,
+    *,
+    chunker: AudioChunker,
+    transcribe_fn: Callable[[str], Tuple[Dict[str, Any], float]],
+    work_dir: Optional[str] = None,
+) -> Tuple[Dict[str, Any], float]:
+    """Split audio, transcribe each chunk, merge results."""
+    chunks = chunker.split(audio_path, work_dir=work_dir)
+    chunk_dir = os.path.dirname(chunks[0].path)
+    try:
+        results: List[Tuple[Dict[str, Any], float]] = []
+        for chunk in chunks:
+            logger.info(
+                "Transcribing audio chunk %d (start=%.1fs): %s",
+                chunk.index + 1,
+                chunk.start_seconds,
+                chunk.path,
+            )
+            results.append(transcribe_fn(chunk.path))
+        return chunker.merge_transcript_results(results, chunks)
+    finally:
+        if work_dir is None and os.path.isdir(chunk_dir):
+            shutil.rmtree(chunk_dir, ignore_errors=True)

--- a/src/podcast_scraper/preprocessing/audio/chunker.py
+++ b/src/podcast_scraper/preprocessing/audio/chunker.py
@@ -81,16 +81,23 @@ class AudioChunker:
         *,
         max_bytes: int = DEFAULT_MAX_BYTES,
         overlap_seconds: float = DEFAULT_OVERLAP_SECONDS,
+        max_duration_seconds: Optional[float] = None,
     ) -> None:
         self.max_bytes = max_bytes
         self.overlap_seconds = overlap_seconds
+        self.max_duration_seconds = max_duration_seconds
 
     def needs_chunking(self, audio_path: str) -> bool:
-        """Return True when file exceeds configured byte limit."""
+        """Return True when file exceeds byte or duration limits."""
         try:
-            return os.path.getsize(audio_path) > self.max_bytes
+            if os.path.getsize(audio_path) > self.max_bytes:
+                return True
         except OSError:
             return False
+        if self.max_duration_seconds is None:
+            return False
+        duration = _probe_duration_seconds(audio_path)
+        return duration is not None and duration > self.max_duration_seconds
 
     def split(self, audio_path: str, work_dir: Optional[str] = None) -> List[AudioChunk]:
         """Split audio into chunks using ffmpeg stream copy."""
@@ -103,6 +110,8 @@ class AudioChunker:
             raise RuntimeError(f"Could not determine duration for chunking: {audio_path}")
 
         chunk_duration = duration * (self.max_bytes / file_size) * 0.95
+        if self.max_duration_seconds is not None:
+            chunk_duration = min(chunk_duration, self.max_duration_seconds * 0.95)
         chunk_duration = max(chunk_duration, self.overlap_seconds + 1.0)
         step = max(chunk_duration - self.overlap_seconds, 1.0)
         num_chunks = max(1, math.ceil((duration - self.overlap_seconds) / step))

--- a/src/podcast_scraper/preprocessing/core.py
+++ b/src/podcast_scraper/preprocessing/core.py
@@ -226,12 +226,8 @@ def clean_transcript(
 def remove_sponsor_blocks(text: str) -> str:
     """Remove sponsor/advertisement blocks from transcript.
 
-    Note: A duplicate exists in providers/ml/summarizer.py. Classic ML paths may still
-    run sponsor removal twice (pattern workflow clean + cleaning_v4 in summarize_long_text).
-    Hybrid ML with ``transcript_cleaning_strategy=pattern`` uses
-    ``cleaning_hybrid_after_pattern`` inside ``HybridMLProvider.summarize`` to avoid that
-    duplicate (Issue #419). Future work will consolidate detection into a single
-    CommercialDetector where still duplicated.
+    Delegates to :class:`~podcast_scraper.cleaning.commercial.CommercialDetector`
+    (confidence-scored patterns + positional heuristics).
 
     Args:
         text: Transcript text potentially containing sponsor blocks
@@ -239,24 +235,9 @@ def remove_sponsor_blocks(text: str) -> str:
     Returns:
         Text with sponsor blocks removed
     """
-    lower = text.lower()
-    cleaned = text
-    for phrase in [
-        "this episode is brought to you by",
-        "today's episode is sponsored by",
-        "today's episode is sponsored by",
-        "our sponsors today are",
-    ]:
-        idx = lower.find(phrase)
-        if idx == -1:
-            continue
-        # Remove, say, up to the next blank line OR up to N chars
-        end = cleaned.find("\n\n", idx)
-        if end == -1 or end - idx > 2000:
-            end = min(idx + 2000, len(cleaned))
-        cleaned = cleaned[:idx] + cleaned[end:]
-        lower = cleaned.lower()
-    return cleaned
+    from ..cleaning.commercial import CommercialDetector
+
+    return CommercialDetector().remove(text)
 
 
 def remove_outro_blocks(text: str) -> str:

--- a/src/podcast_scraper/providers/capabilities.py
+++ b/src/podcast_scraper/providers/capabilities.py
@@ -37,7 +37,7 @@ def gi_segment_timing_expected_for_transcription_provider(provider_name: str) ->
         True for whisper and openai; False otherwise (including unknown strings).
     """
     n = (provider_name or "").strip().lower()
-    return n in ("whisper", "openai")
+    return n in ("whisper", "openai", "deepgram")
 
 
 @dataclass(frozen=True)
@@ -198,7 +198,11 @@ def _infer_capabilities(provider: Any) -> ProviderCapabilities:
     # Semantic cleaning is only supported by LLM providers (not MLProvider)
     supports_semantic_cleaning = has_clean_transcript and provider_type != "MLProvider"
 
-    supports_gi_segment_timing = provider_type in ("OpenAIProvider", "MLProvider")
+    supports_gi_segment_timing = provider_type in (
+        "OpenAIProvider",
+        "MLProvider",
+        "DeepgramTranscriptionProvider",
+    )
 
     return ProviderCapabilities(
         supports_transcription=has_transcribe,

--- a/src/podcast_scraper/providers/deepgram/__init__.py
+++ b/src/podcast_scraper/providers/deepgram/__init__.py
@@ -1,0 +1,5 @@
+"""Deepgram transcription provider package."""
+
+from .deepgram_provider import DeepgramTranscriptionProvider, parse_deepgram_transcript
+
+__all__ = ["DeepgramTranscriptionProvider", "parse_deepgram_transcript"]

--- a/src/podcast_scraper/providers/deepgram/deepgram_provider.py
+++ b/src/podcast_scraper/providers/deepgram/deepgram_provider.py
@@ -95,6 +95,18 @@ def parse_deepgram_transcript(response: Any) -> Dict[str, Any]:
     return {"text": transcript, "segments": segments}
 
 
+def _create_deepgram_client(api_key: str) -> Any:
+    """Construct Deepgram SDK client (isolated for unit-test patching)."""
+    try:
+        from deepgram import DeepgramClient
+    except ImportError as exc:
+        raise RuntimeError(
+            "deepgram-sdk is required for transcription_provider='deepgram'. "
+            "Install with: pip install -e '.[llm]'"
+        ) from exc
+    return DeepgramClient(api_key=api_key)
+
+
 class DeepgramTranscriptionProvider:
     """Transcription-only provider using Deepgram Nova models."""
 
@@ -114,14 +126,7 @@ class DeepgramTranscriptionProvider:
                 "Deepgram API key required for transcription_provider='deepgram'. "
                 "Set DEEPGRAM_API_KEY or deepgram_api_key in config."
             )
-        try:
-            from deepgram import DeepgramClient
-        except ImportError as exc:
-            raise RuntimeError(
-                "deepgram-sdk is required for transcription_provider='deepgram'. "
-                "Install with: pip install -e '.[llm]'"
-            ) from exc
-        self._client = DeepgramClient(api_key=self.cfg.deepgram_api_key)
+        self._client = _create_deepgram_client(self.cfg.deepgram_api_key)
         self._initialized = True
 
     def cleanup(self) -> None:

--- a/src/podcast_scraper/providers/deepgram/deepgram_provider.py
+++ b/src/podcast_scraper/providers/deepgram/deepgram_provider.py
@@ -1,0 +1,198 @@
+"""Deepgram cloud transcription provider."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, cast, Dict, List, Tuple
+
+from ... import config
+from ...utils.log_redaction import format_exception_for_log
+from ..capabilities import ProviderCapabilities
+
+logger = logging.getLogger(__name__)
+
+
+def _response_to_dict(response: Any) -> Dict[str, Any]:
+    if hasattr(response, "model_dump"):
+        return cast(Dict[str, Any], response.model_dump())
+    if isinstance(response, dict):
+        return response
+    return {}
+
+
+def _words_to_segments(words: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if not words:
+        return []
+
+    segments: List[Dict[str, Any]] = []
+    current_speaker = words[0].get("speaker")
+    chunk_words: List[Dict[str, Any]] = [words[0]]
+
+    def _flush(chunk: List[Dict[str, Any]]) -> None:
+        if not chunk:
+            return
+        text = " ".join(str(w.get("punctuated_word") or w.get("word") or "") for w in chunk).strip()
+        if not text:
+            return
+        segments.append(
+            {
+                "start": float(chunk[0].get("start", 0.0)),
+                "end": float(chunk[-1].get("end", chunk[-1].get("start", 0.0))),
+                "text": text,
+                "speaker": chunk[0].get("speaker"),
+            }
+        )
+
+    for word in words[1:]:
+        speaker = word.get("speaker")
+        if speaker != current_speaker:
+            _flush(chunk_words)
+            chunk_words = [word]
+            current_speaker = speaker
+        else:
+            chunk_words.append(word)
+    _flush(chunk_words)
+    return segments
+
+
+def parse_deepgram_transcript(response: Any) -> Dict[str, Any]:
+    """Convert Deepgram Listen response to pipeline segment dict."""
+    data = _response_to_dict(response)
+    results = data.get("results") or {}
+    channels = results.get("channels") or []
+    transcript = ""
+    if channels:
+        alternatives = channels[0].get("alternatives") or []
+        if alternatives:
+            transcript = str(alternatives[0].get("transcript") or "").strip()
+
+    segments: List[Dict[str, Any]] = []
+    utterances = results.get("utterances") or []
+    for utt in utterances:
+        text = str(utt.get("transcript") or "").strip()
+        if not text:
+            continue
+        seg: Dict[str, Any] = {
+            "start": float(utt.get("start", 0.0)),
+            "end": float(utt.get("end", utt.get("start", 0.0))),
+            "text": text,
+        }
+        if utt.get("speaker") is not None:
+            seg["speaker"] = utt.get("speaker")
+        segments.append(seg)
+
+    if not segments and channels:
+        alternatives = channels[0].get("alternatives") or []
+        if alternatives:
+            words = alternatives[0].get("words") or []
+            segments = _words_to_segments(words)
+
+    if not transcript and segments:
+        transcript = " ".join(str(s.get("text", "")) for s in segments).strip()
+
+    return {"text": transcript, "segments": segments}
+
+
+class DeepgramTranscriptionProvider:
+    """Transcription-only provider using Deepgram Nova models."""
+
+    def __init__(self, cfg: config.Config) -> None:
+        """Store config and Deepgram model name."""
+        self.cfg = cfg
+        self._client: Any = None
+        self._initialized = False
+        self.model = (cfg.deepgram_model or "nova-3").strip()
+
+    def initialize(self) -> None:
+        """Create Deepgram SDK client after validating API key."""
+        if self._initialized:
+            return
+        if not self.cfg.deepgram_api_key:
+            raise ValueError(
+                "Deepgram API key required for transcription_provider='deepgram'. "
+                "Set DEEPGRAM_API_KEY or deepgram_api_key in config."
+            )
+        try:
+            from deepgram import DeepgramClient
+        except ImportError as exc:
+            raise RuntimeError(
+                "deepgram-sdk is required for transcription_provider='deepgram'. "
+                "Install with: pip install -e '.[llm]'"
+            ) from exc
+        self._client = DeepgramClient(api_key=self.cfg.deepgram_api_key)
+        self._initialized = True
+
+    def cleanup(self) -> None:
+        """Release SDK client state."""
+        self._client = None
+        self._initialized = False
+
+    def get_capabilities(self) -> ProviderCapabilities:
+        """Return transcription-only capabilities with GI segment timing support."""
+        return ProviderCapabilities(
+            supports_transcription=True,
+            supports_speaker_detection=False,
+            supports_summarization=False,
+            supports_semantic_cleaning=False,
+            supports_audio_input=True,
+            supports_json_mode=False,
+            max_context_tokens=0,
+            provider_name="deepgram",
+            supports_gi_segment_timing=True,
+        )
+
+    def transcribe(self, audio_path: str, language: str | None = None) -> str:
+        """Return transcript text from ``transcribe_with_segments``."""
+        result, _elapsed = self.transcribe_with_segments(audio_path, language=language)
+        return str(result.get("text") or "")
+
+    def transcribe_with_segments(
+        self,
+        audio_path: str,
+        language: str | None = None,
+        pipeline_metrics: Any | None = None,
+        episode_duration_seconds: int | None = None,
+        call_metrics: Any | None = None,
+    ) -> Tuple[Dict[str, Any], float]:
+        """Transcribe audio with diarization and return segments plus elapsed seconds."""
+        if not self._initialized or self._client is None:
+            raise RuntimeError(
+                "DeepgramTranscriptionProvider not initialized. Call initialize() first."
+            )
+        if not os.path.exists(audio_path):
+            raise FileNotFoundError(f"Audio file not found: {audio_path}")
+
+        effective_language = language if language is not None else (self.cfg.language or None)
+        started = time.time()
+        try:
+            with open(audio_path, "rb") as audio_file:
+                kwargs: Dict[str, Any] = {
+                    "request": audio_file.read(),
+                    "model": self.model,
+                    "diarize": True,
+                    "smart_format": True,
+                    "utterances": True,
+                    "punctuate": True,
+                }
+                if effective_language:
+                    kwargs["language"] = effective_language
+                response = self._client.listen.v1.media.transcribe_file(**kwargs)
+        except Exception as exc:
+            logger.error("Deepgram transcription failed: %s", format_exception_for_log(exc))
+            raise
+
+        elapsed = time.time() - started
+        result = parse_deepgram_transcript(response)
+
+        if call_metrics is not None:
+            call_metrics.set_provider_name("deepgram")
+
+        _ = pipeline_metrics, episode_duration_seconds
+        logger.info(
+            "Deepgram transcription completed in %.2fs (%d segments)",
+            elapsed,
+            len(result.get("segments") or []),
+        )
+        return result, elapsed

--- a/src/podcast_scraper/providers/ml/ml_provider.py
+++ b/src/podcast_scraper/providers/ml/ml_provider.py
@@ -15,10 +15,8 @@ from __future__ import annotations
 
 import importlib
 import logging
-import os
 import sys
 import time
-from contextlib import contextmanager
 from types import ModuleType
 from typing import Any, Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 
@@ -38,7 +36,6 @@ from ...exceptions import (
     ProviderNotInitializedError,
     ProviderRuntimeError,
 )
-from ...utils import progress
 from ...utils.log_redaction import format_exception_for_log, redact_for_log
 from ..capabilities import ProviderCapabilities
 from . import speaker_detection, summarizer
@@ -82,87 +79,6 @@ def _import_third_party_whisper() -> ModuleType:
                 "Make sure 'openai-whisper' is installed: pip install openai-whisper"
             )
         ) from exc
-
-
-@contextmanager
-def _intercept_whisper_progress(progress_reporter: progress.ProgressReporter):
-    """Intercept Whisper's tqdm progress calls and forward to our progress reporter.
-
-    Whisper uses tqdm internally for progress reporting. This context manager
-    temporarily overrides tqdm to capture Whisper's progress updates and forward
-    them to our own progress reporter, preventing multiple progress bar lines.
-
-    Args:
-        progress_reporter: Our progress reporter to forward updates to
-    """
-    try:
-        import tqdm
-    except ImportError:
-        # tqdm not available, can't intercept
-        yield
-        return
-
-    original_tqdm = tqdm.tqdm
-
-    class InterceptedTqdm(original_tqdm):  # type: ignore[misc,valid-type]
-        """Custom tqdm that suppresses output and forwards progress to our reporter."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            # Suppress tqdm's own display
-            # Store file handle to ensure it's closed properly
-            self._devnull_file = open(os.devnull, "w")
-            kwargs["file"] = self._devnull_file
-            kwargs["disable"] = True  # Disable tqdm's display completely
-            # Store total for percentage calculation
-            self._whisper_total: Optional[int] = kwargs.get("total")
-            self._whisper_n = 0
-            super().__init__(*args, **kwargs)
-
-        def update(self, n: int = 1) -> Optional[bool]:
-            """Update progress and forward to our reporter."""
-            result: Optional[bool] = super().update(n)
-            self._whisper_n = getattr(self, "n", self._whisper_n + n)
-
-            # Forward update to our progress reporter
-            if progress_reporter:
-                # Forward the increment to our progress reporter
-                progress_reporter.update(n)
-
-            return result
-
-        def close(self) -> None:
-            """Clean up and ensure final update."""
-            if progress_reporter and self._whisper_total:
-                # Ensure we're at 100% if we have a total
-                remaining = self._whisper_total - self._whisper_n
-                if remaining > 0:
-                    progress_reporter.update(remaining)
-            super().close()
-            # Explicitly close the devnull file handle to prevent descriptor leaks
-            if hasattr(self, "_devnull_file") and self._devnull_file:
-                try:
-                    self._devnull_file.close()
-                except Exception:  # nosec B110
-                    # Ignore errors during cleanup
-                    pass
-
-        def __del__(self) -> None:
-            """Safety net: ensure file handle is closed even if close() wasn't called."""
-            if hasattr(self, "_devnull_file") and self._devnull_file:
-                try:
-                    self._devnull_file.close()
-                except Exception:  # nosec B110
-                    # Ignore errors during cleanup
-                    pass
-
-    # Temporarily replace tqdm.tqdm with our interceptor
-    tqdm.tqdm = InterceptedTqdm
-
-    try:
-        yield
-    finally:
-        # Restore original tqdm
-        tqdm.tqdm = original_tqdm
 
 
 class MLProvider:
@@ -938,55 +854,40 @@ class MLProvider:
         total_start = time.time()
 
         step_start = time.time()
-        with progress.progress_context(None, "Transcribing") as reporter:
-            progress_setup_time = time.time() - step_start
-            logger.debug("  [TIMING] Progress context setup: %.3fs", progress_setup_time)
+        suppress_fp16_warning = getattr(self._whisper_model, "_is_cpu_device", False)
+        logger.debug(
+            "Invoking Whisper transcription: media=%s suppress_fp16_warning=%s dtype=%s",
+            audio_path,
+            suppress_fp16_warning,
+            getattr(self._whisper_model, "dtype", None),
+        )
+        logger.debug("Transcribing with language=%s", language)
+        prep_time = time.time() - step_start
+        logger.debug("  [TIMING] Preparation (device check, logging): %.3fs", prep_time)
 
-            step_start = time.time()
-            suppress_fp16_warning = getattr(self._whisper_model, "_is_cpu_device", False)
-            logger.debug(
-                "Invoking Whisper transcription: media=%s suppress_fp16_warning=%s dtype=%s",
-                audio_path,
-                suppress_fp16_warning,
-                getattr(self._whisper_model, "dtype", None),
+        if self._whisper_model is None:
+            raise ProviderNotInitializedError(
+                provider="MLProvider/Whisper",
+                capability="transcription",
             )
-            logger.debug("Transcribing with language=%s", language)
-            prep_time = time.time() - step_start
-            logger.debug("  [TIMING] Preparation (device check, logging): %.3fs", prep_time)
 
-            # Intercept Whisper's tqdm progress calls and forward to our progress reporter
-            # This prevents multiple progress bar lines while showing real progress
-            if self._whisper_model is None:
-                raise ProviderNotInitializedError(
-                    provider="MLProvider/Whisper",
-                    capability="transcription",
-                )
-
-            step_start = time.time()
-            with _intercept_whisper_progress(reporter):
-                intercept_setup_time = time.time() - step_start
-                logger.debug("  [TIMING] Progress interceptor setup: %.3fs", intercept_setup_time)
-
-                step_start = time.time()
-                logger.debug("  [TIMING] Starting Whisper model.transcribe() call...")
-                result = self._whisper_model.transcribe(
-                    audio_path, task="transcribe", language=language, verbose=False
-                )
-                whisper_transcribe_time = time.time() - step_start
-                logger.debug(
-                    "  [TIMING] Whisper model.transcribe() completed: %.3fs",
-                    whisper_transcribe_time,
-                )
+        step_start = time.time()
+        logger.debug("  [TIMING] Starting Whisper model.transcribe() call...")
+        result = self._whisper_model.transcribe(
+            audio_path, task="transcribe", language=language, verbose=False
+        )
+        whisper_transcribe_time = time.time() - step_start
+        logger.debug(
+            "  [TIMING] Whisper model.transcribe() completed: %.3fs",
+            whisper_transcribe_time,
+        )
 
         elapsed = time.time() - total_start
         logger.info(
             "[TIMING BREAKDOWN] Transcription total: %.3fs "
-            "(progress_setup: %.3fs, prep: %.3fs, intercept_setup: %.3fs, "
-            "whisper_transcribe: %.3fs)",
+            "(prep: %.3fs, whisper_transcribe: %.3fs)",
             elapsed,
-            progress_setup_time,
             prep_time,
-            intercept_setup_time,
             whisper_transcribe_time,
         )
         segments = result.get("segments")

--- a/src/podcast_scraper/providers/ml/speaker_detection.py
+++ b/src/podcast_scraper/providers/ml/speaker_detection.py
@@ -1,306 +1,59 @@
-"""Named Entity Recognition (NER) for automatic speaker name detection from episode metadata."""
+"""Backward-compatible re-export of speaker detection public API.
+
+NER/heuristic logic lives in speaker_detectors submodules.
+This module re-exports the public API for existing imports.
+"""
 
 from __future__ import annotations
 
 import logging
-import re
+from typing import Any, Optional
 
-# Bandit: subprocess is needed for spaCy model download
-import subprocess  # nosec B404
-import sys
-from typing import Any, Dict, List, Optional, Set, Tuple
-
-from ... import config, config_constants
-
-# Note: spacy is imported lazily in _load_spacy_model() to avoid requiring ML dependencies
-# at module import time. This allows unit tests to import this module without spacy installed.
-
+from ... import config
+from ...speaker_detectors.constants import (
+    DEFAULT_CONFIDENCE_SCORE,
+    DEFAULT_SAMPLE_SIZE,
+    DEFAULT_SPEAKER_NAMES,
+    PATTERN_BASED_CONFIDENCE_SCORE,
+)
+from ...speaker_detectors.detection import _build_speaker_names_list, detect_speaker_names
+from ...speaker_detectors.entities import (
+    _extract_entities_from_doc,
+    _extract_entities_from_segments,
+    _pattern_based_fallback,
+    _split_text_on_separators,
+    extract_person_entities as _extract_person_entities_impl,
+)
+from ...speaker_detectors.guests import (
+    _has_interview_indicator,
+    _has_mentioned_only_indicator,
+    _is_likely_actual_guest,
+)
+from ...speaker_detectors.hosts import detect_hosts_from_feed, detect_hosts_from_transcript_intro
+from ...speaker_detectors.ner import (
+    _ensure_spacy_sentence_boundaries,
+    _load_spacy_model as _load_spacy_model_impl,
+    _validate_model_name,
+)
+from ...speaker_detectors.normalization import (
+    _extract_confidence_score,
+    _sanitize_person_name,
+    _validate_person_entity,
+    filter_default_speaker_names,
+    is_default_speaker_name,
+)
+from ...speaker_detectors.patterns import analyze_episode_patterns
 
 logger = logging.getLogger(__name__)
 
 
-def _ensure_spacy_sentence_boundaries(nlp: Any) -> None:
-    """Ensure ``doc.sents`` works for downstream code (metadata auto-repair, reconciliation).
-
-    NER-only loads disable the dependency parser; without parser or ``sentencizer``,
-    iterating ``doc.sents`` raises spaCy E030 (sentence boundaries unset).
-    """
-    if "parser" in nlp.pipe_names or "senter" in nlp.pipe_names:
-        return
-    if "sentencizer" in nlp.pipe_names:
-        return
-    try:
-        nlp.add_pipe("sentencizer")
-    except (ValueError, TypeError) as exc:
-        logger.debug("Could not add sentencizer to spaCy pipeline: %s", exc)
-
-
-# Default speaker names when detection fails (Issue #428: use typed placeholder, not "Guest")
-# "Guest" must not appear in detected_guests/detected_hosts to avoid contaminating analytics.
-DEFAULT_SPEAKER_NAMES = ["Host", "unknown_guest_1"]
-
-# Valid spaCy model names contain only alphanumeric, underscore, hyphen, and dot
-_VALID_MODEL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_.-]+$")
-
-# Model validation constants
-MAX_MODEL_NAME_LENGTH = 100
-
-# Name validation constants
-MIN_NAME_LENGTH = 2
-MIN_RAW_NAME_LENGTH = 2
-MIN_SEGMENT_LENGTH = 2
-
-# Confidence score constants
-DEFAULT_CONFIDENCE_SCORE = 1.0
-PATTERN_BASED_CONFIDENCE_SCORE = 0.7
-
-# Guest detection
-DESCRIPTION_SNIPPET_LENGTH = 500
-DEFAULT_SAMPLE_SIZE = 5
-MIN_SPEAKERS_REQUIRED = 2
-
-# Context-aware filtering patterns (Issue #325)
-# These patterns help distinguish actual guests from merely mentioned people
-INTERVIEW_INDICATOR_PATTERNS = [
-    r"interview(?:ed|ing|s)?\s+(?:with\s+)?",  # "interview with X", "interviewing X"
-    r"(?:we(?:'re|'ve)?|i(?:'m|'ve)?)\s+(?:been\s+)?joined\s+by\s+",  # "joined by X"
-    r"speaking\s+(?:with|to)\s+",  # "speaking with X"
-    r"talking\s+(?:with|to)\s+",  # "talking to X"
-    r"talks?\s+(?:with|to)\s+",  # "talks to X", "talk to X"
-    r"conversation\s+with\s+",  # "conversation with X"
-    r"guest(?:s)?(?:\s*:|\s+is|\s+are)?\s*",  # "guest: X", "guest is X"
-    r"featuring\s+",  # "featuring X"
-    r"(?:special\s+)?guest\s+",  # "special guest X"
-    r"welcomes?\s+",  # "welcomes X"
-    r"sits?\s+down\s+with\s+",  # "sits down with X"
-    r"chats?\s+with\s+",  # "chats with X"
-    r"joining\s+us\s+",  # "joining us X"
-]
-
-MENTIONED_ONLY_PATTERNS = [
-    r"about\s+",  # "about John Smith"
-    r"on\s+\w+(?:'s)?\s+",  # "on Smith's policies"
-    r"discuss(?:es|ing|ed)?\s+",  # "discusses John Smith"
-    r"analysis\s+of\s+",  # "analysis of Smith's..."
-    r"according\s+to\s+",  # "according to Smith"
-    r"(?:he|she|they)\s+says?\s+",  # "he says..."
-    r"'s\s+(?:\w+\s+)*(?:policy|plan|speech|decision|statement)",  # "Smith's policy"
-    r"(?:the\s+)?(?:president|ceo|senator|governor)\s+",  # "CEO Jane Doe" (title prefix)
-    r"covers?\s+",  # "covers the story"
-    r"examines?\s+",  # "examines the issue"
-    r"looks?\s+at\s+",  # "looks at the data"
-    r"(?:news|story|report)\s+(?:about|on)\s+",  # "news about the company"
-]
-
-
-def _has_interview_indicator(name: str, text: str) -> bool:
-    """Check if name appears in an interview context.
-
-    Args:
-        name: Person name to check
-        text: Text to search in (title or description)
-
-    Returns:
-        True if name appears after an interview indicator pattern
-    """
-    text_lower = text.lower()
-    name_lower = name.lower()
-
-    for pattern in INTERVIEW_INDICATOR_PATTERNS:
-        # Check if pattern appears before the name
-        full_pattern = pattern + r".*?" + re.escape(name_lower)
-        if re.search(full_pattern, text_lower, re.IGNORECASE):
-            return True
-    return False
-
-
-def _has_mentioned_only_indicator(name: str, text: str) -> bool:
-    """Check if name appears in a mentioned-only context (not an actual guest).
-
-    Args:
-        name: Person name to check
-        text: Text to search in (title or description)
-
-    Returns:
-        True if name appears after a mentioned-only indicator pattern
-    """
-    text_lower = text.lower()
-    name_lower = name.lower()
-
-    for pattern in MENTIONED_ONLY_PATTERNS:
-        # Check if pattern appears before the name
-        full_pattern = pattern + r".*?" + re.escape(name_lower)
-        if re.search(full_pattern, text_lower, re.IGNORECASE):
-            return True
-    return False
-
-
-def is_default_speaker_name(name: str) -> bool:
-    """Check if a speaker name is a default placeholder.
-
-    Args:
-        name: Speaker name to check
-
-    Returns:
-        True if name is in DEFAULT_SPEAKER_NAMES or legacy 'Guest', False otherwise.
-    """
-    return name in DEFAULT_SPEAKER_NAMES or name == config_constants.LEGACY_PLACEHOLDER_GUEST
-
-
-def filter_default_speaker_names(names: List[str]) -> List[str]:
-    """Filter out default speaker names from a list.
-
-    Args:
-        names: List of speaker names
-
-    Returns:
-        List with default speaker names removed
-    """
-    return [name for name in names if not is_default_speaker_name(name)]
-
-
-def _is_likely_actual_guest(name: str, title: str, description: str | None) -> bool:
-    """Determine if a detected person is likely an actual guest vs merely mentioned.
-
-    Uses context-aware filtering to reduce false positives from spaCy NER.
-
-    Args:
-        name: Person name detected by NER
-        title: Episode title
-        description: Episode description (may be None)
-
-    Returns:
-        True if the person is likely an actual guest, False if likely just mentioned
-    """
-    combined_text = title
-    if description:
-        combined_text += " " + description
-
-    # Check for interview indicators (strong signal for actual guest)
-    has_interview = _has_interview_indicator(name, combined_text)
-
-    # Check for mentioned-only indicators (strong signal for NOT a guest)
-    has_mentioned_only = _has_mentioned_only_indicator(name, combined_text)
-
-    # Decision logic (strict for tests):
-    # - If interview indicator found: likely actual guest
-    # - If mentioned-only indicator found: NOT a guest
-    # - Default: NOT a guest (strict - require guest-intent cue)
-    if has_interview:
-        logger.debug("Name '%s' has interview indicator - likely actual guest", name)
-        return True
-    if has_mentioned_only:
-        logger.debug("Name '%s' has mentioned-only indicator - NOT a guest", name)
-        return False
-
-    # Default: NOT a guest (strict - require guest-intent cue)
-    return False
-
-
-def _validate_model_name(model_name: str) -> bool:
-    """Validate spaCy model name to prevent command injection.
-
-    Args:
-        model_name: Model name to validate
-
-    Returns:
-        True if valid, False otherwise
-    """
-    if not model_name or len(model_name) > MAX_MODEL_NAME_LENGTH:
-        return False
-    return bool(_VALID_MODEL_NAME_PATTERN.match(model_name))
-
-
 def _load_spacy_model(model_name: str) -> Optional[Any]:
-    """Load spaCy model, automatically downloading if missing.
-
-    Similar to Whisper's automatic model download, this function will attempt
-    to download the model if it's not found locally.
-
-    Args:
-        model_name: Name of the spaCy model to load (e.g., 'en_core_web_sm')
-
-    Returns:
-        Loaded spaCy nlp object or None if download/load fails
-    """
-    # Lazy import: Only import spacy when this function is called
-    # This allows the module to be imported without ML dependencies installed
-    import spacy  # noqa: F401
-
-    # Validate model name to prevent command injection
-    if not _validate_model_name(model_name):
-        logger.error("Invalid spaCy model name: %s (contains invalid characters)", model_name)
-        return None
-
-    try:
-        # Load only NER component to reduce memory usage
-        # Disable parser, tagger, and lemmatizer since we only need NER
-        # This can reduce memory usage by 30-50% for most models
-        try:
-            nlp = spacy.load(model_name, disable=["parser", "tagger", "lemmatizer"])
-            logger.info("Loaded spaCy model (NER only): %s", model_name)
-        except (ValueError, KeyError):
-            # Some models may not support disabling components, fall back to full load
-            logger.debug(
-                "Model %s doesn't support component disabling, loading full pipeline", model_name
-            )
-            nlp = spacy.load(model_name)
-            logger.info("Loaded spaCy model (full pipeline): %s", model_name)
-        _ensure_spacy_sentence_boundaries(nlp)
-        return nlp
-    except OSError:
-        logger.debug("spaCy model '%s' not found locally, attempting to download...", model_name)
-        try:
-            # Use subprocess to call 'python -m spacy download' (most reliable method)
-            # This ensures we use the same Python interpreter and environment
-            # Model name is validated above to prevent command injection
-            subprocess.run(  # nosec B603
-                [sys.executable, "-m", "spacy", "download", model_name],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            logger.debug("Successfully downloaded spaCy model: %s", model_name)
-            # Now try loading again with disabled components for memory efficiency
-            try:
-                nlp = spacy.load(model_name, disable=["parser", "tagger", "lemmatizer"])
-                logger.info("Loaded spaCy model (NER only) after download: %s", model_name)
-            except (ValueError, KeyError):
-                # Fall back to full pipeline if component disabling not supported
-                nlp = spacy.load(model_name)
-                logger.info("Loaded spaCy model (full pipeline) after download: %s", model_name)
-            _ensure_spacy_sentence_boundaries(nlp)
-            return nlp
-        except subprocess.CalledProcessError as exc:
-            logger.error(
-                "Failed to download spaCy model '%s': %s. Output: %s",
-                model_name,
-                exc,
-                exc.stderr or exc.stdout or "",
-            )
-            logger.info("You can manually install with: python -m spacy download %s", model_name)
-            return None
-        except OSError as exc:
-            logger.error(
-                "Failed to load spaCy model '%s' after download attempt: %s", model_name, exc
-            )
-            return None
+    """Load spaCy model (delegates to speaker_detectors.ner; patchable on this module)."""
+    return _load_spacy_model_impl(model_name)
 
 
 def get_ner_model(cfg: config.Config) -> Optional[Any]:
-    """Get the appropriate spaCy NER model based on configuration.
-
-    This function loads the spaCy model directly without caching.
-    Providers should load the model once during initialization and pass it
-    to detect_speaker_names() to avoid redundant loads.
-
-    Args:
-        cfg: Configuration object
-
-    Returns:
-        Loaded spaCy nlp object or None if model unavailable
-    """
-    # Skip model loading in dry-run mode
+    """Get the appropriate spaCy NER model based on configuration."""
     if cfg.dry_run:
         return None
 
@@ -309,16 +62,12 @@ def get_ner_model(cfg: config.Config) -> Optional[Any]:
 
     model_name = cfg.ner_model
     if not model_name:
-        # Derive default model from language
         if cfg.language == "en":
             model_name = config.DEFAULT_NER_MODEL
         else:
-            # For other languages, try to construct model name (e.g., "fr" -> "fr_core_news_sm")
-            # This is a simple heuristic; users can override with --ner-model
             logger.debug("No default NER model for language '%s', skipping detection", cfg.language)
             return None
 
-    # Load model directly (no caching)
     nlp = _load_spacy_model(model_name)
     if nlp is not None:
         logger.debug("Loaded spaCy model: %s", model_name)
@@ -326,606 +75,17 @@ def get_ner_model(cfg: config.Config) -> Optional[Any]:
     return nlp
 
 
-def _sanitize_person_name(name: str) -> Optional[str]:
-    """Sanitize a person name by removing non-letter characters and normalizing.
-
-    Removes:
-    - Parentheses and their contents: "John (Smith)" -> "John"
-    - Trailing punctuation: "John," -> "John"
-    - Leading/trailing whitespace
-
-    Keeps:
-    - Letters, spaces, hyphens (for names like "Mary-Jane")
-    - Apostrophes (for names like "O'Brien")
-
-    Args:
-        name: Raw person name from NER
-
-    Returns:
-        Sanitized name, or None if name becomes invalid after sanitization
-    """
-    if not name:
-        return None
-
-    # Remove parentheses and their contents: "John (Smith)" -> "John"
-    name = re.sub(r"\([^)]*\)", "", name)
-
-    # Remove trailing punctuation (commas, periods, semicolons, etc.)
-    name = re.sub(r"[,.;:!?]+$", "", name)
-
-    # Remove leading punctuation
-    name = re.sub(r"^[,.;:!?]+", "", name)
-
-    # Strip whitespace
-    name = name.strip()
-
-    # Remove any remaining non-letter characters except spaces, hyphens, and apostrophes
-    # This handles cases like "John, Smith" -> "John Smith"
-    name = re.sub(r"[^\w\s\-\']+", "", name)
-
-    # Normalize whitespace (multiple spaces -> single space)
-    name = re.sub(r"\s+", " ", name).strip()
-
-    # Validate: must have at least one letter and be at least MIN_NAME_LENGTH characters
-    if not name or len(name) < MIN_NAME_LENGTH:
-        return None
-
-    # Must contain at least one letter (not just numbers or punctuation)
-    if not re.search(r"[a-zA-Z]", name):
-        return None
-
-    return name
-
-
-def _validate_person_entity(raw_name: str) -> bool:
-    """Validate that a raw entity name is likely a person.
-
-    Args:
-        raw_name: Raw entity name from NER
-
-    Returns:
-        True if valid person entity, False otherwise
-    """
-    if not raw_name or len(raw_name) < MIN_RAW_NAME_LENGTH:
-        return False
-    # Filter out pure numbers and HTML-like patterns
-    if re.match(r"^\d+$", raw_name) or re.search(r"[<>]", raw_name):
-        return False
-    return True
-
-
-def _extract_confidence_score(ent: Any) -> float:
-    """Extract confidence score from spaCy entity.
-
-    Args:
-        ent: spaCy entity object
-
-    Returns:
-        Confidence score (defaults to DEFAULT_CONFIDENCE_SCORE if not available)
-    """
-    if hasattr(ent, "score") and ent.score is not None:
-        return float(ent.score)
-    elif hasattr(ent, "_") and hasattr(ent._, "score") and ent._.score is not None:
-        return float(ent._.score)
-    return DEFAULT_CONFIDENCE_SCORE
-
-
-def _extract_entities_from_doc(
-    doc: Any, seen_raw_names: Set[str], seen_sanitized_names: Set[str]
-) -> List[Tuple[str, float]]:
-    """Extract PERSON entities from a spaCy document.
-
-    Args:
-        doc: spaCy document object
-        seen_raw_names: Set of already seen raw names (for deduplication)
-        seen_sanitized_names: Set of already seen sanitized names (for deduplication)
-
-    Returns:
-        List of (sanitized_name, confidence_score) tuples
-    """
-    persons = []
-    for ent in doc.ents:
-        if ent.label_ != "PERSON":
-            continue
-
-        raw_name = ent.text.strip()
-
-        # Skip if already seen
-        if raw_name in seen_raw_names:
-            continue
-
-        # Validate entity
-        if not _validate_person_entity(raw_name):
-            continue
-
-        # Sanitize the name
-        sanitized_name = _sanitize_person_name(raw_name)
-        if not sanitized_name:
-            continue
-
-        # Deduplicate based on sanitized name (case-insensitive)
-        sanitized_lower = sanitized_name.lower()
-        if sanitized_lower in seen_sanitized_names:
-            continue
-
-        # Track both raw and sanitized names
-        seen_raw_names.add(raw_name)
-        seen_sanitized_names.add(sanitized_lower)
-
-        # Get confidence score
-        confidence = _extract_confidence_score(ent)
-        persons.append((sanitized_name, confidence))
-
-    return persons
-
-
-def _split_text_on_separators(text: str) -> Tuple[List[str], Optional[str]]:
-    """Split text on common separators used in episode titles.
-
-    Args:
-        text: Text to split
-
-    Returns:
-        Tuple of (segments_list, last_segment)
-    """
-    separators = ["|", "—", "–", " - "]
-    segments = [text]
-    last_segment = None
-
-    # Split on first separator found
-    for sep in separators:
-        if sep in text:
-            segments = [s.strip() for s in text.split(sep)]
-            last_segment = segments[-1] if segments else None
-            break
-
-    return segments, last_segment
-
-
-def _extract_entities_from_segments(
-    segments: List[str],
-    nlp: Any,
-    seen_raw_names: Set[str],
-    seen_sanitized_names: Set[str],
-) -> List[Tuple[str, float]]:
-    """Extract PERSON entities from text segments, prioritizing last segment.
-
-    Args:
-        segments: List of text segments
-        nlp: spaCy NLP model
-        seen_raw_names: Set of already seen raw names
-        seen_sanitized_names: Set of already seen sanitized names
-
-    Returns:
-        List of (sanitized_name, confidence_score) tuples
-    """
-    persons = []
-    # Process segments in reverse order to prioritize last segment
-    for segment in reversed(segments):
-        if not segment or len(segment) < MIN_SEGMENT_LENGTH:
-            continue
-
-        segment_doc = nlp(segment)
-        segment_persons = _extract_entities_from_doc(
-            segment_doc, seen_raw_names, seen_sanitized_names
-        )
-        persons.extend(segment_persons)
-
-        # If we found entities in a segment, stop checking other segments
-        # This ensures we get the guest name from the last segment
-        if persons:
-            break
-
-    return persons
-
-
-def _pattern_based_fallback(
-    last_segment: str, seen_sanitized_names: Set[str]
-) -> Optional[Tuple[str, float]]:
-    """Pattern-based fallback for name extraction when NER fails.
-
-    Args:
-        last_segment: Last segment of text (often contains guest name)
-        seen_sanitized_names: Set of already seen sanitized names
-
-    Returns:
-        Tuple of (sanitized_name, confidence_score) or None
-    """
-    if not last_segment:
-        return None
-
-    # Pattern: 2-3 words, each starting with capital letter
-    # Examples: "Dylan Field", "Mary Jane Watson", "John Smith"
-    name_pattern = r"^[A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,2}$"
-    if not re.match(name_pattern, last_segment):
-        return None
-
-    # Check if it's not a common non-name phrase
-    common_phrases = {
-        "guest",
-        "host",
-        "episode",
-        "title",
-        "interview",
-        "conversation",
-    }
-    last_segment_lower = last_segment.lower()
-    if any(phrase in last_segment_lower for phrase in common_phrases):
-        return None
-
-    # Sanitize and add as candidate
-    sanitized_name = _sanitize_person_name(last_segment)
-    if not sanitized_name:
-        return None
-
-    sanitized_lower = sanitized_name.lower()
-    if sanitized_lower in seen_sanitized_names:
-        return None
-
-    # Lower confidence since it's pattern-based, not NER
-    logger.debug(
-        "Pattern-based fallback: extracted '%s' from last segment '%s'",
-        sanitized_name,
-        last_segment,
-    )
-    return (sanitized_name, PATTERN_BASED_CONFIDENCE_SCORE)
-
-
-def extract_person_entities(text: str, nlp: Any) -> List[Tuple[str, float]]:
-    """Extract PERSON entities from text using spaCy NER with confidence scores.
-
-    Sanitizes names to remove non-letter characters (parentheses, commas, etc.)
-    and deduplicates to return unique person candidates.
-
-    Uses a fallback strategy: if no entities found in full text, splits on
-    common separators (|, —, –) and tries NER on each segment, prioritizing
-    the last segment (often contains guest names).
-
-    Args:
-        text: Text to extract entities from (should already be cleaned of HTML)
-        nlp: spaCy NLP model
-
-    Returns:
-        List of (sanitized_name, confidence_score) tuples, deduplicated.
-        Confidence is 1.0 if not available.
-    """
-    if not text or not nlp:
-        return []
-
-    try:
-        seen_raw_names: Set[str] = set()  # Track raw names to avoid duplicates
-        seen_sanitized_names: Set[str] = set()  # Track sanitized names for deduplication
-
-        # First, try NER on the full text
-        doc = nlp(text)
-        persons = _extract_entities_from_doc(doc, seen_raw_names, seen_sanitized_names)
-
-        # Fallback: if no entities found, try splitting on common separators
-        if not persons:
-            segments, last_segment = _split_text_on_separators(text)
-            persons = _extract_entities_from_segments(
-                segments, nlp, seen_raw_names, seen_sanitized_names
-            )
-
-            # Pattern-based fallback: if still no entities
-            if not persons and last_segment:
-                pattern_result = _pattern_based_fallback(last_segment, seen_sanitized_names)
-                if pattern_result:
-                    sanitized_name, confidence = pattern_result
-                    seen_sanitized_names.add(sanitized_name.lower())
-                    persons.append((sanitized_name, confidence))
-
-        return persons
-    except Exception as exc:
-        logger.debug("Error extracting PERSON entities: %s", exc)
-        return []
-
-
-def detect_hosts_from_transcript_intro(
-    transcript_text: str,
-    nlp: Optional[Any] = None,
-    intro_duration_seconds: int = 120,
-    words_per_second: float = 2.5,
-) -> Set[str]:
-    """Detect host names from transcript intro patterns (first 60-120 seconds).
-
-    Scans the first portion of transcript for common intro patterns like:
-    - "I'm [Name]"
-    - "This is [Show Name]... I'm [Name]"
-    - "Welcome to [Show]... I'm [Name]"
-
-    Args:
-        transcript_text: Full transcript text
-        nlp: spaCy NLP model (optional, only needed if NER is used)
-        intro_duration_seconds: How many seconds of transcript to scan (default: 120)
-        words_per_second: Average words per second for estimating intro length (default: 2.5)
-
-    Returns:
-        Set of detected host names from intro patterns
-    """
-    if not transcript_text or not nlp:
-        return set()
-
-    # Estimate intro length: ~120 seconds * 2.5 words/sec = ~300 words
-    # Take first N words to scan for intro patterns
-    intro_word_count = int(intro_duration_seconds * words_per_second)
-    words = transcript_text.split()[:intro_word_count]
-    intro_text = " ".join(words)
-
-    # Common intro patterns
-    intro_patterns = [
-        r"I'?m\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)",  # "I'm John" or "I'm John Smith"
-        # "This is The Indicator... I'm John"
-        r"This is\s+[^.]+\s+I'?m\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)",
-        # "Welcome to Planet Money... I'm John"
-        r"Welcome to\s+[^.]+\s+I'?m\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)",
-    ]
-
-    detected_names = set()
-    for pattern in intro_patterns:
-        matches = re.finditer(pattern, intro_text, re.IGNORECASE)
-        for match in matches:
-            name = match.group(1).strip()
-            # Filter out common false positives
-            if name and len(name) > 2 and name.lower() not in ["the", "this", "that"]:
-                detected_names.add(name)
-
-    # Also use NER on intro text to find person names
-    if nlp:
-        intro_persons = extract_person_entities(intro_text, nlp)
-        for name, _ in intro_persons:
-            detected_names.add(name)
-
-    return detected_names
-
-
-def detect_hosts_from_feed(
-    feed_title: Optional[str],
-    feed_description: Optional[str],
-    feed_authors: Optional[List[str]] = None,
-    nlp: Optional[Any] = None,
-) -> Set[str]:
-    """Detect host names from feed-level metadata.
-
-    Hosts are recurring speakers and should only be extracted from feed-level
-    metadata, not from individual episodes.
-
-    Priority:
-    1. RSS author tags (<author>, <dc:creator>, <itunes:author>) - most reliable
-    2. NER extraction from feed title/description - fallback if no authors
-
-    Args:
-        feed_title: Feed title
-        feed_description: Feed description (optional)
-        feed_authors: List of author names from RSS feed (optional, preferred source)
-        nlp: spaCy NLP model (optional, only needed if no authors provided)
-
-    Returns:
-        Set of detected host names
-    """
-    hosts: Set[str] = set()
-
-    # Priority 1: Use RSS author tags if available (most reliable)
-    # RSS feeds typically have one channel-level author, plus optional iTunes author/owner
-    # However, these may be organization names (e.g., "NPR") rather than person names
-    # We'll collect them but treat them as "publisher" metadata, not necessarily hosts
-    if feed_authors:
-        for author in feed_authors:
-            if author and author.strip():
-                # Author tags may contain email format "Name <email>", extract just the name
-                author_clean = author.strip()
-                # Remove email part if present (format: "Name <email@example.com>")
-                if "<" in author_clean and ">" in author_clean:
-                    author_clean = author_clean.split("<")[0].strip()
-                if author_clean:
-                    # Check if this looks like an organization name (all caps, short, no spaces)
-                    # Common patterns: "NPR", "BBC", "CNN", etc.
-                    is_likely_org = (
-                        len(author_clean) <= 10
-                        and author_clean.isupper()
-                        and " " not in author_clean
-                    )
-                    if is_likely_org:
-                        logger.debug(
-                            "RSS author '%s' appears to be an organization name, "
-                            "treating as publisher metadata rather than host",
-                            author_clean,
-                        )
-                        # Don't add to hosts - these are publishers, not actual hosts
-                    else:
-                        hosts.add(author_clean)
-        if hosts:
-            logger.debug(
-                "Detected hosts from RSS author tags (author/itunes:author/itunes:owner): %s",
-                list(hosts),
-            )
-            return hosts
-        # All feed authors were organisations (e.g. NPR, BBC) - log at INFO (Issue #393)
-        if feed_authors:
-            logger.info(
-                "All RSS author(s) treated as organisation(s); host detection will use "
-                "NER from feed title/description, episode-level authors, or config known_hosts"
-            )
-
-    # Priority 2: Fall back to NER extraction from feed title/description
-    if nlp:
-        if feed_title:
-            title_persons = extract_person_entities(feed_title, nlp)
-            hosts.update(name for name, _ in title_persons)
-        if feed_description:
-            desc_persons = extract_person_entities(feed_description, nlp)
-            hosts.update(name for name, _ in desc_persons)
-        if hosts:
-            logger.debug("Detected hosts via NER from feed metadata: %s", list(hosts))
-
-    return hosts
-
-
-def analyze_episode_patterns(
-    episodes: List[Any],
-    nlp: Any,
-    cached_hosts: Set[str],
-    sample_size: int = DEFAULT_SAMPLE_SIZE,
-) -> Dict[str, Any]:
-    """No-op — heuristic pattern learner removed in #598 simplification.
-
-    Kept for backward compat with callers (ml_provider.analyze_patterns).
-    detect_speaker_names no longer uses heuristics.
-    """
-    _ = sample_size
-    return {}
-
-
-def detect_speaker_names(
-    episode_title: str,
-    episode_description: Optional[str],
-    nlp: Any,
-    cfg: Optional[config.Config] = None,
-    known_hosts: Optional[Set[str]] = None,
-    cached_hosts: Optional[Set[str]] = None,
-    heuristics: Optional[Dict[str, Any]] = None,
-    transcript_text: Optional[str] = None,
-) -> Tuple[List[str], Set[str], bool, bool]:
-    """Detect guest names from episode title and description using NER.
-
-    Host names should be detected separately via detect_hosts_from_feed()
-    and passed via cached_hosts or known_hosts.
-
-    Flow:
-      1. NER on title + first 500 chars of description → PERSON entities
-      2. Filter out known hosts
-      3. Keep only names with interview-intent context (Issue #325)
-      4. Deduplicate, build speaker list with hosts
-
-    Args:
-        episode_title: Episode title.
-        episode_description: Episode description (first 500 chars used).
-        nlp: Pre-loaded spaCy model.
-        cfg: Configuration (optional).
-        known_hosts: Manually specified host names (optional).
-        cached_hosts: Previously detected hosts to reuse (optional).
-        heuristics: Ignored (kept for backward compat, was pattern learner).
-        transcript_text: Full transcript for intro-fallback host detection.
-
-    Returns:
-        (speaker_names, detected_hosts, detection_succeeded, used_defaults)
-    """
-    if cfg and not cfg.auto_speakers:
-        return DEFAULT_SPEAKER_NAMES.copy(), set(), False, True
-
-    if not nlp:
-        return DEFAULT_SPEAKER_NAMES.copy(), set(), False, True
-
-    # Resolve hosts: known_hosts > cached_hosts > transcript intro fallback
-    hosts: Set[str] = set()
-    if known_hosts:
-        hosts.update(known_hosts)
-    elif cached_hosts:
-        hosts.update(cached_hosts)
-
-    if not hosts and transcript_text and nlp:
-        transcript_hosts = detect_hosts_from_transcript_intro(transcript_text, nlp)
-        if transcript_hosts:
-            hosts.update(transcript_hosts)
-            logger.info("  → Hosts from transcript intro: %s", sorted(transcript_hosts))
-
-    # NER on title + description snippet
-    title_persons = extract_person_entities(episode_title, nlp)
-
-    description_snippet = None
-    if episode_description:
-        description_snippet = episode_description[:DESCRIPTION_SNIPPET_LENGTH].strip() or None
-
-    desc_persons = extract_person_entities(description_snippet, nlp) if description_snippet else []
-
-    # Filter out hosts, deduplicate
-    hosts_lower = {h.lower().strip() for h in hosts}
-    seen: Set[str] = set()
-    guests: List[str] = []
-    for name, _score in title_persons + desc_persons:
-        key = name.lower().strip()
-        if key in hosts_lower or key in seen:
-            continue
-        if not _is_likely_actual_guest(name, episode_title, episode_description):
-            continue
-        seen.add(key)
-        guests.append(name)
-
-    if guests:
-        logger.info("  → Guest: %s", ", ".join(guests))
-
-    max_names = cfg.screenplay_num_speakers if cfg else 2
-    speaker_names, detection_succeeded, used_defaults = _build_speaker_names_list(
-        hosts, guests, max_names
-    )
-    return speaker_names, hosts, detection_succeeded, used_defaults
-
-
-def _build_speaker_names_list(
-    hosts: Set[str],
-    guests: List[str],
-    max_names: int,
-) -> Tuple[List[str], bool, bool]:
-    """Build final speaker names list from hosts and guests.
-
-    Args:
-        hosts: Set of host names
-        guests: List of guest names
-        max_names: Maximum number of names to return
-
-    Returns:
-        Tuple of (speaker_names_list, detection_succeeded, used_defaults)
-        - detection_succeeded: True if real names were detected, False if defaults were used
-        - used_defaults: True if defaults were added to reach min speakers (quality flag)
-    """
-    # Detection succeeded if we have real names (hosts or guests), not defaults
-    # Note: Having hosts but no guests is still a success (host-only episodes are valid)
-    detection_succeeded = bool(hosts or guests)
-    used_defaults = False  # Quality flag: track if defaults were used
-
-    if not guests and hosts:
-        # Hosts detected but no guests - use actual host names
-        # Convert set to sorted list for deterministic ordering
-        host_list = sorted(list(hosts))[:max_names]
-        speaker_names = host_list
-        logger.debug("  → Using detected host names: %s (no guests detected)", speaker_names)
-    elif not hosts and not guests:
-        # No hosts AND no guests detected - this is "unknown host" not a failure
-        # Allow "unknown host" without flagging as detection failure
-        # This is common when RSS metadata has organization names (publishers) not person names
-        logger.info("  → No hosts or guests detected (using defaults)")
-        speaker_names = DEFAULT_SPEAKER_NAMES.copy()
-        detection_succeeded = False  # Still mark as failed for backward compatibility
-        used_defaults = True  # Quality flag: defaults were used
-    else:
-        # Combine hosts and guests, prioritizing hosts
-        speaker_names = list(hosts)[:max_names] + guests[: max_names - len(hosts)]
-        if len(speaker_names) < MIN_SPEAKERS_REQUIRED:
-            # Ensure at least MIN_SPEAKERS_REQUIRED speakers for screenplay formatting
-            # Only add defaults if we have at least one real speaker (host or guest)
-            # This prevents adding defaults when we have hosts but no guests (host-only episodes)
-            if hosts or guests:
-                used_defaults = True  # Quality flag: defaults were used
-                logger.debug(
-                    (
-                        "  → Only %d speaker(s) detected, extending with defaults "
-                        "to ensure %d+ speakers"
-                    ),
-                    len(speaker_names),
-                    MIN_SPEAKERS_REQUIRED,
-                )
-                speaker_names.extend(DEFAULT_SPEAKER_NAMES[len(speaker_names) :])
-            else:
-                # No real speakers - use defaults (this case should be rare)
-                speaker_names = DEFAULT_SPEAKER_NAMES.copy()
-                used_defaults = True
-
-    return speaker_names[:max_names], detection_succeeded, used_defaults
+def extract_person_entities(text: str, nlp: Any) -> list[tuple[str, float]]:
+    """Extract PERSON entities (delegates to speaker_detectors.entities; patchable)."""
+    return _extract_person_entities_impl(text, nlp)
 
 
 __all__ = [
     "analyze_episode_patterns",
+    "DEFAULT_CONFIDENCE_SCORE",
+    "DEFAULT_SAMPLE_SIZE",
     "DEFAULT_SPEAKER_NAMES",
+    "PATTERN_BASED_CONFIDENCE_SCORE",
     "detect_hosts_from_feed",
     "detect_hosts_from_transcript_intro",
     "detect_speaker_names",
@@ -933,4 +93,19 @@ __all__ = [
     "filter_default_speaker_names",
     "get_ner_model",
     "is_default_speaker_name",
+    "logger",
+    "_build_speaker_names_list",
+    "_ensure_spacy_sentence_boundaries",
+    "_extract_confidence_score",
+    "_extract_entities_from_doc",
+    "_extract_entities_from_segments",
+    "_has_interview_indicator",
+    "_has_mentioned_only_indicator",
+    "_is_likely_actual_guest",
+    "_load_spacy_model",
+    "_pattern_based_fallback",
+    "_sanitize_person_name",
+    "_split_text_on_separators",
+    "_validate_model_name",
+    "_validate_person_entity",
 ]

--- a/src/podcast_scraper/providers/ml/speaker_detection.py
+++ b/src/podcast_scraper/providers/ml/speaker_detection.py
@@ -55,7 +55,7 @@ def _load_spacy_model(model_name: str) -> Optional[Any]:
 
 def get_ner_model(cfg: config.Config) -> Optional[Any]:
     """Get the appropriate spaCy NER model based on configuration."""
-    return _get_ner_model_impl(cfg)
+    return _get_ner_model_impl(cfg, loader=_load_spacy_model)
 
 
 def extract_person_entities(text: str, nlp: Any) -> list[tuple[str, float]]:

--- a/src/podcast_scraper/providers/ml/speaker_detection.py
+++ b/src/podcast_scraper/providers/ml/speaker_detection.py
@@ -34,6 +34,7 @@ from ...speaker_detectors.ner import (
     _ensure_spacy_sentence_boundaries,
     _load_spacy_model as _load_spacy_model_impl,
     _validate_model_name,
+    get_ner_model as _get_ner_model_impl,
 )
 from ...speaker_detectors.normalization import (
     _extract_confidence_score,
@@ -54,25 +55,7 @@ def _load_spacy_model(model_name: str) -> Optional[Any]:
 
 def get_ner_model(cfg: config.Config) -> Optional[Any]:
     """Get the appropriate spaCy NER model based on configuration."""
-    if cfg.dry_run:
-        return None
-
-    if not cfg.auto_speakers:
-        return None
-
-    model_name = cfg.ner_model
-    if not model_name:
-        if cfg.language == "en":
-            model_name = config.DEFAULT_NER_MODEL
-        else:
-            logger.debug("No default NER model for language '%s', skipping detection", cfg.language)
-            return None
-
-    nlp = _load_spacy_model(model_name)
-    if nlp is not None:
-        logger.debug("Loaded spaCy model: %s", model_name)
-
-    return nlp
+    return _get_ner_model_impl(cfg)
 
 
 def extract_person_entities(text: str, nlp: Any) -> list[tuple[str, float]]:

--- a/src/podcast_scraper/providers/ml/summarizer.py
+++ b/src/podcast_scraper/providers/ml/summarizer.py
@@ -524,38 +524,10 @@ def _validate_model_source_legacy(model_name: str) -> None:
 
 
 def remove_sponsor_blocks(text: str) -> str:
-    """Remove common sponsor block phrases from text.
+    """Remove sponsor blocks via canonical preprocessing implementation."""
+    from ...preprocessing.core import remove_sponsor_blocks as _remove
 
-    Duplicate of preprocessing.core.remove_sponsor_blocks — this copy is
-    called by cleaning_v4 profile in summarize_long_text. Hybrid ML with
-    pattern workflow cleaning uses cleaning_hybrid_after_pattern to avoid
-    duplicate sponsor passes (Issue #419). Future work will consolidate
-    into a single CommercialDetector where duplication remains.
-
-    Args:
-        text: Raw transcript or summary text.
-
-    Returns:
-        Text with sponsor blocks removed.
-    """
-    lower = text.lower()
-    cleaned = text
-    for phrase in [
-        "this episode is brought to you by",
-        "today's episode is sponsored by",
-        "today’s episode is sponsored by",
-        "our sponsors today are",
-    ]:
-        idx = lower.find(phrase)
-        if idx == -1:
-            continue
-        # Remove, say, up to the next blank line OR up to N chars
-        end = cleaned.find("\n\n", idx)
-        if end == -1 or end - idx > 2000:
-            end = min(idx + 2000, len(cleaned))
-        cleaned = cleaned[:idx] + cleaned[end:]
-        lower = cleaned.lower()
-    return cleaned
+    return _remove(text)
 
 
 def select_summary_model(cfg) -> str:

--- a/src/podcast_scraper/speaker_detectors/__init__.py
+++ b/src/podcast_scraper/speaker_detectors/__init__.py
@@ -1,7 +1,28 @@
-"""Speaker detection providers.
+"""Speaker detection: provider protocol and NER implementation submodules."""
 
-This package contains implementations of speaker detection providers
-following the SpeakerDetector protocol.
-"""
+from __future__ import annotations
 
-# Stage 0: Empty package - implementations will be added in later stages
+from .base import SpeakerDetector
+from .constants import DEFAULT_SAMPLE_SIZE, DEFAULT_SPEAKER_NAMES
+from .detection import detect_speaker_names
+from .entities import extract_person_entities
+from .factory import create_speaker_detector
+from .hosts import detect_hosts_from_feed, detect_hosts_from_transcript_intro
+from .ner import get_ner_model
+from .normalization import filter_default_speaker_names, is_default_speaker_name
+from .patterns import analyze_episode_patterns
+
+__all__ = [
+    "SpeakerDetector",
+    "analyze_episode_patterns",
+    "create_speaker_detector",
+    "DEFAULT_SAMPLE_SIZE",
+    "DEFAULT_SPEAKER_NAMES",
+    "detect_hosts_from_feed",
+    "detect_hosts_from_transcript_intro",
+    "detect_speaker_names",
+    "extract_person_entities",
+    "filter_default_speaker_names",
+    "get_ner_model",
+    "is_default_speaker_name",
+]

--- a/src/podcast_scraper/speaker_detectors/constants.py
+++ b/src/podcast_scraper/speaker_detectors/constants.py
@@ -1,0 +1,53 @@
+"""Thresholds, defaults, and pattern lists for NER-based speaker detection."""
+
+from __future__ import annotations
+
+import re
+
+# Default speaker names when detection fails (Issue #428: use typed placeholder, not "Guest")
+DEFAULT_SPEAKER_NAMES = ["Host", "unknown_guest_1"]
+
+_VALID_MODEL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_.-]+$")
+
+MAX_MODEL_NAME_LENGTH = 100
+MIN_NAME_LENGTH = 2
+MIN_RAW_NAME_LENGTH = 2
+MIN_SEGMENT_LENGTH = 2
+
+DEFAULT_CONFIDENCE_SCORE = 1.0
+PATTERN_BASED_CONFIDENCE_SCORE = 0.7
+
+DESCRIPTION_SNIPPET_LENGTH = 500
+DEFAULT_SAMPLE_SIZE = 5
+MIN_SPEAKERS_REQUIRED = 2
+
+INTERVIEW_INDICATOR_PATTERNS = [
+    r"interview(?:ed|ing|s)?\s+(?:with\s+)?",
+    r"(?:we(?:'re|'ve)?|i(?:'m|'ve)?)\s+(?:been\s+)?joined\s+by\s+",
+    r"speaking\s+(?:with|to)\s+",
+    r"talking\s+(?:with|to)\s+",
+    r"talks?\s+(?:with|to)\s+",
+    r"conversation\s+with\s+",
+    r"guest(?:s)?(?:\s*:|\s+is|\s+are)?\s*",
+    r"featuring\s+",
+    r"(?:special\s+)?guest\s+",
+    r"welcomes?\s+",
+    r"sits?\s+down\s+with\s+",
+    r"chats?\s+with\s+",
+    r"joining\s+us\s+",
+]
+
+MENTIONED_ONLY_PATTERNS = [
+    r"about\s+",
+    r"on\s+\w+(?:'s)?\s+",
+    r"discuss(?:es|ing|ed)?\s+",
+    r"analysis\s+of\s+",
+    r"according\s+to\s+",
+    r"(?:he|she|they)\s+says?\s+",
+    r"'s\s+(?:\w+\s+)*(?:policy|plan|speech|decision|statement)",
+    r"(?:the\s+)?(?:president|ceo|senator|governor)\s+",
+    r"covers?\s+",
+    r"examines?\s+",
+    r"looks?\s+at\s+",
+    r"(?:news|story|report)\s+(?:about|on)\s+",
+]

--- a/src/podcast_scraper/speaker_detectors/detection.py
+++ b/src/podcast_scraper/speaker_detectors/detection.py
@@ -1,0 +1,125 @@
+"""Speaker name detection orchestration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from .. import config
+from .constants import DEFAULT_SPEAKER_NAMES, DESCRIPTION_SNIPPET_LENGTH, MIN_SPEAKERS_REQUIRED
+from .guests import _is_likely_actual_guest
+from .hosts import detect_hosts_from_transcript_intro
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_person_entities(text: str, nlp: Any) -> list[tuple[str, float]]:
+    """Resolve extract_person_entities via public wrapper when loaded (patchable in tests)."""
+    try:
+        from podcast_scraper.providers.ml import speaker_detection
+
+        return speaker_detection.extract_person_entities(text, nlp)
+    except ImportError:
+        from .entities import extract_person_entities as direct
+
+        return direct(text, nlp)
+
+
+def detect_speaker_names(
+    episode_title: str,
+    episode_description: Optional[str],
+    nlp: Any,
+    cfg: Optional[config.Config] = None,
+    known_hosts: Optional[Set[str]] = None,
+    cached_hosts: Optional[Set[str]] = None,
+    heuristics: Optional[Dict[str, Any]] = None,
+    transcript_text: Optional[str] = None,
+) -> Tuple[List[str], Set[str], bool, bool]:
+    """Detect guest names from episode title and description using NER."""
+    _ = heuristics
+
+    if cfg and not cfg.auto_speakers:
+        return DEFAULT_SPEAKER_NAMES.copy(), set(), False, True
+
+    if not nlp:
+        return DEFAULT_SPEAKER_NAMES.copy(), set(), False, True
+
+    hosts: Set[str] = set()
+    if known_hosts:
+        hosts.update(known_hosts)
+    elif cached_hosts:
+        hosts.update(cached_hosts)
+
+    if not hosts and transcript_text and nlp:
+        transcript_hosts = detect_hosts_from_transcript_intro(transcript_text, nlp)
+        if transcript_hosts:
+            hosts.update(transcript_hosts)
+            logger.info("  → Hosts from transcript intro: %s", sorted(transcript_hosts))
+
+    title_persons = _extract_person_entities(episode_title, nlp)
+
+    description_snippet = None
+    if episode_description:
+        description_snippet = episode_description[:DESCRIPTION_SNIPPET_LENGTH].strip() or None
+
+    desc_persons = _extract_person_entities(description_snippet, nlp) if description_snippet else []
+
+    hosts_lower = {h.lower().strip() for h in hosts}
+    seen: Set[str] = set()
+    guests: List[str] = []
+    for name, _score in title_persons + desc_persons:
+        key = name.lower().strip()
+        if key in hosts_lower or key in seen:
+            continue
+        if not _is_likely_actual_guest(name, episode_title, episode_description):
+            continue
+        seen.add(key)
+        guests.append(name)
+
+    if guests:
+        logger.info("  → Guest: %s", ", ".join(guests))
+
+    max_names = cfg.screenplay_num_speakers if cfg else 2
+    speaker_names, detection_succeeded, used_defaults = _build_speaker_names_list(
+        hosts, guests, max_names
+    )
+    return speaker_names, hosts, detection_succeeded, used_defaults
+
+
+def _build_speaker_names_list(
+    hosts: Set[str],
+    guests: List[str],
+    max_names: int,
+) -> Tuple[List[str], bool, bool]:
+    """Build final speaker names list from hosts and guests."""
+    detection_succeeded = bool(hosts or guests)
+    used_defaults = False
+
+    if not guests and hosts:
+        host_list = sorted(list(hosts))[:max_names]
+        speaker_names = host_list
+        logger.debug("  → Using detected host names: %s (no guests detected)", speaker_names)
+    elif not hosts and not guests:
+        logger.info("  → No hosts or guests detected (using defaults)")
+        speaker_names = DEFAULT_SPEAKER_NAMES.copy()
+        detection_succeeded = False
+        used_defaults = True
+    else:
+        speaker_names = list(hosts)[:max_names] + guests[: max_names - len(hosts)]
+        if len(speaker_names) < MIN_SPEAKERS_REQUIRED:
+            if hosts or guests:
+                used_defaults = True
+                logger.debug(
+                    (
+                        "  → Only %d speaker(s) detected, extending with defaults "
+                        "to ensure %d+ speakers"
+                    ),
+                    len(speaker_names),
+                    MIN_SPEAKERS_REQUIRED,
+                )
+                speaker_names.extend(DEFAULT_SPEAKER_NAMES[len(speaker_names) :])
+            else:
+                speaker_names = DEFAULT_SPEAKER_NAMES.copy()
+                used_defaults = True
+
+    return speaker_names[:max_names], detection_succeeded, used_defaults

--- a/src/podcast_scraper/speaker_detectors/entities.py
+++ b/src/podcast_scraper/speaker_detectors/entities.py
@@ -1,0 +1,159 @@
+"""PERSON entity extraction from text via spaCy NER."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, List, Optional, Set, Tuple
+
+from .constants import MIN_SEGMENT_LENGTH, PATTERN_BASED_CONFIDENCE_SCORE
+from .normalization import (
+    _extract_confidence_score,
+    _sanitize_person_name,
+    _validate_person_entity,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_entities_from_doc(
+    doc: Any, seen_raw_names: Set[str], seen_sanitized_names: Set[str]
+) -> List[Tuple[str, float]]:
+    """Extract PERSON entities from a spaCy document."""
+    persons = []
+    for ent in doc.ents:
+        if ent.label_ != "PERSON":
+            continue
+
+        raw_name = ent.text.strip()
+
+        if raw_name in seen_raw_names:
+            continue
+
+        if not _validate_person_entity(raw_name):
+            continue
+
+        sanitized_name = _sanitize_person_name(raw_name)
+        if not sanitized_name:
+            continue
+
+        sanitized_lower = sanitized_name.lower()
+        if sanitized_lower in seen_sanitized_names:
+            continue
+
+        seen_raw_names.add(raw_name)
+        seen_sanitized_names.add(sanitized_lower)
+
+        confidence = _extract_confidence_score(ent)
+        persons.append((sanitized_name, confidence))
+
+    return persons
+
+
+def _split_text_on_separators(text: str) -> Tuple[List[str], Optional[str]]:
+    """Split text on common separators used in episode titles."""
+    separators = ["|", "—", "–", " - "]
+    segments = [text]
+    last_segment = None
+
+    for sep in separators:
+        if sep in text:
+            segments = [s.strip() for s in text.split(sep)]
+            last_segment = segments[-1] if segments else None
+            break
+
+    return segments, last_segment
+
+
+def _extract_entities_from_segments(
+    segments: List[str],
+    nlp: Any,
+    seen_raw_names: Set[str],
+    seen_sanitized_names: Set[str],
+) -> List[Tuple[str, float]]:
+    """Extract PERSON entities from text segments, prioritizing last segment."""
+    persons = []
+    for segment in reversed(segments):
+        if not segment or len(segment) < MIN_SEGMENT_LENGTH:
+            continue
+
+        segment_doc = nlp(segment)
+        segment_persons = _extract_entities_from_doc(
+            segment_doc, seen_raw_names, seen_sanitized_names
+        )
+        persons.extend(segment_persons)
+
+        if persons:
+            break
+
+    return persons
+
+
+def _pattern_based_fallback(
+    last_segment: str, seen_sanitized_names: Set[str]
+) -> Optional[Tuple[str, float]]:
+    """Pattern-based fallback for name extraction when NER fails."""
+    if not last_segment:
+        return None
+
+    name_pattern = r"^[A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,2}$"
+    if not re.match(name_pattern, last_segment):
+        return None
+
+    common_phrases = {
+        "guest",
+        "host",
+        "episode",
+        "title",
+        "interview",
+        "conversation",
+    }
+    last_segment_lower = last_segment.lower()
+    if any(phrase in last_segment_lower for phrase in common_phrases):
+        return None
+
+    sanitized_name = _sanitize_person_name(last_segment)
+    if not sanitized_name:
+        return None
+
+    sanitized_lower = sanitized_name.lower()
+    if sanitized_lower in seen_sanitized_names:
+        return None
+
+    logger.debug(
+        "Pattern-based fallback: extracted '%s' from last segment '%s'",
+        sanitized_name,
+        last_segment,
+    )
+    return (sanitized_name, PATTERN_BASED_CONFIDENCE_SCORE)
+
+
+def extract_person_entities(text: str, nlp: Any) -> List[Tuple[str, float]]:
+    """Extract PERSON entities from text using spaCy NER with confidence scores."""
+    if not text or not nlp:
+        return []
+
+    try:
+        seen_raw_names: Set[str] = set()
+        seen_sanitized_names: Set[str] = set()
+
+        doc = nlp(text)
+        persons = _extract_entities_from_doc(doc, seen_raw_names, seen_sanitized_names)
+
+        if not persons:
+            segments, last_segment = _split_text_on_separators(text)
+            persons = _extract_entities_from_segments(
+                segments, nlp, seen_raw_names, seen_sanitized_names
+            )
+
+            if not persons and last_segment:
+                pattern_result = _pattern_based_fallback(last_segment, seen_sanitized_names)
+                if pattern_result:
+                    sanitized_name, confidence = pattern_result
+                    seen_sanitized_names.add(sanitized_name.lower())
+                    persons.append((sanitized_name, confidence))
+
+        return persons
+    except Exception as exc:
+        logger.debug("Error extracting PERSON entities: %s", exc)
+        return []

--- a/src/podcast_scraper/speaker_detectors/guests.py
+++ b/src/podcast_scraper/speaker_detectors/guests.py
@@ -1,0 +1,53 @@
+"""Guest-intent filtering from episode title and description."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from .constants import INTERVIEW_INDICATOR_PATTERNS, MENTIONED_ONLY_PATTERNS
+
+logger = logging.getLogger(__name__)
+
+
+def _has_interview_indicator(name: str, text: str) -> bool:
+    """Check if name appears in an interview context."""
+    text_lower = text.lower()
+    name_lower = name.lower()
+
+    for pattern in INTERVIEW_INDICATOR_PATTERNS:
+        full_pattern = pattern + r".*?" + re.escape(name_lower)
+        if re.search(full_pattern, text_lower, re.IGNORECASE):
+            return True
+    return False
+
+
+def _has_mentioned_only_indicator(name: str, text: str) -> bool:
+    """Check if name appears in a mentioned-only context (not an actual guest)."""
+    text_lower = text.lower()
+    name_lower = name.lower()
+
+    for pattern in MENTIONED_ONLY_PATTERNS:
+        full_pattern = pattern + r".*?" + re.escape(name_lower)
+        if re.search(full_pattern, text_lower, re.IGNORECASE):
+            return True
+    return False
+
+
+def _is_likely_actual_guest(name: str, title: str, description: str | None) -> bool:
+    """Determine if a detected person is likely an actual guest vs merely mentioned."""
+    combined_text = title
+    if description:
+        combined_text += " " + description
+
+    has_interview = _has_interview_indicator(name, combined_text)
+    has_mentioned_only = _has_mentioned_only_indicator(name, combined_text)
+
+    if has_interview:
+        logger.debug("Name '%s' has interview indicator - likely actual guest", name)
+        return True
+    if has_mentioned_only:
+        logger.debug("Name '%s' has mentioned-only indicator - NOT a guest", name)
+        return False
+
+    return False

--- a/src/podcast_scraper/speaker_detectors/hosts.py
+++ b/src/podcast_scraper/speaker_detectors/hosts.py
@@ -1,0 +1,122 @@
+"""Host detection from feed metadata and transcript intro."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, List, Optional, Set
+
+from .entities import extract_person_entities as _extract_person_entities_direct
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_person_entities(text: str, nlp: Any) -> list[tuple[str, float]]:
+    """Resolve extract_person_entities via public wrapper when loaded (patchable in tests)."""
+    try:
+        from podcast_scraper.providers.ml import speaker_detection
+
+        return speaker_detection.extract_person_entities(text, nlp)
+    except ImportError:
+        return _extract_person_entities_direct(text, nlp)
+
+
+def _log(logger_method: str, message: str, *args: object) -> None:
+    """Emit log via wrapper module logger when available (patchable in tests)."""
+    try:
+        from podcast_scraper.providers.ml import speaker_detection
+
+        getattr(speaker_detection.logger, logger_method)(message, *args)
+    except ImportError:
+        getattr(logger, logger_method)(message, *args)
+
+
+def detect_hosts_from_transcript_intro(
+    transcript_text: str,
+    nlp: Optional[Any] = None,
+    intro_duration_seconds: int = 120,
+    words_per_second: float = 2.5,
+) -> Set[str]:
+    """Detect host names from transcript intro patterns (first 60-120 seconds)."""
+    if not transcript_text or not nlp:
+        return set()
+
+    intro_word_count = int(intro_duration_seconds * words_per_second)
+    words = transcript_text.split()[:intro_word_count]
+    intro_text = " ".join(words)
+
+    intro_patterns = [
+        r"I'?m\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)",
+        r"This is\s+[^.]+\s+I'?m\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)",
+        r"Welcome to\s+[^.]+\s+I'?m\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)",
+    ]
+
+    detected_names = set()
+    for pattern in intro_patterns:
+        matches = re.finditer(pattern, intro_text, re.IGNORECASE)
+        for match in matches:
+            name = match.group(1).strip()
+            if name and len(name) > 2 and name.lower() not in ["the", "this", "that"]:
+                detected_names.add(name)
+
+    if nlp:
+        intro_persons = _extract_person_entities(intro_text, nlp)
+        for name, _ in intro_persons:
+            detected_names.add(name)
+
+    return detected_names
+
+
+def detect_hosts_from_feed(
+    feed_title: Optional[str],
+    feed_description: Optional[str],
+    feed_authors: Optional[List[str]] = None,
+    nlp: Optional[Any] = None,
+) -> Set[str]:
+    """Detect host names from feed-level metadata."""
+    hosts: Set[str] = set()
+
+    if feed_authors:
+        for author in feed_authors:
+            if author and author.strip():
+                author_clean = author.strip()
+                if "<" in author_clean and ">" in author_clean:
+                    author_clean = author_clean.split("<")[0].strip()
+                if author_clean:
+                    is_likely_org = (
+                        len(author_clean) <= 10
+                        and author_clean.isupper()
+                        and " " not in author_clean
+                    )
+                    if is_likely_org:
+                        logger.debug(
+                            "RSS author '%s' appears to be an organization name, "
+                            "treating as publisher metadata rather than host",
+                            author_clean,
+                        )
+                    else:
+                        hosts.add(author_clean)
+        if hosts:
+            logger.debug(
+                "Detected hosts from RSS author tags (author/itunes:author/itunes:owner): %s",
+                list(hosts),
+            )
+            return hosts
+        if feed_authors:
+            _log(
+                "info",
+                "All RSS author(s) treated as organisation(s); host detection will use "
+                "NER from feed title/description, episode-level authors, or config known_hosts",
+            )
+
+    if nlp:
+        if feed_title:
+            title_persons = _extract_person_entities(feed_title, nlp)
+            hosts.update(name for name, _ in title_persons)
+        if feed_description:
+            desc_persons = _extract_person_entities(feed_description, nlp)
+            hosts.update(name for name, _ in desc_persons)
+        if hosts:
+            logger.debug("Detected hosts via NER from feed metadata: %s", list(hosts))
+
+    return hosts

--- a/src/podcast_scraper/speaker_detectors/ner.py
+++ b/src/podcast_scraper/speaker_detectors/ner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import subprocess  # nosec B404
 import sys
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from .. import config
 from .constants import _VALID_MODEL_NAME_PATTERN, MAX_MODEL_NAME_LENGTH
@@ -86,7 +86,11 @@ def _load_spacy_model(model_name: str) -> Optional[Any]:
             return None
 
 
-def get_ner_model(cfg: config.Config) -> Optional[Any]:
+def get_ner_model(
+    cfg: config.Config,
+    *,
+    loader: Optional[Callable[[str], Optional[Any]]] = None,
+) -> Optional[Any]:
     """Get the appropriate spaCy NER model based on configuration."""
     if cfg.dry_run:
         return None
@@ -102,7 +106,8 @@ def get_ner_model(cfg: config.Config) -> Optional[Any]:
             logger.debug("No default NER model for language '%s', skipping detection", cfg.language)
             return None
 
-    nlp = _load_spacy_model(model_name)
+    load_fn = loader if loader is not None else _load_spacy_model
+    nlp = load_fn(model_name)
     if nlp is not None:
         logger.debug("Loaded spaCy model: %s", model_name)
 

--- a/src/podcast_scraper/speaker_detectors/ner.py
+++ b/src/podcast_scraper/speaker_detectors/ner.py
@@ -1,0 +1,109 @@
+"""spaCy model loading and NER model access."""
+
+from __future__ import annotations
+
+import logging
+import subprocess  # nosec B404
+import sys
+from typing import Any, Optional
+
+from .. import config
+from .constants import _VALID_MODEL_NAME_PATTERN, MAX_MODEL_NAME_LENGTH
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_spacy_sentence_boundaries(nlp: Any) -> None:
+    """Ensure ``doc.sents`` works for downstream code."""
+    if "parser" in nlp.pipe_names or "senter" in nlp.pipe_names:
+        return
+    if "sentencizer" in nlp.pipe_names:
+        return
+    try:
+        nlp.add_pipe("sentencizer")
+    except (ValueError, TypeError) as exc:
+        logger.debug("Could not add sentencizer to spaCy pipeline: %s", exc)
+
+
+def _validate_model_name(model_name: str) -> bool:
+    """Validate spaCy model name to prevent command injection."""
+    if not model_name or len(model_name) > MAX_MODEL_NAME_LENGTH:
+        return False
+    return bool(_VALID_MODEL_NAME_PATTERN.match(model_name))
+
+
+def _load_spacy_model(model_name: str) -> Optional[Any]:
+    """Load spaCy model, automatically downloading if missing."""
+    import spacy  # noqa: F401
+
+    if not _validate_model_name(model_name):
+        logger.error("Invalid spaCy model name: %s (contains invalid characters)", model_name)
+        return None
+
+    try:
+        try:
+            nlp = spacy.load(model_name, disable=["parser", "tagger", "lemmatizer"])
+            logger.info("Loaded spaCy model (NER only): %s", model_name)
+        except (ValueError, KeyError):
+            logger.debug(
+                "Model %s doesn't support component disabling, loading full pipeline", model_name
+            )
+            nlp = spacy.load(model_name)
+            logger.info("Loaded spaCy model (full pipeline): %s", model_name)
+        _ensure_spacy_sentence_boundaries(nlp)
+        return nlp
+    except OSError:
+        logger.debug("spaCy model '%s' not found locally, attempting to download...", model_name)
+        try:
+            subprocess.run(  # nosec B603
+                [sys.executable, "-m", "spacy", "download", model_name],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            logger.debug("Successfully downloaded spaCy model: %s", model_name)
+            try:
+                nlp = spacy.load(model_name, disable=["parser", "tagger", "lemmatizer"])
+                logger.info("Loaded spaCy model (NER only) after download: %s", model_name)
+            except (ValueError, KeyError):
+                nlp = spacy.load(model_name)
+                logger.info("Loaded spaCy model (full pipeline) after download: %s", model_name)
+            _ensure_spacy_sentence_boundaries(nlp)
+            return nlp
+        except subprocess.CalledProcessError as exc:
+            logger.error(
+                "Failed to download spaCy model '%s': %s. Output: %s",
+                model_name,
+                exc,
+                exc.stderr or exc.stdout or "",
+            )
+            logger.info("You can manually install with: python -m spacy download %s", model_name)
+            return None
+        except OSError as exc:
+            logger.error(
+                "Failed to load spaCy model '%s' after download attempt: %s", model_name, exc
+            )
+            return None
+
+
+def get_ner_model(cfg: config.Config) -> Optional[Any]:
+    """Get the appropriate spaCy NER model based on configuration."""
+    if cfg.dry_run:
+        return None
+
+    if not cfg.auto_speakers:
+        return None
+
+    model_name = cfg.ner_model
+    if not model_name:
+        if cfg.language == "en":
+            model_name = config.DEFAULT_NER_MODEL
+        else:
+            logger.debug("No default NER model for language '%s', skipping detection", cfg.language)
+            return None
+
+    nlp = _load_spacy_model(model_name)
+    if nlp is not None:
+        logger.debug("Loaded spaCy model: %s", model_name)
+
+    return nlp

--- a/src/podcast_scraper/speaker_detectors/normalization.py
+++ b/src/podcast_scraper/speaker_detectors/normalization.py
@@ -1,0 +1,63 @@
+"""Name sanitization, validation, and default-speaker filtering."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, List, Optional
+
+from .. import config_constants
+from .constants import (
+    DEFAULT_CONFIDENCE_SCORE,
+    DEFAULT_SPEAKER_NAMES,
+    MIN_NAME_LENGTH,
+    MIN_RAW_NAME_LENGTH,
+)
+
+
+def is_default_speaker_name(name: str) -> bool:
+    """Check if a speaker name is a default placeholder."""
+    return name in DEFAULT_SPEAKER_NAMES or name == config_constants.LEGACY_PLACEHOLDER_GUEST
+
+
+def filter_default_speaker_names(names: List[str]) -> List[str]:
+    """Filter out default speaker names from a list."""
+    return [name for name in names if not is_default_speaker_name(name)]
+
+
+def _sanitize_person_name(name: str) -> Optional[str]:
+    """Sanitize a person name by removing non-letter characters and normalizing."""
+    if not name:
+        return None
+
+    name = re.sub(r"\([^)]*\)", "", name)
+    name = re.sub(r"[,.;:!?]+$", "", name)
+    name = re.sub(r"^[,.;:!?]+", "", name)
+    name = name.strip()
+    name = re.sub(r"[^\w\s\-\']+", "", name)
+    name = re.sub(r"\s+", " ", name).strip()
+
+    if not name or len(name) < MIN_NAME_LENGTH:
+        return None
+
+    if not re.search(r"[a-zA-Z]", name):
+        return None
+
+    return name
+
+
+def _validate_person_entity(raw_name: str) -> bool:
+    """Validate that a raw entity name is likely a person."""
+    if not raw_name or len(raw_name) < MIN_RAW_NAME_LENGTH:
+        return False
+    if re.match(r"^\d+$", raw_name) or re.search(r"[<>]", raw_name):
+        return False
+    return True
+
+
+def _extract_confidence_score(ent: Any) -> float:
+    """Extract confidence score from spaCy entity."""
+    if hasattr(ent, "score") and ent.score is not None:
+        return float(ent.score)
+    if hasattr(ent, "_") and hasattr(ent._, "score") and ent._.score is not None:
+        return float(ent._.score)
+    return DEFAULT_CONFIDENCE_SCORE

--- a/src/podcast_scraper/speaker_detectors/patterns.py
+++ b/src/podcast_scraper/speaker_detectors/patterns.py
@@ -1,0 +1,18 @@
+"""Episode pattern analysis stub (backward compatibility)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Set
+
+from .constants import DEFAULT_SAMPLE_SIZE
+
+
+def analyze_episode_patterns(
+    episodes: List[Any],
+    nlp: Any,
+    cached_hosts: Set[str],
+    sample_size: int = DEFAULT_SAMPLE_SIZE,
+) -> Dict[str, Any]:
+    """No-op — heuristic pattern learner removed in #598 simplification."""
+    _ = episodes, nlp, cached_hosts, sample_size
+    return {}

--- a/src/podcast_scraper/transcription/factory.py
+++ b/src/podcast_scraper/transcription/factory.py
@@ -25,7 +25,7 @@ else:
 from podcast_scraper.utils.protocol_verification import verify_protocol_compliance
 
 
-def create_transcription_provider(
+def create_transcription_provider(  # noqa: C901
     cfg_or_provider_type: Union[config.Config, str],
     params: Optional[Union[TranscriptionParams, Dict[str, Any]]] = None,
 ) -> TranscriptionProvider:
@@ -86,12 +86,13 @@ def create_transcription_provider(
             "openai",
             "gemini",
             "mistral",
+            "deepgram",
             "tailnet_dgx_whisper",
         ):
             raise ValueError(f"Invalid provider type: {provider_type_str}")
 
         provider_type_value = cast(
-            Literal["whisper", "openai", "gemini", "mistral", "tailnet_dgx_whisper"],
+            Literal["whisper", "openai", "gemini", "mistral", "deepgram", "tailnet_dgx_whisper"],
             provider_type_str,
         )
         experiment_mode = True
@@ -219,6 +220,25 @@ def create_transcription_provider(
         # Runtime protocol verification (dev-mode only)
         verify_protocol_compliance(provider, TranscriptionProvider, "TranscriptionProvider")
         return provider
+    elif provider_type == "deepgram":
+        from ..providers.deepgram.deepgram_provider import DeepgramTranscriptionProvider
+
+        if experiment_mode:
+            from ..config import Config
+
+            assert isinstance(params, TranscriptionParams)
+            cfg = Config(
+                rss="",
+                transcription_provider="deepgram",
+                deepgram_model=params.model_name if params.model_name else "nova-3",
+                deepgram_api_key=os.getenv("DEEPGRAM_API_KEY"),
+            )
+            provider = DeepgramTranscriptionProvider(cfg)
+        else:
+            provider = DeepgramTranscriptionProvider(cfg)
+
+        verify_protocol_compliance(provider, TranscriptionProvider, "TranscriptionProvider")
+        return provider
     elif provider_type == "anthropic":
         from ..providers.anthropic.anthropic_provider import AnthropicProvider
 
@@ -259,6 +279,6 @@ def create_transcription_provider(
     else:
         raise ValueError(
             f"Unsupported transcription provider: {provider_type}. "
-            "Supported providers: 'whisper', 'openai', 'gemini', 'mistral', "
+            "Supported providers: 'whisper', 'openai', 'gemini', 'mistral', 'deepgram', "
             "'anthropic', 'tailnet_dgx_whisper'"
         )

--- a/src/podcast_scraper/transcription/factory.py
+++ b/src/podcast_scraper/transcription/factory.py
@@ -37,7 +37,7 @@ def create_transcription_provider(  # noqa: C901
 
     Args:
         cfg_or_provider_type: Either a Config object or provider type string
-            ("whisper", "openai", "gemini", or "mistral")
+            ("whisper", "openai", "gemini", "mistral", "deepgram", etc.)
         params: Optional parameters dict or TranscriptionParams object (experiment mode only)
 
     Returns:

--- a/src/podcast_scraper/utils/audio_payload_limits.py
+++ b/src/podcast_scraper/utils/audio_payload_limits.py
@@ -2,7 +2,21 @@
 
 from __future__ import annotations
 
-from typing import Union
+from typing import Any, Optional, Union
+
+# OpenAI gpt-4o-transcribe family hard duration cap (seconds).
+OPENAI_GPT4O_TRANSCRIBE_MAX_DURATION_SECONDS = 1400.0
+
+
+def transcription_max_chunk_duration_seconds(cfg: Any) -> Optional[float]:
+    """Return max single-request audio duration when provider enforces a cap."""
+    provider = str(getattr(cfg, "transcription_provider", None) or "").lower()
+    if provider != "openai":
+        return None
+    model = str(getattr(cfg, "openai_transcription_model", None) or "whisper-1")
+    if model in ("gpt-4o-transcribe", "gpt-4o-mini-transcribe"):
+        return OPENAI_GPT4O_TRANSCRIBE_MAX_DURATION_SECONDS
+    return None
 
 
 def is_provider_audio_payload_limit_error(exc_or_message: Union[BaseException, str]) -> bool:

--- a/src/podcast_scraper/utils/filesystem.py
+++ b/src/podcast_scraper/utils/filesystem.py
@@ -208,6 +208,7 @@ def _build_provider_model_suffix(cfg: config.Config) -> Optional[str]:
         "openai": ("oa", "openai_transcription_model", "whisper-1"),
         "gemini": ("gm", "gemini_transcription_model", "gemini-2.5-flash-lite"),
         "mistral": ("ms", "mistral_transcription_model", "voxtral-mini-latest"),
+        "deepgram": ("dg", "deepgram_model", "nova-3"),
     }
     if cfg.transcribe_missing:
         if cfg.transcription_provider == "whisper":

--- a/src/podcast_scraper/utils/provider_metrics.py
+++ b/src/podcast_scraper/utils/provider_metrics.py
@@ -176,8 +176,17 @@ def transcription_model_for_cfg(cfg: Any) -> str:
     provider = str(getattr(cfg, "transcription_provider", None) or "whisper")
     if provider == "whisper":
         return str(getattr(cfg, "whisper_model", None) or "base")
-    field = f"{provider}_transcription_model"
-    return str(getattr(cfg, field, None) or getattr(cfg, "openai_transcription_model", "") or "")
+    model_field_by_provider = {
+        "openai": "openai_transcription_model",
+        "gemini": "gemini_transcription_model",
+        "mistral": "mistral_transcription_model",
+        "deepgram": "deepgram_model",
+    }
+    field = model_field_by_provider.get(provider, f"{provider}_transcription_model")
+    model = getattr(cfg, field, None)
+    if model:
+        return str(model)
+    return ""
 
 
 def _safe_openai_retryable() -> tuple[type[Exception], ...]:

--- a/src/podcast_scraper/workflow/episode_processor.py
+++ b/src/podcast_scraper/workflow/episode_processor.py
@@ -1222,6 +1222,58 @@ def _resolve_episode_duration_seconds(job) -> Optional[int]:
     return None
 
 
+_API_CHUNKING_PROVIDERS = frozenset({"openai", "gemini", "mistral"})
+
+
+def _transcription_provider_supports_chunking(cfg: config.Config) -> bool:
+    return cfg.transcription_provider in _API_CHUNKING_PROVIDERS
+
+
+def _transcribe_with_segments_maybe_chunked(
+    media_for_transcription: str,
+    *,
+    cfg: config.Config,
+    job: TranscriptionJob,  # type: ignore[valid-type]
+    transcription_provider: Any,
+    pipeline_metrics: Any,
+    episode_duration_seconds: Optional[float],
+    call_metrics: Any,
+) -> Tuple[Dict[str, Any], float]:
+    """Transcribe media, splitting into chunks when post-preprocess size exceeds API cap."""
+    from ..preprocessing.audio.chunker import AudioChunker, transcribe_file_in_chunks
+    from ..utils.timeout import timeout_context, TimeoutError
+
+    def _transcribe_one(path: str) -> Tuple[Dict[str, Any], float]:
+        with timeout_context(cfg.transcription_timeout, f"transcription for episode {job.idx}"):
+            result, elapsed = transcription_provider.transcribe_with_segments(
+                path,
+                language=cfg.language,
+                pipeline_metrics=pipeline_metrics,
+                episode_duration_seconds=episode_duration_seconds,
+                call_metrics=call_metrics,
+            )
+            return (result, elapsed)
+
+    chunker = AudioChunker(max_bytes=_PREPROCESSING_API_REENCODE_TARGET_BYTES)
+    if _transcription_provider_supports_chunking(cfg) and chunker.needs_chunking(
+        media_for_transcription
+    ):
+        logger.info(
+            "[%s] Preprocessed audio exceeds API limit; transcribing in chunks",
+            job.idx,
+        )
+        return transcribe_file_in_chunks(
+            media_for_transcription,
+            chunker=chunker,
+            transcribe_fn=_transcribe_one,
+        )
+
+    try:
+        return _transcribe_one(media_for_transcription)
+    except TimeoutError:
+        raise
+
+
 def transcribe_media_to_text(
     job: TranscriptionJob,  # type: ignore[valid-type]
     cfg: config.Config,
@@ -1309,54 +1361,24 @@ def transcribe_media_to_text(
     # All providers receive optimized audio (Whisper, OpenAI, future providers)
     media_for_transcription = _preprocess_audio_if_needed(job, cfg, temp_media, pipeline_metrics)
 
-    if (
-        cfg.transcription_provider in ("openai", "gemini")
-        and media_for_transcription
-        and os.path.exists(media_for_transcription)
-    ):
-        try:
-            preprocessed_bytes = os.path.getsize(media_for_transcription)
-        except OSError:
-            preprocessed_bytes = None
-        # OPENAI_MAX_FILE_SIZE_BYTES names the historical constant; both OpenAI and Gemini
-        # transcription paths use this same post-preprocess ceiling (GitHub #557 / #561).
-        if preprocessed_bytes is not None and preprocessed_bytes > OPENAI_MAX_FILE_SIZE_BYTES:
-            msg = (
-                f"Preprocessed audio ({preprocessed_bytes} B) exceeds API limit "
-                f"({OPENAI_MAX_FILE_SIZE_BYTES} B); skipping transcription (GitHub #557)"
-            )
-            logger.warning("[%s] %s", job.idx, msg)
-            _append_transcription_incident(
-                cfg, job, category="policy", message=msg, exception_type="PolicySkip"
-            )
-            _mark_episode_skipped_policy(job, cfg, pipeline_metrics, msg)
-            _cleanup_temp_media(temp_media, cfg)
-            return False, None, bytes_downloaded
-
     try:
-        # Stage 2: Use provider's transcribe_with_segments method for full result with segments
-        # This supports both plain text and screenplay formatting
-        # Pass pipeline_metrics and episode duration for LLM call tracking (if OpenAI provider)
-        # Note: Provider receives preprocessed audio (if preprocessing was successful)
-        # Provider is agnostic to whether audio was preprocessed
+        # Stage 2: Use provider's transcribe_with_segments (chunked when over API cap)
         episode_duration_seconds = _resolve_episode_duration_seconds(job)
-        # Apply timeout enforcement for transcription (Issue #379)
-        # Create call metrics for tracking per-episode provider metrics
         from ..utils.provider_metrics import ProviderCallMetrics
-        from ..utils.timeout import timeout_context, TimeoutError
+        from ..utils.timeout import TimeoutError
 
         call_metrics = ProviderCallMetrics()
 
         try:
-            with timeout_context(cfg.transcription_timeout, f"transcription for episode {job.idx}"):
-                # All providers must support call_metrics (no backward compatibility)
-                result, tc_elapsed = transcription_provider.transcribe_with_segments(
-                    media_for_transcription,
-                    language=cfg.language,
-                    pipeline_metrics=pipeline_metrics,
-                    episode_duration_seconds=episode_duration_seconds,
-                    call_metrics=call_metrics,
-                )
+            result, tc_elapsed = _transcribe_with_segments_maybe_chunked(
+                media_for_transcription,
+                cfg=cfg,
+                job=job,
+                transcription_provider=transcription_provider,
+                pipeline_metrics=pipeline_metrics,
+                episode_duration_seconds=episode_duration_seconds,
+                call_metrics=call_metrics,
+            )
         except TimeoutError as e:
             logger.error(
                 f"[{job.idx}] Transcription timeout after {cfg.transcription_timeout}s: {e}"

--- a/src/podcast_scraper/workflow/episode_processor.py
+++ b/src/podcast_scraper/workflow/episode_processor.py
@@ -1222,7 +1222,7 @@ def _resolve_episode_duration_seconds(job) -> Optional[int]:
     return None
 
 
-_API_CHUNKING_PROVIDERS = frozenset({"openai", "gemini", "mistral"})
+_API_CHUNKING_PROVIDERS = frozenset({"openai", "gemini", "mistral", "deepgram"})
 
 
 def _transcription_provider_supports_chunking(cfg: config.Config) -> bool:

--- a/src/podcast_scraper/workflow/episode_processor.py
+++ b/src/podcast_scraper/workflow/episode_processor.py
@@ -683,7 +683,7 @@ def _preprocessing_reencode_mp3_until_target(
     working_path = preprocessed_path
     final_kbps = int(audio_preprocessor.mp3_bitrate_kbps)
     total_preprocess_elapsed = float(preprocess_elapsed)
-    if transcription_provider not in ("openai", "gemini"):
+    if transcription_provider not in ("openai", "gemini", "mistral", "deepgram"):
         return working_path, final_kbps, total_preprocess_elapsed
 
     while True:
@@ -779,7 +779,7 @@ def _preprocess_audio_if_needed(
     cache_dir = cfg.preprocessing_cache_dir or preprocessing_cache.PREPROCESSING_CACHE_DIR
     transcription_provider = str(cfg.transcription_provider or "").lower()
     first_pass_kbps = resolve_preprocessing_mp3_bitrate_kbps(cfg)
-    if transcription_provider in ("openai", "gemini"):
+    if transcription_provider in ("openai", "gemini", "mistral", "deepgram"):
         cache_probe_bitrates = mp3_bitrates_to_probe_for_cache(first_pass_kbps)
     else:
         cache_probe_bitrates = [first_pass_kbps]
@@ -1241,6 +1241,7 @@ def _transcribe_with_segments_maybe_chunked(
 ) -> Tuple[Dict[str, Any], float]:
     """Transcribe media, splitting into chunks when post-preprocess size exceeds API cap."""
     from ..preprocessing.audio.chunker import AudioChunker, transcribe_file_in_chunks
+    from ..utils.audio_payload_limits import transcription_max_chunk_duration_seconds
     from ..utils.timeout import timeout_context, TimeoutError
 
     def _transcribe_one(path: str) -> Tuple[Dict[str, Any], float]:
@@ -1254,7 +1255,10 @@ def _transcribe_with_segments_maybe_chunked(
             )
             return (result, elapsed)
 
-    chunker = AudioChunker(max_bytes=_PREPROCESSING_API_REENCODE_TARGET_BYTES)
+    chunker = AudioChunker(
+        max_bytes=_PREPROCESSING_API_REENCODE_TARGET_BYTES,
+        max_duration_seconds=transcription_max_chunk_duration_seconds(cfg),
+    )
     if _transcription_provider_supports_chunking(cfg) and chunker.needs_chunking(
         media_for_transcription
     ):

--- a/src/podcast_scraper/workflow/metadata_generation.py
+++ b/src/podcast_scraper/workflow/metadata_generation.py
@@ -1782,6 +1782,8 @@ def _build_transcription_provider_info(cfg: config.Config) -> Optional[Dict[str,
         transcription_model = getattr(cfg, "mistral_transcription_model", None)
         if transcription_model:
             provider_info["mistral_model"] = transcription_model
+    elif cfg.transcription_provider == "deepgram":
+        provider_info["deepgram_model"] = getattr(cfg, "deepgram_model", "nova-3")
 
     return provider_info
 

--- a/src/podcast_scraper/workflow/stages/processing.py
+++ b/src/podcast_scraper/workflow/stages/processing.py
@@ -576,7 +576,7 @@ def _check_episode_size_skip(
     if (
         cfg.dry_run
         or not cfg.transcribe_missing
-        or cfg.transcription_provider not in ("openai", "gemini")
+        or cfg.transcription_provider not in ("openai", "gemini", "mistral", "deepgram")
         or not episode.media_url
     ):
         return False, False
@@ -593,7 +593,13 @@ def _check_episode_size_skip(
     if file_size_bytes <= OPENAI_MAX_FILE_SIZE_BYTES:
         return False, False
     file_size_mb = file_size_bytes / BYTES_PER_MB
-    provider_name = "OpenAI" if cfg.transcription_provider == "openai" else "Gemini"
+    provider_labels = {
+        "openai": "OpenAI",
+        "gemini": "Gemini",
+        "mistral": "Mistral",
+        "deepgram": "Deepgram",
+    }
+    provider_name = provider_labels.get(cfg.transcription_provider, cfg.transcription_provider)
     if not episode.transcript_urls:
         logger.info(
             "[%d] Audio file size (%.1f MB) exceeds %s API limit (25 MB) "

--- a/src/podcast_scraper/workflow/stages/processing.py
+++ b/src/podcast_scraper/workflow/stages/processing.py
@@ -596,13 +596,13 @@ def _check_episode_size_skip(
     provider_name = "OpenAI" if cfg.transcription_provider == "openai" else "Gemini"
     if not episode.transcript_urls:
         logger.info(
-            "[%d] Skipping episode: Audio file size (%.1f MB) exceeds %s API limit (25 MB) "
-            "and no transcript URLs available.",
+            "[%d] Audio file size (%.1f MB) exceeds %s API limit (25 MB) "
+            "and no transcript URLs available; will attempt chunking after preprocess.",
             episode.idx,
             file_size_mb,
             provider_name,
         )
-        return True, True
+        return True, False
     logger.info(
         "[%d] Skipping speaker detection: Audio file size (%.1f MB) exceeds %s API limit "
         "(25 MB), but transcript URLs available.",

--- a/tests/integration/providers/test_protocol_compliance.py
+++ b/tests/integration/providers/test_protocol_compliance.py
@@ -179,3 +179,27 @@ class TestProtocolTypeHints(unittest.TestCase):
         """Test that SummarizationProvider protocol has type hints."""
         hints = get_type_hints(SummarizationProvider.summarize)
         self.assertIn("return", hints)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+class TestDeepgramTranscriptionProviderProtocol(unittest.TestCase):
+    """Test Deepgram TranscriptionProvider factory wiring."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.cfg = config.Config(
+            rss_url="https://example.com/feed.xml",
+            transcription_provider="deepgram",
+            deepgram_api_key="dg-test",
+        )
+        self.provider = create_transcription_provider(self.cfg)
+
+    def test_factory_creates_deepgram_provider(self):
+        """Factory returns DeepgramTranscriptionProvider for deepgram config."""
+        self.assertEqual(self.provider.__class__.__name__, "DeepgramTranscriptionProvider")
+
+    def test_provider_implements_transcribe_with_segments(self):
+        """Deepgram provider exposes segment transcription API."""
+        self.assertTrue(hasattr(self.provider, "transcribe_with_segments"))
+        self.assertTrue(callable(getattr(self.provider, "transcribe_with_segments")))

--- a/tests/unit/podcast_scraper/cleaning/commercial/test_detector.py
+++ b/tests/unit/podcast_scraper/cleaning/commercial/test_detector.py
@@ -1,0 +1,47 @@
+"""Unit tests for CommercialDetector Phase 1."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.cleaning.commercial import CommercialDetector
+
+pytestmark = pytest.mark.unit
+
+
+class TestCommercialDetector:
+    def test_removes_intro_sponsor_block(self) -> None:
+        text = (
+            "Host: Welcome to the show.\n\n"
+            "This episode is brought to you by Stripe. Visit stripe.com/podcast for details.\n\n"
+            "Host: Let's talk about design systems."
+        )
+        cleaned = CommercialDetector(confidence_threshold=0.65).remove(text)
+        assert "stripe.com" not in cleaned.lower()
+        assert "design systems" in cleaned.lower()
+
+    def test_keeps_non_sponsor_conversation(self) -> None:
+        text = "Host: We discuss Stripe the company history without any sponsor CTA."
+        cleaned = CommercialDetector(confidence_threshold=0.65).remove(text)
+        assert cleaned == text
+
+    def test_detect_returns_candidates_with_confidence(self) -> None:
+        text = "This episode is sponsored by Figma. Visit figma.com/start today."
+        detector = CommercialDetector(confidence_threshold=0.5)
+        candidates = detector.detect(text)
+        assert candidates
+        assert candidates[0].confidence >= 0.65
+
+    def test_legacy_four_phrase_still_removed(self) -> None:
+        text = "Intro\n\nOur sponsors today are Notion and Linear.\n\nMain content here."
+        cleaned = CommercialDetector().remove(text)
+        assert "notion" not in cleaned.lower()
+        assert "main content" in cleaned.lower()
+
+    def test_podcast_intro_welcome_back_not_removed(self) -> None:
+        text = (
+            "Maya: Welcome back to Singletrack Sessions. Today we're talking about trails.\n"
+            "Liam: Thanks, Maya. Let's dive into maintenance routines."
+        )
+        cleaned = CommercialDetector().remove(text)
+        assert cleaned == text

--- a/tests/unit/podcast_scraper/preprocessing/audio/test_audio_chunker.py
+++ b/tests/unit/podcast_scraper/preprocessing/audio/test_audio_chunker.py
@@ -1,0 +1,69 @@
+"""Unit tests for API audio chunking."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.preprocessing.audio.chunker import (
+    _dedupe_overlap_text,
+    AudioChunk,
+    AudioChunker,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestDedupeOverlapText:
+    def test_removes_shared_suffix_prefix(self) -> None:
+        prev = "one two three four five"
+        nxt = "four five six seven"
+        assert _dedupe_overlap_text(prev, nxt, overlap_seconds=5.0) == "six seven"
+
+    def test_no_overlap_returns_next(self) -> None:
+        assert (
+            _dedupe_overlap_text("alpha beta", "gamma delta", overlap_seconds=5.0) == "gamma delta"
+        )
+
+
+class TestMergeTranscriptResults:
+    def test_offsets_and_text_merge(self) -> None:
+        chunker = AudioChunker(max_bytes=1024, overlap_seconds=5.0)
+        chunks = [
+            AudioChunk(path="a.mp3", start_seconds=0.0, index=0),
+            AudioChunk(path="b.mp3", start_seconds=95.0, index=1),
+        ]
+        results = [
+            (
+                {
+                    "text": "hello world",
+                    "segments": [{"start": 0.0, "end": 1.0, "text": "hello world"}],
+                },
+                1.0,
+            ),
+            (
+                {
+                    "text": "world again",
+                    "segments": [{"start": 0.0, "end": 1.0, "text": "world again"}],
+                },
+                1.5,
+            ),
+        ]
+        merged, elapsed = chunker.merge_transcript_results(results, chunks)
+        assert elapsed == 2.5
+        assert "hello" in merged["text"]
+        assert len(merged["segments"]) == 2
+        assert merged["segments"][1]["start"] == pytest.approx(95.0)
+
+
+class TestNeedsChunking:
+    def test_needs_chunking_when_over_limit(self, tmp_path) -> None:
+        audio = tmp_path / "big.mp3"
+        audio.write_bytes(b"x" * 2000)
+        chunker = AudioChunker(max_bytes=1000)
+        assert chunker.needs_chunking(str(audio))
+
+    def test_no_chunking_when_under_limit(self, tmp_path) -> None:
+        audio = tmp_path / "small.mp3"
+        audio.write_bytes(b"x" * 100)
+        chunker = AudioChunker(max_bytes=1000)
+        assert not chunker.needs_chunking(str(audio))

--- a/tests/unit/podcast_scraper/preprocessing/audio/test_audio_chunker.py
+++ b/tests/unit/podcast_scraper/preprocessing/audio/test_audio_chunker.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
 import pytest
 
 from podcast_scraper.preprocessing.audio.chunker import (
     _dedupe_overlap_text,
     AudioChunk,
     AudioChunker,
+)
+from podcast_scraper.utils.audio_payload_limits import (
+    OPENAI_GPT4O_TRANSCRIBE_MAX_DURATION_SECONDS,
+    transcription_max_chunk_duration_seconds,
 )
 
 pytestmark = pytest.mark.unit
@@ -67,3 +74,52 @@ class TestNeedsChunking:
         audio.write_bytes(b"x" * 100)
         chunker = AudioChunker(max_bytes=1000)
         assert not chunker.needs_chunking(str(audio))
+
+
+class TestDurationChunking:
+    @patch("podcast_scraper.preprocessing.audio.chunker._probe_duration_seconds")
+    def test_needs_chunking_when_duration_over_limit(self, mock_probe, tmp_path) -> None:
+        mock_probe.return_value = 1500.0
+        audio = tmp_path / "short.mp3"
+        audio.write_bytes(b"x" * 100)
+        chunker = AudioChunker(max_bytes=1_000_000, max_duration_seconds=1400.0)
+        assert chunker.needs_chunking(str(audio))
+
+    def test_transcription_duration_limit_openai_gpt4o(self) -> None:
+        from podcast_scraper import config
+
+        cfg = config.Config(
+            rss="https://example.com/feed.xml",
+            transcription_provider="openai",
+            openai_api_key="sk-test",
+            openai_transcription_model="gpt-4o-transcribe",
+        )
+        assert transcription_max_chunk_duration_seconds(cfg) == (
+            OPENAI_GPT4O_TRANSCRIBE_MAX_DURATION_SECONDS
+        )
+
+
+class TestSplitAudio:
+    @patch("podcast_scraper.preprocessing.audio.chunker._run_text_subprocess")
+    @patch("podcast_scraper.preprocessing.audio.chunker._probe_duration_seconds")
+    @patch("podcast_scraper.preprocessing.audio.chunker.shutil.which")
+    def test_split_invokes_ffmpeg_stream_copy(
+        self, mock_which, mock_probe, mock_run, tmp_path
+    ) -> None:
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_probe.return_value = 3000.0
+        audio = tmp_path / "long.mp3"
+        audio.write_bytes(b"x" * (26 * 1024 * 1024))
+
+        def _fake_ffmpeg(cmd, **kwargs):
+            out_path = cmd[-1]
+            with open(out_path, "wb") as handle:
+                handle.write(b"chunk-bytes")
+            return CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = _fake_ffmpeg
+        chunker = AudioChunker(max_bytes=1024 * 1024, max_duration_seconds=1400.0)
+        chunks = chunker.split(str(audio), work_dir=str(tmp_path / "chunks"))
+        assert len(chunks) >= 2
+        assert "-c" in mock_run.call_args[0][0]
+        assert "copy" in mock_run.call_args[0][0]

--- a/tests/unit/podcast_scraper/providers/deepgram/test_deepgram_provider.py
+++ b/tests/unit/podcast_scraper/providers/deepgram/test_deepgram_provider.py
@@ -1,0 +1,111 @@
+"""Unit tests for Deepgram transcription provider."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from podcast_scraper import config
+from podcast_scraper.providers.deepgram.deepgram_provider import (
+    DeepgramTranscriptionProvider,
+    parse_deepgram_transcript,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestParseDeepgramTranscript:
+    def test_utterances_map_to_segments(self) -> None:
+        payload = {
+            "results": {
+                "channels": [{"alternatives": [{"transcript": "hello world"}]}],
+                "utterances": [
+                    {
+                        "start": 0.0,
+                        "end": 1.2,
+                        "transcript": "hello world",
+                        "speaker": 0,
+                    }
+                ],
+            }
+        }
+        parsed = parse_deepgram_transcript(payload)
+        assert parsed["text"] == "hello world"
+        assert len(parsed["segments"]) == 1
+        assert parsed["segments"][0]["speaker"] == 0
+
+
+class TestDeepgramTranscriptionProvider:
+    def test_initialize_requires_api_key(self) -> None:
+        cfg = config.Config.model_construct(
+            rss="https://example.com/feed.xml",
+            transcription_provider="deepgram",
+            deepgram_api_key=None,
+        )
+        provider = DeepgramTranscriptionProvider(cfg)
+        with pytest.raises(ValueError, match="Deepgram API key"):
+            provider.initialize()
+
+    @patch("deepgram.DeepgramClient")
+    def test_transcribe_with_segments_maps_response(self, mock_client_cls) -> None:
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.listen.v1.media.transcribe_file.return_value = {
+            "results": {
+                "channels": [{"alternatives": [{"transcript": "episode text"}]}],
+                "utterances": [
+                    {
+                        "start": 0.5,
+                        "end": 2.0,
+                        "transcript": "episode text",
+                        "speaker": 1,
+                    }
+                ],
+            }
+        }
+
+        cfg = config.Config(
+            rss="https://example.com/feed.xml",
+            transcription_provider="deepgram",
+            deepgram_api_key="dg-test-key",
+            deepgram_model="nova-3",
+        )
+        provider = DeepgramTranscriptionProvider(cfg)
+        provider.initialize()
+
+        with (
+            patch("builtins.open", create=True) as mock_open,
+            patch(
+                "podcast_scraper.providers.deepgram.deepgram_provider.os.path.exists",
+                return_value=True,
+            ),
+        ):
+            mock_open.return_value.__enter__.return_value.read.return_value = b"audio-bytes"
+            result, elapsed = provider.transcribe_with_segments("/tmp/ep.mp3", language="en")
+
+        assert result["text"] == "episode text"
+        assert result["segments"][0]["text"] == "episode text"
+        assert elapsed >= 0
+        mock_client.listen.v1.media.transcribe_file.assert_called_once()
+        call_kwargs = mock_client.listen.v1.media.transcribe_file.call_args.kwargs
+        assert call_kwargs["model"] == "nova-3"
+        assert call_kwargs["diarize"] is True
+
+
+class TestDeepgramConfigValidation:
+    def test_missing_key_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Deepgram API key"):
+            config.Config(
+                rss="https://example.com/feed.xml",
+                transcription_provider="deepgram",
+            )
+
+    def test_with_key_accepts(self) -> None:
+        cfg = config.Config(
+            rss="https://example.com/feed.xml",
+            transcription_provider="deepgram",
+            deepgram_api_key="dg-test",
+        )
+        assert cfg.deepgram_model == "nova-3"

--- a/tests/unit/podcast_scraper/providers/deepgram/test_deepgram_provider.py
+++ b/tests/unit/podcast_scraper/providers/deepgram/test_deepgram_provider.py
@@ -36,6 +36,39 @@ class TestParseDeepgramTranscript:
         assert len(parsed["segments"]) == 1
         assert parsed["segments"][0]["speaker"] == 0
 
+    def test_words_fallback_when_no_utterances(self) -> None:
+        payload = {
+            "results": {
+                "channels": [
+                    {
+                        "alternatives": [
+                            {
+                                "transcript": "hello there",
+                                "words": [
+                                    {
+                                        "word": "hello",
+                                        "start": 0.0,
+                                        "end": 0.4,
+                                        "speaker": 0,
+                                    },
+                                    {
+                                        "word": "there",
+                                        "start": 0.5,
+                                        "end": 0.9,
+                                        "speaker": 0,
+                                    },
+                                ],
+                            }
+                        ]
+                    }
+                ],
+                "utterances": [],
+            }
+        }
+        parsed = parse_deepgram_transcript(payload)
+        assert parsed["text"] == "hello there"
+        assert len(parsed["segments"]) == 1
+
 
 class TestDeepgramTranscriptionProvider:
     def test_initialize_requires_api_key(self) -> None:
@@ -48,10 +81,10 @@ class TestDeepgramTranscriptionProvider:
         with pytest.raises(ValueError, match="Deepgram API key"):
             provider.initialize()
 
-    @patch("deepgram.DeepgramClient")
-    def test_transcribe_with_segments_maps_response(self, mock_client_cls) -> None:
+    @patch("podcast_scraper.providers.deepgram.deepgram_provider._create_deepgram_client")
+    def test_transcribe_with_segments_maps_response(self, mock_create_client) -> None:
         mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
+        mock_create_client.return_value = mock_client
         mock_client.listen.v1.media.transcribe_file.return_value = {
             "results": {
                 "channels": [{"alternatives": [{"transcript": "episode text"}]}],
@@ -92,6 +125,21 @@ class TestDeepgramTranscriptionProvider:
         call_kwargs = mock_client.listen.v1.media.transcribe_file.call_args.kwargs
         assert call_kwargs["model"] == "nova-3"
         assert call_kwargs["diarize"] is True
+        mock_create_client.assert_called_once_with("dg-test-key")
+
+    @patch(
+        "podcast_scraper.providers.deepgram.deepgram_provider._create_deepgram_client",
+        side_effect=RuntimeError("deepgram-sdk is required"),
+    )
+    def test_initialize_requires_deepgram_sdk(self, _mock_create) -> None:
+        cfg = config.Config(
+            rss="https://example.com/feed.xml",
+            transcription_provider="deepgram",
+            deepgram_api_key="dg-test-key",
+        )
+        provider = DeepgramTranscriptionProvider(cfg)
+        with pytest.raises(RuntimeError, match="deepgram-sdk is required"):
+            provider.initialize()
 
 
 class TestDeepgramConfigValidation:

--- a/tests/unit/podcast_scraper/test_cli.py
+++ b/tests/unit/podcast_scraper/test_cli.py
@@ -2023,7 +2023,10 @@ class TestAddArgumentGroups(unittest.TestCase):
             (a for a in parser._actions if a.dest == "transcription_provider"), None
         )
         self.assertIsNotNone(transcription_action)
-        self.assertEqual(transcription_action.choices, ["whisper", "openai", "gemini", "mistral"])
+        self.assertEqual(
+            transcription_action.choices,
+            ["whisper", "openai", "gemini", "mistral", "deepgram"],
+        )
         self.assertEqual(transcription_action.default, "whisper")
 
     def test_add_mistral_arguments(self):

--- a/tests/unit/podcast_scraper/test_cli.py
+++ b/tests/unit/podcast_scraper/test_cli.py
@@ -2046,6 +2046,15 @@ class TestAddArgumentGroups(unittest.TestCase):
         self.assertIn("mistral_cleaning_model", action_dests)
         self.assertIn("mistral_cleaning_temperature", action_dests)
 
+    def test_add_deepgram_arguments(self):
+        """Test that _add_deepgram_arguments adds expected arguments."""
+        parser = argparse.ArgumentParser()
+        cli._add_deepgram_arguments(parser)
+
+        action_dests = [a.dest for a in parser._actions]
+        self.assertIn("deepgram_api_key", action_dests)
+        self.assertIn("deepgram_model", action_dests)
+
     def test_add_deepseek_arguments(self):
         """Test that _add_deepseek_arguments adds expected arguments."""
         parser = argparse.ArgumentParser()

--- a/tests/unit/podcast_scraper/test_config.py
+++ b/tests/unit/podcast_scraper/test_config.py
@@ -1263,5 +1263,36 @@ class TestScreenplayApiTranscriptionCoerce562(unittest.TestCase):
         self.assertIn("PODCAST_SCRAPER_SCREENPLAY_STRICT", str(ctx.exception))
 
 
+@pytest.mark.unit
+class TestDeepgramProviderRequirements(unittest.TestCase):
+    """Deepgram transcription config validation."""
+
+    def test_deepgram_requires_api_key(self) -> None:
+        with self.assertRaises(ValidationError) as ctx:
+            Config(
+                rss="https://example.com/feed.xml",
+                transcription_provider="deepgram",
+            )
+        self.assertIn("Deepgram API key required", str(ctx.exception))
+
+    @patch.dict(os.environ, {"DEEPGRAM_API_KEY": "dg-env-key"}, clear=False)
+    def test_deepgram_accepts_env_api_key(self) -> None:
+        cfg = Config(
+            rss="https://example.com/feed.xml",
+            transcription_provider="deepgram",
+        )
+        self.assertEqual(cfg.deepgram_api_key, "dg-env-key")
+
+    def test_deepgram_fallback_requires_api_key(self) -> None:
+        with self.assertRaises(ValidationError) as ctx:
+            Config(
+                rss="https://example.com/feed.xml",
+                transcription_provider="tailnet_dgx_whisper",
+                transcription_fallback_provider="deepgram",
+                dgx_tailnet_host="dgx.example",
+            )
+        self.assertIn("transcription_fallback_provider='deepgram'", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/podcast_scraper/test_preprocessing.py
+++ b/tests/unit/podcast_scraper/test_preprocessing.py
@@ -202,6 +202,15 @@ class TestRemoveSponsorBlocks(unittest.TestCase):
         self.assertNotIn("This episode is brought to you by", result)
         self.assertIn("Content before", result)
 
+    def test_podcast_intro_not_removed(self):
+        """Phase 1: normal podcast intros must not be treated as post-ad breaks."""
+        text = (
+            "Maya: Welcome back to Singletrack Sessions. Today we discuss trails.\n"
+            "Liam: Thanks, Maya."
+        )
+        result = preprocessing.remove_sponsor_blocks(text)
+        self.assertEqual(result, text)
+
 
 class TestRemoveOutroBlocks(unittest.TestCase):
     """Test remove_outro_blocks() function."""

--- a/tests/unit/podcast_scraper/test_provider_metrics_cost.py
+++ b/tests/unit/podcast_scraper/test_provider_metrics_cost.py
@@ -47,6 +47,37 @@ def test_transcription_model_for_cfg_whisper_and_openai() -> None:
 
 
 @pytest.mark.unit
+def test_transcription_model_for_cfg_deepgram() -> None:
+    deepgram_cfg = create_test_config(
+        transcription_provider="deepgram",
+        deepgram_api_key="dg-test",
+        deepgram_model="nova-3",
+    )
+    assert transcription_model_for_cfg(deepgram_cfg) == "nova-3"
+
+
+@pytest.mark.unit
+def test_apply_estimated_cost_if_missing_deepgram() -> None:
+    cfg = create_test_config(
+        transcription_provider="deepgram",
+        deepgram_api_key="dg-test",
+        deepgram_model="nova-3",
+        pricing_assumptions_file="config/pricing_assumptions.yaml",
+    )
+    call = ProviderCallMetrics()
+    apply_estimated_cost_if_missing(
+        call,
+        cfg=cfg,
+        provider_type="deepgram",
+        capability="transcription",
+        model="nova-3",
+        audio_minutes=10.0,
+    )
+    assert call.estimated_cost is not None
+    assert call.estimated_cost == pytest.approx(0.043)
+
+
+@pytest.mark.unit
 def test_apply_estimated_cost_if_missing_no_op_when_cost_set() -> None:
     cfg = create_test_config(openai_api_key="sk-test")
     call = ProviderCallMetrics()

--- a/tests/unit/podcast_scraper/transcription/test_factory_deepgram.py
+++ b/tests/unit/podcast_scraper/transcription/test_factory_deepgram.py
@@ -1,0 +1,27 @@
+"""Transcription factory tests for Deepgram provider."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from podcast_scraper import config
+from podcast_scraper.transcription.factory import create_transcription_provider
+
+pytestmark = pytest.mark.unit
+
+
+def test_factory_creates_deepgram_provider() -> None:
+    cfg = config.Config(
+        rss="https://example.com/feed.xml",
+        transcription_provider="deepgram",
+        deepgram_api_key="dg-test",
+    )
+    with patch(
+        "podcast_scraper.providers.deepgram.deepgram_provider.DeepgramTranscriptionProvider"
+    ) as mock_cls:
+        mock_cls.return_value.initialize = lambda: None
+        provider = create_transcription_provider(cfg)
+        mock_cls.assert_called_once_with(cfg)
+        assert provider is mock_cls.return_value

--- a/tests/unit/podcast_scraper/transcription/test_transcription_provider.py
+++ b/tests/unit/podcast_scraper/transcription/test_transcription_provider.py
@@ -153,8 +153,7 @@ class TestMLProviderTranscription(unittest.TestCase):
             self.assertFalse(provider._whisper_initialized)
 
     @patch("podcast_scraper.providers.ml.ml_provider._import_third_party_whisper")
-    @patch("podcast_scraper.providers.ml.ml_provider.progress.progress_context")
-    def test_provider_transcribe(self, mock_progress, mock_import_whisper):
+    def test_provider_transcribe(self, mock_import_whisper):
         """Test that transcribe() calls internal transcription method via factory."""
         cfg = config.Config(
             rss_url=self.cfg.rss_url,
@@ -170,7 +169,6 @@ class TestMLProviderTranscription(unittest.TestCase):
         mock_whisper_lib = Mock()
         mock_whisper_lib.load_model.return_value = mock_model
         mock_import_whisper.return_value = mock_whisper_lib
-        mock_progress.return_value.__enter__.return_value = None
 
         provider = create_transcription_provider(cfg)
         provider.initialize()
@@ -198,8 +196,7 @@ class TestMLProviderTranscription(unittest.TestCase):
         self.assertEqual(context.exception.provider, "MLProvider/Whisper")
 
     @patch("podcast_scraper.providers.ml.ml_provider._import_third_party_whisper")
-    @patch("podcast_scraper.providers.ml.ml_provider.progress.progress_context")
-    def test_provider_transcribe_empty_text(self, mock_progress, mock_import_whisper):
+    def test_provider_transcribe_empty_text(self, mock_import_whisper):
         """Test that transcribe() raises ValueError if transcription returns empty text."""
         cfg = config.Config(
             rss_url=self.cfg.rss_url,
@@ -215,7 +212,6 @@ class TestMLProviderTranscription(unittest.TestCase):
         mock_whisper_lib = Mock()
         mock_whisper_lib.load_model.return_value = mock_model
         mock_import_whisper.return_value = mock_whisper_lib
-        mock_progress.return_value.__enter__.return_value = None
 
         provider = create_transcription_provider(cfg)
         provider.initialize()

--- a/tests/unit/podcast_scraper/utils/test_progress.py
+++ b/tests/unit/podcast_scraper/utils/test_progress.py
@@ -8,7 +8,7 @@ progress indicators for long-running operations.
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # Allow importing the package when tests run from within the package directory.
 PACKAGE_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -191,6 +191,24 @@ class TestProgressContext(unittest.TestCase):
         mock_reporter.update.assert_any_call(10)
         mock_reporter.update.assert_any_call(20)
         mock_reporter.update.assert_any_call(30)
+
+
+class TestWhisperTranscriptionProgress(unittest.TestCase):
+    """Whisper per-episode transcription must not open a nested progress bar."""
+
+    @patch("podcast_scraper.utils.progress.progress_context")
+    def test_transcribe_with_whisper_uses_batch_bar_only(self, mock_progress_context):
+        from podcast_scraper.providers.ml.ml_provider import MLProvider
+
+        provider = MLProvider.__new__(MLProvider)
+        provider.cfg = MagicMock(whisper_model="tiny")
+        provider._whisper_model = MagicMock()
+        provider._whisper_model.transcribe.return_value = {"text": "hello", "segments": []}
+
+        result, _elapsed = MLProvider._transcribe_with_whisper(provider, "/tmp/x.mp3", "en")
+
+        mock_progress_context.assert_not_called()
+        self.assertEqual(result["text"], "hello")
 
 
 class TestProgressBackwardsCompatibility(unittest.TestCase):

--- a/tests/unit/podcast_scraper/workflow/test_episode_processor.py
+++ b/tests/unit/podcast_scraper/workflow/test_episode_processor.py
@@ -1235,6 +1235,7 @@ class TestTranscribeMediaToText(unittest.TestCase):
             if os.path.exists(temp_media):
                 os.unlink(temp_media)
 
+    @patch("podcast_scraper.workflow.episode_processor._transcribe_with_segments_maybe_chunked")
     @patch("podcast_scraper.workflow.episode_processor._preprocess_audio_if_needed")
     @patch("podcast_scraper.workflow.episode_processor._check_transcript_cache", return_value=None)
     @patch(
@@ -1245,7 +1246,7 @@ class TestTranscribeMediaToText(unittest.TestCase):
     @patch("os.path.exists")
     @patch("os.path.getsize")
     @patch("podcast_scraper.workflow.episode_processor._cleanup_temp_media")
-    def test_transcribe_media_to_text_preprocessed_oversize_skips_before_provider(
+    def test_transcribe_media_to_text_preprocessed_oversize_uses_chunking(
         self,
         mock_cleanup,
         mock_getsize,
@@ -1254,8 +1255,9 @@ class TestTranscribeMediaToText(unittest.TestCase):
         mock_reuse,
         mock_cache,
         mock_preprocess,
+        mock_chunked_transcribe,
     ):
-        """GitHub #557: post-preprocess stat over API cap skips before transcribe_with_segments."""
+        """GitHub #286: post-preprocess oversize routes through chunked transcription."""
         import tempfile
 
         from podcast_scraper.rss.downloader import OPENAI_MAX_FILE_SIZE_BYTES
@@ -1286,6 +1288,10 @@ class TestTranscribeMediaToText(unittest.TestCase):
                 )
                 mock_build_path.return_value = os.path.join(out_dir, "0001 - Episode_1.txt")
                 mock_preprocess.return_value = ghost_pre
+                mock_chunked_transcribe.return_value = (
+                    {"text": "chunked transcript", "segments": []},
+                    2.0,
+                )
 
                 def _exists(path: str) -> bool:
                     return path in (temp_media, ghost_pre)
@@ -1308,25 +1314,31 @@ class TestTranscribeMediaToText(unittest.TestCase):
                 eid, enum = get_episode_id_from_episode(job.episode, cfg.rss_url or "")
                 pipeline_metrics.get_or_create_episode_status(eid, enum or job.idx)
 
-                success, transcript_path, _bd = episode_processor.transcribe_media_to_text(
-                    job=job,
-                    cfg=cfg,
-                    whisper_model=None,
-                    run_suffix=None,
-                    effective_output_dir=out_dir,
-                    transcription_provider=mock_provider,
-                    pipeline_metrics=pipeline_metrics,
-                )
+                with (
+                    patch(
+                        "podcast_scraper.workflow.episode_processor._format_transcript_if_needed",
+                        return_value="chunked transcript",
+                    ),
+                    patch(
+                        "podcast_scraper.workflow.episode_processor._save_transcript_file",
+                        return_value="0001 - Episode_1.txt",
+                    ),
+                ):
+                    success, transcript_path, _bd = episode_processor.transcribe_media_to_text(
+                        job=job,
+                        cfg=cfg,
+                        whisper_model=None,
+                        run_suffix=None,
+                        effective_output_dir=out_dir,
+                        transcription_provider=mock_provider,
+                        pipeline_metrics=pipeline_metrics,
+                    )
 
-                self.assertFalse(success)
-                self.assertIsNone(transcript_path)
+                self.assertTrue(success)
+                self.assertEqual(transcript_path, "0001 - Episode_1.txt")
+                mock_chunked_transcribe.assert_called_once()
                 mock_provider.transcribe_with_segments.assert_not_called()
-                self.assertEqual(pipeline_metrics.episodes_skipped_total, 1)
-                lines = Path(incident_path).read_text(encoding="utf-8").strip().splitlines()
-                self.assertEqual(len(lines), 1)
-                row = json.loads(lines[0])
-                self.assertEqual(row["category"], "policy")
-                self.assertEqual(row["exception_type"], "PolicySkip")
+                self.assertEqual(pipeline_metrics.episodes_skipped_total, 0)
         finally:
             if os.path.exists(temp_media):
                 os.unlink(temp_media)

--- a/tests/unit/podcast_scraper/workflow/test_episode_processor.py
+++ b/tests/unit/podcast_scraper/workflow/test_episode_processor.py
@@ -1108,7 +1108,7 @@ class TestTranscribeMediaToText(unittest.TestCase):
     def test_transcribe_media_to_text_oversized_file_skipped(
         self, mock_cleanup, mock_getsize, mock_exists, mock_build_path
     ):
-        """Test that oversized audio files are skipped gracefully with warning."""
+        """Provider rejects raw oversize file when preprocessing/chunking do not apply."""
         import tempfile
 
         job = Mock()


### PR DESCRIPTION
## Summary

Wave 1 audio/transcription batch in five commits (one issue each):

- **#269** — Modularize `speaker_detection` into `speaker_detectors/*` with a thin re-export wrapper
- **#286** — `AudioChunker` for oversized API transcription files (ffmpeg stream-copy + merge)
- **#486** — `CommercialDetector` Phase 1 (patterns + positional heuristics); delegates `remove_sponsor_blocks`
- **#19** — Remove nested Whisper `"Transcribing"` progress bar (batch bar remains sole indicator)
- **#597** — Deepgram Nova-3 provider (`deepgram-sdk` in `[llm]` extra), config/factory/CLI wiring

## Parallel work (other worktrees)

Not in this PR: **#594** (autoresearch), **#109** + **#111** (fixtures).

## Wave 2 note

Diarization-aware commercial cleaning proof is blocked on **#111** fixture merge.

## Test plan

- [x] `make ci-fast` — `MAKE_EXIT=0` locally
- [ ] Operator: one real episode with `DEEPGRAM_API_KEY` if available (optional pre-merge)


Made with [Cursor](https://cursor.com)