### PR TITLE
Search retrieval prerequisites + entity quality (resolver, cross-layer graph, same/cross-episode dedup)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,19 @@ operator repeatedly. Adherence beats every other rule.
     fine when the user asked for that fix; adding a **new** name is not. If the
     task seems to need one, stop and ask — do not add it "to unblock" the PR.
 
+14. **Read the design intent before reasoning about a subsystem — not just the
+    code.** Before extending, judging, or building on an existing capability (a
+    layer, builder, pipeline, artifact), find and read its governing `RFC-*` /
+    `ADR-*` / `PRD-*` first — especially the **Non-Goals / "what it does NOT do"
+    / boundary** sections — before inferring behavior from the implementation.
+    Code shows what runs; the spec shows what it was *meant* to do and
+    deliberately does not. When the work spans layers, read each layer's spec
+    (and the cross-layer doc) so you know which layer owns the concern. Failure
+    mode of record (2026-05-30): assumed the cross-layer `bridge` deduplicated
+    entities because `bridge_builder` exposed a `fuzzy_reconcile`; RFC-072 states
+    plainly "the bridge is the seam, not a merge" — that wrong mental model
+    derailed a plan before the design doc was read.
+
 ---
 
 ## User intent beats procedural defaults

--- a/docs/prd/PRD-031-search.md
+++ b/docs/prd/PRD-031-search.md
@@ -1,0 +1,296 @@
+# PRD-031: Search
+
+- **Status**: Draft
+- **Author**: Marko
+- **Created**: 2026-05-24
+- **Target**: v2.7 (retrieval foundation) + Media Alpha (full Search UI)
+- **Related PRDs**:
+  - `docs/prd/PRD-032-hybrid-corpus-search.md` — backend capability
+  - `docs/prd/PRD-033-search-powered-surfaces.md` — surface propagation
+  - `docs/prd/PRD-021-semantic-corpus-search.md` — predecessor (FAISS semantic search)
+  - `docs/prd/PRD-028-position-tracker.md` — position evolution data (temporal intent)
+- **Related RFCs**:
+  - `docs/rfc/RFC-090-hybrid-retrieval.md` — hybrid retrieval pipeline
+  - `docs/rfc/RFC-072-canonical-identity-layer-cross-layer-bridge.md` — canonical identity
+- **Related issues**: #849 (Search retrieval prerequisites), #466 (GI/KG depth roadmap — CLOSED, superseded), #484 (Semantic Corpus Search — predecessor), #671 (Search/Explore filter UX, CLOSED), #672 (right rail entity views, CLOSED), #674 (cross-surface flows, CLOSED)
+
+> **Stabilization note (2026-05-30):** This doc was rebased from an earlier draft (PRD-029)
+> authored against a different doc-numbering universe. Numbers, titles, and module paths
+> have been corrected to this repo. Forward-references to capabilities that do not yet
+> exist here (an MCP tool layer; a corpus-impact / coverage surface; typed contradiction
+> KG edges) are marked **[TBD — not yet specified]** rather than linked to a number.
+
+---
+
+## Summary
+
+Search in the viewer today is a single-signal FAISS vector lookup over Grounded Insight Layer
+(GIL) insight nodes (see `docs/prd/PRD-021-semantic-corpus-search.md`, shipped). It answers
+"what is similar to this query" — but not "who said what, across which shows, and how does it
+relate to everything else in the corpus." **Search** is the first version of search that
+earns the name: multi-signal (BM25 + vector + KG proximity), intent-aware, corpus-oriented,
+provenance-grounded, and structured for how humans actually ask questions about media. It is the
+product layer over the retrieval backend specified in RFC-090 and PRD-032.
+
+## Background & Context
+
+- **What problem this solves.** Users don't experience current search as a search engine — they
+  experience it as autocomplete with extra steps. It surfaces one signal (semantic similarity),
+  ignores named entities, ignores show boundaries, ignores time, ignores contradiction, and dumps
+  results with no structure. Speaker names are plain text; there is no provenance, no synthesis,
+  and no way to orient to the corpus before diving in.
+- **Why now.** PRD-021 / RFC-061 delivered semantic corpus search (FAISS over insights). The
+  GI/KG depth roadmap (#466) explicitly calls for moving beyond shallow single-signal retrieval —
+  named-entity recall, relational context, corpus-level behavior. Search is the product
+  framing of that next step.
+- **How it relates to existing features.** Search consumes the hybrid retrieval backend
+  (RFC-090 plus the additive signals in RFC-091/092/093) and the canonical identity layer
+  (RFC-072). It is complementary to the Graph surface, not a replacement.
+
+## Goals
+
+- Deliver meaningful search-quality improvement through hybrid retrieval (BM25 + vector + KG
+  proximity).
+- Make search results navigable into the full knowledge graph — not a dead end.
+- Surface corpus context before and alongside results (scope, coverage, contradictions).
+- Support four distinct query intents with appropriate result presentation for each.
+- Lay the Search surface foundation that later enrichers can build on.
+
+## Non-Goals
+
+- Full AI synthesis over results (that is the autoresearch loop — Search is retrieval +
+  structure, not generation).
+- Real-time ingestion (corpus is batch-indexed; Search operates on committed corpus state).
+- Public-facing search (this is the viewer for beta users, not an embeddable widget).
+- Replacing the Graph surface — Search and Graph are complementary, not competing.
+
+## Personas
+
+- **Beta researcher**: Power user exploring the corpus for media-intelligence work.
+  - Needs to find specific people, quotes, and cross-show positions quickly.
+  - Search gives named-entity recall, provenance, and graph navigation from results.
+- **Operator (you)**: Owns corpus quality and coverage.
+  - Needs to understand what the corpus covers densely vs sparsely.
+  - The corpus scope bar and coverage intent surface this at query time.
+- **Agent (future)**: Autoresearch / MCP consumer issuing programmatic queries.
+  - Needs shaped, intent-aware results rather than raw lists.
+  - Served by the briefing-pack tool specified in RFC-093 **[TBD — MCP tool layer not yet built]**.
+
+## User Stories
+
+- _As a beta researcher, I can search "Sam Altman" and find every place his name appears across
+  shows — not just things "about OpenAI" — so that exact named-entity queries work._
+- _As a beta researcher, I can see "this query spans 6 shows, 34 episodes, 12 speakers" before
+  reading results, so that I understand the size and shape of what's out there._
+- _As a beta researcher, I can click a speaker name in a result to open that person's entity view,
+  so that a result is a graph entry point, not a dead end._
+- _As a beta researcher, I can see upfront that a topic has conflicting positions across shows, so
+  that I know to look at the contradiction breakdown before reading individual quotes._
+- _As a beta researcher, I can compare how two shows cover a topic side by side, so that I get
+  cross-show synthesis instead of an interleaved ranked list._
+- _As a beta researcher, I can ask how a topic's coverage changed over time and see an arc, so that
+  temporal queries track position evolution, not just similarity._
+
+## Functional Requirements
+
+### FR1: Query Intent Routing
+
+Search routes each query to one of four intents. Routing is automatic (no user
+configuration) but the detected intent is surfaced lightly so users understand the result
+structure they see.
+
+- **FR1.1**: Detect intent across four types — `entity_lookup`, `cross_show_synthesis`,
+  `temporal_tracking`, `corpus_coverage` — using the rules-based router in RFC-090 §3.6.
+- **FR1.2**: Default to hybrid retrieval for unclassified queries.
+- **FR1.3**: Surface the detected intent in the UI ("Searching as: entity lookup") with an
+  optional manual override.
+- **FR1.4**: Intent routing is rules-based in v2.7; ML-upgradable per RFC-092 (no UI change).
+
+| Intent | Trigger signals | Result presentation |
+|--------|----------------|---------------------|
+| `entity_lookup` | Person name, show name, specific term | Entity card header + insight list below |
+| `cross_show_synthesis` | Comparative language, multiple show refs, "vs", "across" | Grouped by show + synthesis header |
+| `temporal_tracking` | Date references, "over time", "evolution", "changed" | Timeline view + date-ordered results |
+| `corpus_coverage` | "how much", "which shows", "covered" | Coverage map, not result list |
+
+### FR2: Query Bar
+
+- **FR2.1**: Single full-width text input, prominent.
+- **FR2.2**: Query-intent badge below the input (auto-detected, lightly displayed, overridable).
+
+### FR3: Corpus Scope Bar
+
+- **FR3.1**: Compact indicator immediately below the query bar, before results, showing coverage
+  of the current result set: shows · episodes · speakers · date range.
+- **FR3.2**: Updates on each search; active filters reduce the counts in real time.
+- **FR3.3**: Links to a full coverage map for `corpus_coverage` intent queries. _(The richer
+  coverage/"impact" visualization is **[TBD — corpus-impact surface not yet specified]**;
+  v2.7 ships basic counts only.)_
+
+```text
+Searching across: 6 shows  ·  34 episodes  ·  12 speakers  ·  Date range: Jan 2023 – Mar 2026
+```
+
+### FR4: Filter Chip Bar
+
+- **FR4.1**: Unified filter chip bar per issue #671 (CLOSED). Chips: Show, Person, Date Range,
+  Content Type.
+- **FR4.2**: Applied chips shown inline; active filters reduce the corpus scope bar numbers.
+
+### FR5: Result Cards (Grounded Insight Cards)
+
+Each result card is a grounded insight card, not a text snippet.
+
+- **FR5.1**: Show name, episode title, date — all clickable, navigate to show/episode.
+- **FR5.2**: Exact grounding quote (the evidence, not a summary).
+- **FR5.3**: Speaker name clickable → Person Entity View in right rail (#672, CLOSED).
+- **FR5.4**: Topic tag clickable → Topic Entity View in right rail (#672, CLOSED).
+- **FR5.5**: Confidence indicator (enricher confidence score; subtle).
+- **FR5.6**: Contradiction badge when the insight is in a detected contradiction cluster.
+  _Depends on typed contradiction KG edges, which **do not exist yet** (see RFC-091 open
+  questions); until then this badge is hidden / degrades gracefully._
+
+```text
+┌─────────────────────────────────────────────────────────┐
+│  [Show name] · [Episode title] · [Date]                 │
+│                                                          │
+│  "[Exact quote supporting this insight]"                 │
+│                                                          │
+│  ── [Speaker name ↗] ── [Topic tag] ── [Confidence] ──   │
+│                                          ⚡ Contradiction │
+└─────────────────────────────────────────────────────────┘
+```
+
+### FR6: Result Presentation by Intent
+
+- **FR6.1 `entity_lookup`**: Entity card header (Person Landing or Topic Entity View, #672) with
+  canonical identity, key positions, coverage summary; insight list below, filtered to the entity.
+- **FR6.2 `cross_show_synthesis`**: Results grouped by show; each group header shows the show's
+  dominant coverage angle. Synthesis panel above: "N shows covered this topic — A: pro / B:
+  skeptical / C: neutral." _(Synthesis derivation source is an open question — see below.)_
+- **FR6.3 `temporal_tracking`**: Results ordered by episode date ascending with a lightweight
+  timeline (dots sized by insight count per episode).
+- **FR6.4 `corpus_coverage`**: No result list — a coverage table (shows × time periods, cells =
+  episode count). This is the Explore surface bleeding into Search for coverage queries.
+
+### FR7: Right Rail (Search Context)
+
+- **FR7.1**: Clicking a speaker or topic from a result opens Person Landing / Topic Entity View
+  (#672) in the right rail. Search is the primary entry point for these panels.
+- **FR7.2**: Right rail persists across result scrolling (#673, CLOSED); clicking a different
+  speaker updates it without closing.
+
+## Success Metrics
+
+**Retrieval quality (internal eval loop):**
+
+- Named-entity recall: >85% (entity appears in top-5 when queried by exact name).
+- Hybrid vs vector-only nDCG@10: >10% improvement on the test query set.
+- Cross-show query diversity: ≥2 distinct shows in top-5 for cross-show queries.
+
+**User behavior (beta):**
+
+- Right-rail activation rate from Search results: >30% of sessions (navigability).
+- Contradiction badge click-through: any non-zero rate (value of surfacing).
+- Query refinement rate: <40% (high refinement ⇒ intent routing is wrong).
+
+**Qualitative (beta feedback):**
+
+- Can users find a specific person's statements without knowing the episode?
+- Do users understand what they're searching across before reading results?
+- Do cross-show queries feel meaningfully different from single-show results?
+
+## Dependencies
+
+- **RFC-090** Hybrid Retrieval Pipeline (LanceDB + RRF) — **Hard** — Draft.
+- **RFC-072** Canonical Identity — **Hard** — **Partial**: slug-based IDs exist
+  (`src/podcast_scraper/identity/slugify.py`); the freeform-text → canonical-ID **entity
+  resolver this PRD assumes does not exist yet** (tracked in #849).
+- **Issue #672** Person Landing + Topic Entity View — **Hard** — issue CLOSED; panels specified,
+  build state to confirm.
+- **Issue #671** Filter chip bar — **Soft** — CLOSED.
+- **Issue #673** Right rail persistence — **Soft** — CLOSED.
+- **RFC-088** Enrichment Layer Architecture (contradiction signals) — **Soft** — contradiction
+  badge degrades gracefully; typed contradiction edges are **not yet built**.
+- **MCP tool layer** — **[TBD — not yet specified]** — required only for the agent-facing
+  briefing pack (RFC-093), not for the viewer.
+
+## Constraints & Assumptions
+
+**Constraints:**
+
+- Operates on committed (batch-indexed) corpus state; no real-time indexing.
+- Local-first: retrieval and embedding run on the operator's machine (Apple M-series), no cloud
+  dependency required for core search.
+
+**Assumptions:**
+
+- GIL insight nodes carry grounding quotes with timestamps (`timestamp_start_ms` /
+  `timestamp_end_ms` on `SupportingQuote`) — verified in `src/podcast_scraper/gi/contracts.py`,
+  which makes segment↔insight linking feasible.
+- Embedding model is `sentence-transformers/all-MiniLM-L6-v2` (384-dim), per the current FAISS
+  index.
+
+## Design Considerations
+
+### Intent routing: rules-based now, ML later
+
+- **Option A — Rules-based router (v2.7)**: Deterministic keyword/regex routing (RFC-090 §3.6).
+  - **Pros**: Ships immediately; no training data needed; transparent.
+  - **Cons**: Misclassifies ambiguous/novel phrasings.
+- **Option B — ML classifier (later)**: Fine-tuned classifier (RFC-092).
+  - **Pros**: Robust; improves with query data.
+  - **Cons**: Needs ≥500 labeled queries from the eval loop first.
+  - **Decision**: Ship A now; B is config-switchable once data exists. Misrouting degrades to
+    sub-optimal weights, not wrong results — RRF is robust to weight perturbation.
+
+## Open Questions
+
+1. **Intent routing override.** Allow manual intent selection? Leaning yes, optional — auto-detect
+   default, dropdown to override.
+2. **Synthesis panel generation.** Is the cross-show synthesis header derived at index time
+   (preferred — no per-query LLM calls) or query time? Needs enricher output structured enough for
+   index-time derivation (RFC-088).
+3. **Contradiction edge availability.** The contradiction badge depends on typed contradiction KG
+   edges, which **do not exist yet**. Define the fallback (enrichment-time metadata scan) explicitly.
+4. **Search vs Explore boundary.** `corpus_coverage` intent overlaps the Explore surface. Likely
+   converging; for now treat as separate surfaces with a navigation link.
+
+## Related Work
+
+- PRD-032: `docs/prd/PRD-032-hybrid-corpus-search.md` — backend capability.
+- PRD-033: `docs/prd/PRD-033-search-powered-surfaces.md` — cross-surface propagation.
+- PRD-021: `docs/prd/PRD-021-semantic-corpus-search.md` — predecessor.
+- PRD-026: `docs/prd/PRD-026-topic-entity-view.md` — Topic Entity View panel.
+- PRD-029: `docs/prd/PRD-029-person-profile.md` — Person profile content.
+- RFC-090/091/092/093 — the retrieval backend and additive signals.
+- Issue #849: Search retrieval prerequisites (survivors of #466).
+- Issue #466: GI + KG depth roadmap (CLOSED, superseded).
+- Issues #671, #672, #673, #674 (all CLOSED).
+
+## Release Checklist
+
+**v2.7 (retrieval foundation):**
+
+- [ ] RFC-090 LanceDB backend + RRF fusion layer
+- [ ] Query intent router (rules-based)
+- [ ] Corpus scope bar (basic counts)
+- [ ] Hybrid result cards with full provenance
+- [ ] Speaker/topic names as clickable links (#672 prerequisites confirmed)
+- [ ] Filter chip bar (#671)
+
+**Media Alpha (full Search):**
+
+- [ ] Cross-show synthesis grouping
+- [ ] Temporal timeline view
+- [ ] Contradiction badge (requires typed KG contradiction edges — prerequisite RFC/issue)
+- [ ] Right rail integration with persistence (#672 + #673)
+- [ ] Corpus coverage intent → coverage map view
+- [ ] Entity card header for `entity_lookup` intent
+
+**V3:**
+
+- [ ] ML query intent classifier (RFC-092)
+- [ ] Saved searches
+- [ ] Search result export (research bundle)
+- [ ] Search as MCP tool endpoint (agents call Search directly — requires MCP layer)

--- a/docs/prd/PRD-032-hybrid-corpus-search.md
+++ b/docs/prd/PRD-032-hybrid-corpus-search.md
@@ -1,0 +1,239 @@
+# PRD-032: Hybrid Corpus Search
+
+- **Status**: Draft
+- **Author**: Marko
+- **Created**: 2026-05-24
+- **Target**: v2.7
+- **Related PRDs**:
+  - `docs/prd/PRD-031-search.md` — product surface that consumes this backend
+  - `docs/prd/PRD-033-search-powered-surfaces.md` — cross-surface propagation
+  - `docs/prd/PRD-021-semantic-corpus-search.md` — predecessor (FAISS semantic search)
+  - `docs/prd/PRD-028-position-tracker.md` — position evolution data (temporal queries)
+- **Related RFCs**:
+  - `docs/rfc/RFC-090-hybrid-retrieval.md` — two-tier index + BM25 + vector + RRF (implements core)
+  - `docs/rfc/RFC-091-kg-proximity-signal.md` — KG proximity signal
+  - `docs/rfc/RFC-092-ml-query-router.md` — ML query router
+  - `docs/rfc/RFC-093-litm-context-packs.md` — LITM-aware context packs
+  - `docs/rfc/RFC-072-canonical-identity-layer-cross-layer-bridge.md` — canonical identity
+  - `docs/rfc/RFC-088-enrichment-layer-architecture.md` — enrichment layer
+- **Related issues**: #849 (Search retrieval prerequisites), #466 (GI/KG depth roadmap — CLOSED, superseded), #484 (Semantic Corpus Search — CLOSED, predecessor), #485 (Topic nodes + ABOUT edges — CLOSED)
+
+> **Stabilization note (2026-05-30):** Rebased to this repo. The original draft pointed at an
+> MCP-integration RFC and "Position Tracker"/"Guest Intelligence Brief" PRDs that do not exist
+> under those numbers here. Corrected: enrichment → RFC-088; Position Tracker → PRD-028; the
+> MCP tool layer and a guest-briefing PRD are **[TBD — not yet specified]**. Module paths are
+> corrected to `src/podcast_scraper/…`.
+
+---
+
+## Summary
+
+Podcast Scraper's search today is single-signal FAISS vector retrieval over GIL insight nodes only
+(`src/podcast_scraper/search/`, shipped via #484). This misses raw transcript evidence, fails on
+named-entity queries, ignores KG relational structure, and gives agents unstructured result dumps.
+This PRD covers the evolution to **hybrid corpus search**: a two-tier index (transcript segments +
+GIL insights) with three retrieval signals (BM25 + dense vector + KG proximity), intent-aware
+query routing, mixed-tier result ranking, and LITM-aware agent context packs. It is implemented by
+RFC-090 (core) and the additive RFC-091/092/093.
+
+## Background & Context
+
+- **What problem this solves.** Single-signal vector search over insights answers similarity but
+  not exact-match, relational, or raw-evidence questions. The corpus has structure (typed entities,
+  topics, shows, time) that retrieval ignores.
+- **Why now.** Semantic corpus search (#484, PRD-021/RFC-061) shipped and exposed its own ceiling:
+  named-entity queries degrade, transcript-level evidence is unreachable, and the KG contributes
+  nothing to ranking. The GI/KG depth roadmap (#466) names exactly these gaps.
+- **How it relates to existing features.** Builds on the existing FAISS pipeline, the GIL insight
+  contracts (`src/podcast_scraper/gi/contracts.py`), the KG artifacts (`*.kg.json`), and the
+  canonical identity layer (RFC-072). It is the backend for the Search product (PRD-031).
+
+## Goals
+
+- **Two-tier retrieval.** Transcript segments and GIL insights are both indexed and retrievable;
+  results are mixed by score, not grouped by tier.
+- **Named-entity recall.** Searches for person names, show names, and specific terminology return
+  directly relevant results, not just semantic neighbours.
+- **Graph-aware ranking.** KG proximity is a third retrieval signal (RFC-091). Topically connected,
+  centrally-positioned content ranks higher for relevant queries.
+- **Intent-aware routing.** Query intent is classified and retrieval strategy adjusted: person
+  lookup, synthesis, raw evidence, and temporal queries each get the right signal/tier mix.
+- **Clean backend abstraction.** A `SearchBackend` protocol makes the backend swappable; LanceDB
+  embedded is the initial implementation. Cloud backends require no retrieval-logic changes.
+- **Agent-ready context packs.** MCP search tools return LITM-aware, compressed, grounded context,
+  not raw lists (RFC-093).
+
+## Non-Goals
+
+- Real-time / sub-second indexing of new episodes.
+- Cross-language search (corpus is English-only).
+- User-facing faceted search UI (filter chips are existing UX work; this PRD provides the backend
+  filter mechanism).
+- Search personalisation (no auth layer yet).
+- Cross-encoder reranking (deferred, post-RRF baseline).
+- Cloud search backends (turbopuffer, Qdrant Cloud) — supported by the abstraction, not implemented.
+
+## Personas
+
+- **Beta researcher**: Wants exact quotes, named-entity hits, and cross-show breadth — not just
+  similar snippets.
+- **Autoresearch / agent consumer**: Issues typed queries and needs shaped, tier-weighted results
+  without specifying signal weights manually. _(Autoresearch is today an eval/prompt-tuning harness
+  — `autoresearch/` — and is not yet a live search consumer; this is the integration target.)_
+- **Operator (you)**: Tunes retrieval quality via the eval loop and owns the backend choice.
+
+## User Stories
+
+- _As a beta researcher, I can search a specific phrase or quote and find the transcript segment
+  containing it, so that raw evidence is reachable even when no insight was extracted from it._
+- _As a beta researcher, I can search a person's name and get results containing their name
+  directly, so that named-entity queries don't degrade to topical neighbours._
+- _As a beta researcher, I can ask a cross-show question and see results from multiple shows
+  weighted by breadth, so that synthesis queries surface diversity._
+- _As an agent via MCP, I can receive a shaped context pack — grounded insights first, supporting
+  segments middle, caveats last, within a token budget — so that I extract more value per token._
+- _As the autoresearch loop, I can issue typed queries and receive tier-weighted results
+  appropriate to my intent without specifying signal weights manually._
+
+## Functional Requirements
+
+### FR1: Two-Tier Index
+
+- **FR1.1 Segment tier (Tier 1)**: Transcript chunks, 200–300 words, 50-word overlap over Whisper
+  output segments. Indexed fields: chunk text (BM25 + vector), `show_id`, `episode_id`,
+  `speaker_id` (if diarized), `start_time`, `end_time`, `linked_insight_ids`. Catches exact
+  phrases, terminology, raw evidence, content that did not surface as an insight.
+- **FR1.2 Insight tier (Tier 2)**: GIL insight nodes. Indexed fields: insight text (BM25 + vector),
+  `show_id`, `episode_id`, `speaker_id`, `entity_type`, `confidence`, `derived`,
+  `source_segment_id`. Catches distilled claims and positions.
+- **FR1.3**: A chunker already exists at `src/podcast_scraper/search/chunker.py` (used by
+  `indexer.py`); RFC-090 extends rather than recreates it.
+
+### FR2: Mixed Ranking (RRF)
+
+- **FR2.1**: Both tiers searched in parallel; results merged via RRF into a single ranked list.
+- **FR2.2**: `source_tier: "segment" | "insight"` is a payload field on every result — the score
+  decides order, not the tier.
+- **FR2.3**: Default RRF tier weights — insights 1.2, segments 1.0. Query router overrides per
+  intent (e.g. raw-evidence → segments 1.3, insights 0.9).
+
+### FR3: Deduplication (Compound Results)
+
+- **FR3.1**: When a segment result and an insight result refer to the same underlying content
+  (segment contains the insight's grounding quote), merge into a single **compound result** at the
+  retrieval layer, carrying both the raw segment and the synthesized insight.
+- **FR3.2**: Compound result takes the higher of the two scores; the consumer receives one object.
+
+### FR4: Intent-Aware Routing
+
+- **FR4.1**: Classify query intent (rules-based in RFC-090; ML in RFC-092) and adjust signal/tier
+  weights accordingly.
+- **FR4.2**: Misclassification degrades to sub-optimal weights, not wrong results (RRF is robust).
+
+### FR5: Backend Abstraction
+
+- **FR5.1**: A `SearchBackend` protocol decouples signal generation from fusion (RFC-090 §3.2).
+- **FR5.2**: LanceDB embedded is the initial backend; swapping backends costs zero changes outside
+  `config/search.yaml`.
+
+### FR6: Agent Context Packs
+
+- **FR6.1**: MCP search tools return LITM-aware, token-budgeted context packs (RFC-093).
+  _Requires an MCP tool layer, which **does not exist yet** — **[TBD]**._
+
+## Success Metrics
+
+| Metric | Target |
+| --- | --- |
+| Named-entity recall@10 | ≥ 90% top-10 contains exact-match result for queried person/show |
+| nDCG@10 vs FAISS baseline | Statistically significant improvement on held-out query set |
+| Segment-only result rate | > 20% of top-10 are segment-tier (validates two-tier value) |
+| Cross-show diversity (synthesis queries) | ≥ 3 distinct shows in top-10 |
+| Compound-result dedup rate | Measurable — confirms segment↔insight linking works |
+| Backend swap cost | Zero changes outside `config/search.yaml` |
+
+## Dependencies
+
+- **RFC-090** Hybrid Retrieval Pipeline — **Hard** — Draft.
+- **RFC-091/092/093** — **Soft/additive** — Draft; the KG and MCP features depend on prerequisites
+  below.
+- **RFC-072** Canonical Identity — **Hard for KG proximity** — **Partial**: only
+  `identity/slugify.py` exists; no entity resolver yet.
+- **GIL contracts** — **Hard** — shipped; grounding quotes carry `timestamp_start_ms` /
+  `timestamp_end_ms`, enabling segment↔insight linking.
+- **Prerequisites not yet built** (tracked in #849): file-local entity resolver; in-memory
+  KnowledgeGraph access layer (`neighbors()`/`get_node()`); typed KG edges beyond the current
+  `MENTIONS`/`RELATED_TO` (note: `ABOUT` edges + Topic nodes already exist via #485); MCP tool layer.
+
+## Constraints & Assumptions
+
+**Constraints:**
+
+- Embedded, local-first backend (LanceDB) on the operator's machine; no cloud dependency.
+- English-only corpus.
+
+**Assumptions:**
+
+- Whisper output segments (`{text, start, end, speaker_id?}`) are available to the chunker. Today
+  segments are passed into GI/KG builders as optional sidecar data
+  (`src/podcast_scraper/gi/pipeline.py`), not retained as a first-class artifact — RFC-090 OQ-5
+  covers diarization integration.
+- Embedding model `all-MiniLM-L6-v2` (384-dim); validate dimensionality on migration.
+
+## Design Considerations
+
+Decisions carried from draft review (now resolved):
+
+- **Dedup strategy**: Compound result at the retrieval layer; consumer receives one object with
+  both segment and insight.
+- **Result presentation**: Uniform ranking by score; `source_tier` as a payload field; no forced
+  grouping.
+- **Default tier weights**: Insight 1.2, segment 1.0; query router overrides per intent.
+- **Segment granularity**: 200–300 words, 50-word overlap over Whisper output.
+- **Segment–insight linking**: `linked_insight_ids` on the segment doc; `source_segment_id` on the
+  insight doc.
+
+## Open Questions
+
+Risks and their mitigations (tracked as open until validated):
+
+1. **Segment index size.** ~700 episodes × ~200 chunks ≈ ~140k segment docs vs ~15k insights.
+   LanceDB handles this at embedded scale — validate before assuming.
+2. **LanceDB FTS rebuild on upserts.** Schedule as a post-ingestion step, not per-upsert
+   (RFC-090 OQ-1).
+3. **Compound-result linking quality.** Depends on timestamp overlap between Whisper segments and
+   GIL grounding quotes. Mitigation: tolerance window; log unlinked insights.
+4. **Tier-weight calibration.** Defaults are heuristic; weights are config-driven and the eval loop
+   produces tuning signal.
+5. **Rules-based router misclassification.** Degrades to wrong weights, not wrong results; RFC-092
+   ML router fixes systematic misclassification once eval data exists.
+
+## Related Work
+
+- `docs/rfc/RFC-090-hybrid-retrieval.md`
+- `docs/rfc/RFC-091-kg-proximity-signal.md`
+- `docs/rfc/RFC-092-ml-query-router.md`
+- `docs/rfc/RFC-093-litm-context-packs.md`
+- `docs/rfc/RFC-072-canonical-identity-layer-cross-layer-bridge.md`
+- `docs/rfc/RFC-088-enrichment-layer-architecture.md`
+- `docs/prd/PRD-031-search.md`
+- `docs/prd/PRD-028-position-tracker.md`
+- Issue #849 (Search retrieval prerequisites), #466 (GI/KG depth roadmap — superseded), #484, #485.
+
+## Release Checklist
+
+- [ ] PRD reviewed and approved
+- [ ] RFC-090 (core) approved; prerequisite issues for entity resolver / graph access / typed edges
+      filed in #849
+- [ ] Two-tier index + RRF fusion + compound dedup implemented
+- [ ] Segment chunking wired post-transcription (extend existing chunker)
+- [ ] Eval: two-tier hybrid vs FAISS baseline on held-out query set
+- [ ] `config/search.yaml` backend abstraction in place
+- [ ] FAISS deprecated on confirmed improvement
+
+## Future
+
+- Turbopuffer or Qdrant Cloud backend (abstraction ready).
+- Cross-encoder reranking post-RRF baseline.
+- Query expansion / HyDE for sparse queries.
+- Personalisation (requires auth layer).

--- a/docs/prd/PRD-033-search-powered-surfaces.md
+++ b/docs/prd/PRD-033-search-powered-surfaces.md
@@ -1,0 +1,266 @@
+# PRD-033: Search-Powered Surface Enhancements
+
+- **Status**: Draft
+- **Author**: Marko
+- **Created**: 2026-05-24
+- **Target**: v2.7 (foundation), podcast product (full)
+- **Related PRDs**:
+  - `docs/prd/PRD-031-search.md` — Search product
+  - `docs/prd/PRD-032-hybrid-corpus-search.md` — retrieval backend (dependency)
+  - `docs/prd/PRD-026-topic-entity-view.md` — Topic Entity View panel
+  - `docs/prd/PRD-029-person-profile.md` — Person Landing content
+  - `docs/prd/PRD-028-position-tracker.md` — position evolution data
+- **Related RFCs**:
+  - `docs/rfc/RFC-090-hybrid-retrieval.md`, `docs/rfc/RFC-091-kg-proximity-signal.md`
+  - `docs/rfc/RFC-080-graph-visualization-extensions.md` — graph viz extensions
+- **Related issues**: #658 (Graph filter UX), #669 (Library), #670 (Digest), #671 (Search/Explore), #672 (right rail), #673 (nav), #674 (cross-surface flows) — all CLOSED
+
+> **Stabilization note (2026-05-30):** Rebased to this repo. Original draft referenced
+> "RFC-077 (graph visualization extensions)" and "RFC-080 (corpus impact surface)" — both wrong
+> here. Corrected: graph viz extensions → **RFC-080**. A dedicated **corpus-impact / coverage
+> surface** does not exist as its own doc and is marked **[TBD — not yet specified]**. This PRD is
+> a cross-surface companion to PRD-031/032: it specifies how the retrieval backend propagates
+> across viewer surfaces, not a standalone feature.
+
+---
+
+## Summary
+
+PRD-032 delivers a two-tier hybrid retrieval backend with BM25, vector, and KG-proximity signals.
+This PRD covers how that capability propagates across the viewer's surfaces — Search/Explore,
+Library, Digest, Detail panels, Graph, and Dashboard — and what becomes possible on each that
+wasn't before. It is not a cosmetic refresh: the retrieval upgrade changes what information can be
+surfaced, how confidently, and in response to what triggers.
+
+## Background & Context
+
+- **What problem this solves.** Each viewer surface today is limited by single-signal,
+  insight-only retrieval. Library filtering is presence/absence; Digest bands are static; node
+  clicks dead-end; Dashboard cards aren't drillable to evidence.
+- **Why now.** Once PRD-032's backend lands, every surface can be re-grounded in actual,
+  attributable corpus evidence. The cross-surface flow gaps in #674 become fixable.
+- **How it relates to existing features.** This PRD is the consumer-side companion to PRD-031
+  (Search product) and PRD-032 (backend). It depends on the right-rail panels (#672), the filter
+  chip bars (#658/#669/#670/#671), and the canonical identity layer (RFC-072).
+
+### What the backend unlocks per surface
+
+| Old capability | New capability |
+| --- | --- |
+| Vector similarity only | BM25 + vector + KG proximity, mixed-tier results |
+| Insight nodes only | Transcript segments + insights, raw evidence accessible |
+| No query intent | Query-type routing — entity, synthesis, temporal, evidence |
+| Static ranked lists | Compound results (segment + insight linked) |
+| No coverage signal | Corpus coverage counts (richer impact surface **[TBD]**) |
+| Raw MCP dumps | LITM-aware briefing packs (requires MCP layer **[TBD]**) |
+
+## Goals
+
+- Propagate hybrid retrieval consistently across all viewer surfaces, not just Search.
+- Turn dead-end node clicks into evidence-grounded panels (#672).
+- Make filtering rank by relevance (retrieval-backed), not just presence/absence.
+- Establish cross-show synthesis as a first-class, differentiated capability (Digest).
+
+## Non-Goals
+
+- Building the retrieval backend (PRD-032 / RFC-090 own that).
+- Net-new surfaces — this enhances existing surfaces only.
+- Surfaces whose content depends on capabilities not yet built (contradiction edges, MCP packs,
+  corpus-impact surface) ship as graceful placeholders, not blockers.
+
+## Personas
+
+- **Beta researcher**: Navigates across surfaces (Search → Detail → Graph) and expects continuity
+  and real content at each stop.
+- **Operator (you)**: Uses Dashboard/Library coverage signals to guide corpus expansion.
+
+## User Stories
+
+- _As a beta researcher, I can filter Library by a topic and get episodes ranked by relevance, so
+  that a 700+ episode corpus doesn't return an undifferentiated list._
+- _As a beta researcher, I can click a speaker name in Digest and open their Person Landing, so
+  that names are navigation anchors, not plain text._
+- _As a beta researcher, I can see a cross-show synthesis band in Digest, so that I get a
+  horizontal slice across shows on a topic._
+- _As a beta researcher, I can click a Graph node and open an evidence-grounded panel, so that the
+  graph is a navigation surface, not just a visualization._
+- _As an operator, I can see a coverage-gaps card on the Dashboard, so that I know which topics are
+  thinly covered._
+
+## Functional Requirements
+
+### FR1: Search and Explore
+
+_Primary surface for PRD-031/032; specified here for cross-surface consistency._
+
+- **FR1.1**: Two-tier results in the list with a `source_tier` indicator; compound results appear
+  as a single card with both layers accessible.
+- **FR1.2**: Named-entity search returns exact-match results (purely retrieval quality, no UI
+  change).
+- **FR1.3**: Raw-evidence toggle ("Insights" / "Transcript" / "Both") constraining to
+  segment-tier results (uses the `raw_evidence` query type).
+- **FR1.4**: Query-type indicator near the search bar (transparency / debuggability).
+- **FR1.5 (Explore)**: Corpus-coverage card above results when a topic/person is selected — N
+  shows, M episodes, date range, contradiction count. Placeholder in v2.7; full when the
+  corpus-impact surface exists **[TBD]**. Affected: #671.
+
+### FR2: Library (#669)
+
+- **FR2.1**: "Why this episode" relevance snippet on rows when a search/filter context is active —
+  top-scoring segment or insight for the current context. Triggered only with active context;
+  rows stay clean by default.
+- **FR2.2**: Topic/person filter chips rank episodes by hybrid relevance, not presence/absence.
+- **FR2.3**: Coverage-gap indicator on show groups for a filtered view (requires corpus-impact
+  surface **[TBD]**; placeholder in v2.7).
+
+### FR3: Digest (#670)
+
+- **FR3.1**: Topic bands ranked by retrieval signal (insight density, contradiction presence,
+  cross-show coverage), not just recency/frequency.
+- **FR3.2**: Cross-show synthesis band — for a topic, the top insight from each show that covers
+  it. A genuine product differentiator (the corpus moat).
+- **FR3.3**: Contradiction indicator in bands when typed contradiction KG edges exist (**not yet
+  built**; placeholder until then).
+- **FR3.4**: Speaker names become interactive — resolve to canonical person IDs (RFC-072) and open
+  Person Landing (#672). _Depends on the entity resolver, which **does not exist yet**._
+
+### FR4: Detail Panels (#672)
+
+- **FR4.1 Person Landing**: Dynamically assembled via an `entity_lookup`, BM25-heavy query scoped
+  to `speaker_id = canonical_id` — top insight, top segment, shows ranked by contribution, topics
+  by insight density, position evolution (if PRD-028 data exists). Returns compound results.
+- **FR4.2 Topic Entity View**: `cross_show_synthesis`, KG-proximity-weighted, unscoped — cross-show
+  coverage summary, dominant positions, contradictions (when edges exist), key voices, raw
+  evidence.
+- **FR4.3 Episode Detail**: Navigable transcript with highlighted matched segments; "related
+  insights" via a KG-proximity query scoped to the episode's topics.
+
+### FR5: Graph (#658)
+
+- **FR5.1**: Node size reflects a retrieval signal (insight density / cross-show breadth /
+  search-context relevance), not just degree.
+- **FR5.2**: Edge weight reflects retrieval confidence (insight count × confidence). Feeds the
+  graph-viz edge-weight target in RFC-080.
+- **FR5.3**: Contradiction edges shown as a distinct edge type when present (**not yet built**).
+- **FR5.4**: Node click opens the populated Detail panel (FR4), not a dead-end generic panel.
+
+### FR6: Dashboard
+
+- **FR6.1**: Briefing cards grounded in retrieval (top insight + top segment per topic) via a
+  briefing-pack call. _Requires MCP layer **[TBD]**; until then, cards use existing enrichment._
+- **FR6.2**: "View evidence" affordance opening the briefing-pack view (RFC-093).
+- **FR6.3**: Activity chart driven by retrieval-volume signal (query volume by topic over time).
+  Tufte-compliant: single y-axis, no dual-axis, no decorative lines.
+- **FR6.4**: Coverage-gaps card (corpus quality for the operator). Requires corpus-impact surface
+  **[TBD]**.
+- Design constraints unchanged: 5-second-answer cards; enrichment feeds retrieval, retrieval feeds
+  cards; Tufte chart discipline.
+
+## Success Metrics
+
+- Cross-surface navigation rate (Search → Detail → Graph) increases vs current baseline.
+- Library filter → episode click-through increases with relevance snippets active.
+- Digest cross-show synthesis band engagement: any non-zero rate (validates the differentiator).
+- Node-click → populated-panel rate: ~100% of clicks reach real content (no dead-ends).
+
+## Dependencies
+
+- **PRD-032 / RFC-090** hybrid retrieval backend — **Hard** — Draft.
+- **RFC-091** KG proximity (Topic Entity View, related insights) — **Hard for those** — Draft;
+  depends on graph-access prerequisites.
+- **#672** right-rail panels — **Hard** — CLOSED.
+- **RFC-072** canonical identity / entity resolver — **Hard for interactive names** — **Partial**
+  (no resolver yet).
+- **RFC-080** graph-visualization extensions — **Soft** — for edge-weight/node-size signals.
+- **MCP layer** (Dashboard briefing packs) — **[TBD — not yet specified]**.
+- **Corpus-impact / coverage surface** (coverage cards/gaps) — **[TBD — not yet specified]**.
+- **Typed contradiction KG edges** — **not yet built** (placeholders degrade gracefully).
+
+## Constraints & Assumptions
+
+**Constraints:**
+
+- Surfaces depending on unbuilt capabilities ship placeholders, never blockers.
+- Dashboard cards remain 5-second answers; retrieval happens async/in background.
+
+**Assumptions:**
+
+- Right-rail panels (#672) and filter chip bars (#658/#669/#670/#671) are built or buildable.
+- Canonical IDs become available via the entity resolver prerequisite (#849).
+
+## Design Considerations
+
+### OQ-1: PanelRetrievalStore
+
+A `PanelRetrievalStore` (Pinia) caches retrieval results per entity ID with a short TTL; panel
+opens trigger a retrieval call, subsequent opens within TTL are instant. Resolves the #672
+`subjectStore` open question. Decide before podcast-product panel work.
+
+### OQ-2: Search context propagation
+
+A shared `activeSearchContext` store so Graph reflects an active search (retrieval-score-weighted
+nodes). Useful but adds cross-surface state complexity — defer to podcast product, design
+separately.
+
+### OQ-3: Dashboard async card content
+
+Briefing-pack-backed cards add load latency — render skeleton-first, populate async. Confirm the
+dashboard architecture supports async card content before implementing.
+
+### OQ-4: Contradiction-edge dependency
+
+Multiple surfaces show placeholders for contradiction content; all depend on
+contradiction-as-KG-edge, which has no RFC yet. Schedule that prerequisite before podcast product
+to avoid shipping a cluster of "coming soon" placeholders.
+
+## Cross-Surface Flows (Issue #674 Revisited)
+
+Issue #674 identified five cross-surface flow gaps. Hybrid search addresses four:
+
+| Gap | How hybrid search fixes it |
+| --- | --- |
+| Feed names in Digest non-interactive | Show names resolve via canonical identity → show-scoped Library view |
+| Library rows require too many clicks to reach graph | Relevance snippets give enough context to decide before clicking; compound results reduce pogo-sticking |
+| Digest topic bands switch tabs instead of opening Topic Entity View | Topic Entity View now has real content; band click opens right rail |
+| Speaker names in Search plain text | Entity resolver maps names → canonical IDs → Person Landing |
+| _(fifth gap: not directly addressed here)_ | — |
+
+## Milestone Assignment
+
+| Surface | Change | Milestone |
+| --- | --- | --- |
+| Search/Explore | Two-tier results, raw-evidence toggle, query-type indicator | v2.7 |
+| Search/Explore | Corpus coverage card in Explore | podcast product |
+| Library | Hybrid retrieval ranking on filter chips | v2.7 |
+| Library | Relevance snippets on rows (active context) | v2.7 |
+| Library | Coverage gap indicator | podcast product |
+| Digest | Topic bands ranked by retrieval signal | v2.7 |
+| Digest | Cross-show synthesis band | podcast product |
+| Digest | Contradiction indicator | podcast product (when edges exist) |
+| Digest | Speaker names interactive | v2.7 (needs entity resolver) |
+| Detail — Person Landing | Retrieval-grounded content | podcast product |
+| Detail — Topic Entity View | Retrieval-grounded content | podcast product |
+| Detail — Episode Detail | Related insights, segment highlights | podcast product |
+| Graph | Node size / search-context prominence | podcast product |
+| Graph | Contradiction edges visible | podcast product (when edges exist) |
+| Graph | Node click → populated panel | podcast product |
+| Dashboard | Briefing cards + "view evidence" | podcast product (needs MCP) |
+| Dashboard | Coverage gaps card | podcast product |
+| Dashboard | Retrieval-volume activity chart | podcast product |
+
+## Related Work
+
+- `docs/prd/PRD-031-search.md`, `docs/prd/PRD-032-hybrid-corpus-search.md`
+- `docs/rfc/RFC-090-hybrid-retrieval.md`, `docs/rfc/RFC-091-kg-proximity-signal.md`,
+  `docs/rfc/RFC-093-litm-context-packs.md`
+- `docs/rfc/RFC-080-graph-visualization-extensions.md`
+- GitHub issues #658, #669, #670, #671, #672, #673, #674 (all CLOSED).
+
+## Release Checklist
+
+- [ ] PRD reviewed and approved
+- [ ] PRD-032 / RFC-090 backend available
+- [ ] v2.7 surface slices (Search two-tier, Library ranking + snippets, Digest band ranking) shipped
+- [ ] Entity resolver prerequisite filed and tracked (interactive names)
+- [ ] Placeholder behavior verified for unbuilt-capability surfaces (no broken UI)
+- [ ] Corpus-impact surface and MCP layer prerequisites scheduled before podcast-product slices

--- a/docs/rfc/RFC-090-hybrid-retrieval.md
+++ b/docs/rfc/RFC-090-hybrid-retrieval.md
@@ -1,0 +1,439 @@
+# RFC-090: Hybrid Retrieval Pipeline
+
+- **Status**: Draft
+- **Authors**: Marko
+- **Stakeholders**: Core team
+- **Related PRDs**:
+  - `docs/prd/PRD-032-hybrid-corpus-search.md` — hybrid corpus search (parent)
+  - `docs/prd/PRD-031-search.md` — Search product surface
+  - `docs/prd/PRD-021-semantic-corpus-search.md` — predecessor (FAISS)
+- **Related ADRs**:
+  - _(none yet)_
+- **Related RFCs**:
+  - `docs/rfc/RFC-091-kg-proximity-signal.md` — third RRF signal (additive)
+  - `docs/rfc/RFC-092-ml-query-router.md` — ML query router (additive)
+  - `docs/rfc/RFC-093-litm-context-packs.md` — LITM context packs (additive)
+  - `docs/rfc/RFC-072-canonical-identity-layer-cross-layer-bridge.md` — canonical identity
+  - `docs/rfc/RFC-088-enrichment-layer-architecture.md` — enrichment layer
+- **Related UX specs**:
+  - _(viewer Search surface — see PRD-031)_
+- **Related Documents**:
+  - `docs/architecture/kg/kg.schema.json` — KG edge schema (today: `MENTIONS`/`RELATED_TO`)
+
+> **Stabilization note (2026-05-30):** Rebased from an earlier draft (RFC-078) authored against a
+> different numbering universe. Module paths corrected to `src/podcast_scraper/…`; references to an
+> "enrichment" RFC and an "MCP integration" RFC corrected to RFC-088 and **[TBD — no MCP RFC
+> exists]**. The third signal, ML router, and context packs are split into RFC-091/092/093.
+> **Prerequisite reality check** (see Constraints): the entity resolver, in-memory KG access layer,
+> and most typed KG edges this pipeline's _additive_ signals assume **do not exist yet** — they are
+> the genuine survivors of issue #466 and are tracked in #849. RFC-090 itself
+> (BM25 + vector + RRF over two tiers) does **not** depend on them.
+
+---
+
+## Abstract
+
+Replace single-signal FAISS vector search with a two-tier, three-signal hybrid retrieval pipeline.
+Tier 1 indexes transcript segments (raw evidence); Tier 2 indexes GIL insight nodes (synthesized
+intelligence). Signals — BM25, dense vector, and (additively, in RFC-091) KG proximity — are fused
+via Reciprocal Rank Fusion (RRF) into a single mixed result list. A `SearchBackend` protocol
+decouples signal generation from fusion, enabling backend substitution without touching retrieval
+or MCP layers. LanceDB embedded is the initial backend.
+
+**Architecture Alignment:** Extends the existing search package
+(`src/podcast_scraper/search/`) rather than replacing it; reuses the GIL insight contracts
+(`src/podcast_scraper/gi/contracts.py`) and the existing chunker
+(`src/podcast_scraper/search/chunker.py`). The `SearchBackend` protocol follows the RFC-016
+modularization principle (swap implementations behind a stable interface).
+
+## Problem Statement
+
+Single-signal FAISS over insights only produces three failure classes:
+
+1. **Missed raw evidence.** Transcript segments not captured as GIL insights are invisible to
+   search — exact phrase matches, specific terminology, minority-view content below the insight
+   extraction threshold are all unreachable.
+2. **Named-entity degradation.** Embedding models under-weight proper nouns; BM25 fixes this.
+3. **No relational context.** KG edge structure contributes nothing to ranking. RFC-091 adds this
+   as the third signal; this RFC builds the fusion layer it plugs into.
+
+**Use Cases:**
+
+1. **Raw evidence**: A user searches for an exact phrase and finds the transcript segment, even if
+   no insight was extracted from it.
+2. **Named entity**: A user searches "Sam Altman" and gets results containing the name directly.
+3. **Mixed-tier synthesis**: A cross-show question returns both distilled insights and supporting
+   raw segments, deduplicated into compound results.
+
+## Goals
+
+1. **Two-tier retrieval**: Segments and insights both indexed and retrievable; results mixed by
+   score.
+2. **Named-entity recall**: BM25 signal restores proper-noun matching.
+3. **Clean fusion layer**: RRF in the retrieval layer, ready to accept a third (KG) signal with no
+   backend change.
+4. **Compound dedup**: Segment+insight pairs referring to the same content merge into one result.
+5. **Swappable backend**: `SearchBackend` protocol; LanceDB first.
+
+## Constraints & Assumptions
+
+**Constraints:**
+
+- Embedded, local-first backend (LanceDB) on the operator's machine; no cloud dependency.
+- `lancedb` is **not currently a dependency** (`pyproject.toml` ships `faiss-cpu`); adding it is
+  part of this RFC.
+- No changes to GIL grounding invariants or the enrichment pipeline.
+
+**Assumptions:**
+
+- GIL insight grounding quotes carry `timestamp_start_ms` / `timestamp_end_ms`
+  (`src/podcast_scraper/gi/contracts.py`), enabling timestamp-based segment↔insight linking.
+- Whisper output segments (`{text, start, end, speaker_id?}`) are available at index time. Today
+  they are passed into GI/KG builders as optional sidecar data
+  (`src/podcast_scraper/gi/pipeline.py`), not retained as a standalone artifact (OQ-5).
+- **Additive-signal prerequisites are NOT assumed by this RFC.** KG proximity (RFC-091) needs an
+  in-memory KG access layer and an entity resolver that do not exist yet; RFC-090 ships BM25 +
+  vector + RRF without them.
+
+## Design & Implementation
+
+### 1. Document Schemas
+
+**Segment document (Tier 1)**
+
+```python
+# src/podcast_scraper/search/backend.py
+
+@dataclass
+class SegmentDocument:
+    id: str                      # "{episode_id}_chunk_{n}"
+    text: str                    # 200-300 word chunk, 50-word overlap
+    embedding: list[float]
+    show_id: str
+    episode_id: str
+    speaker_id: str | None       # if diarized
+    start_time: float            # seconds from episode start
+    end_time: float
+    linked_insight_ids: list[str]  # GIL insight IDs whose grounding quote
+                                   # falls within this chunk (timestamp overlap)
+    source_tier: str = "segment"
+```
+
+**Insight document (Tier 2)**
+
+```python
+@dataclass
+class InsightDocument:
+    id: str                      # GIL insight node ID
+    text: str
+    embedding: list[float]
+    show_id: str
+    episode_id: str
+    speaker_id: str | None
+    entity_type: str
+    confidence: float
+    derived: bool
+    source_segment_id: str | None  # back-ref to segment with grounding quote
+    source_tier: str = "insight"
+```
+
+### 2. SearchBackend Protocol
+
+```python
+# src/podcast_scraper/search/backend.py
+
+from typing import Protocol, runtime_checkable, Literal
+from dataclasses import dataclass, field
+
+Tier = Literal["segment", "insight", "all"]
+
+@dataclass
+class SearchQuery:
+    text: str
+    embedding: list[float]
+    filters: dict = field(default_factory=dict)
+    k: int = 20
+    tier: Tier = "all"
+
+@dataclass
+class ScoredResult:
+    doc_id: str
+    score: float
+    rank: int
+    payload: dict
+    signal: str                  # "bm25" | "vector" | "kg" | "rrf"
+    source_tier: str             # "segment" | "insight" | "compound"
+
+@dataclass
+class CompoundResult:
+    """Merged result when a segment and insight refer to the same content."""
+    doc_id: str                  # segment id (primary key)
+    score: float                 # max(segment_score, insight_score)
+    rank: int
+    segment: ScoredResult
+    insight: ScoredResult
+    signal: str = "rrf"
+    source_tier: str = "compound"
+
+@runtime_checkable
+class SearchBackend(Protocol):
+    def search_bm25(self, query: SearchQuery) -> list[ScoredResult]: ...
+    def search_vector(self, query: SearchQuery) -> list[ScoredResult]: ...
+    def upsert_segment(self, doc: SegmentDocument) -> None: ...
+    def upsert_insight(self, doc: InsightDocument) -> None: ...
+    def delete(self, doc_id: str, tier: Tier) -> None: ...
+    def create_indices(self) -> None: ...
+    def health(self) -> dict: ...
+```
+
+### 3. RRF Fusion with Tier Weights
+
+```python
+# src/podcast_scraper/search/fusion.py
+
+TIER_WEIGHTS = {"insight": 1.2, "segment": 1.0}
+
+def rrf_fuse(ranked_lists, k=60, signal_weights=None, tier_weights=None):
+    """RRF score(d) = sum( (signal_weight * tier_weight) / (k + rank_i(d)) )"""
+    signal_weights = signal_weights or {}
+    tier_weights = tier_weights or TIER_WEIGHTS
+    scores, payloads, tiers = {}, {}, {}
+    for result_list in ranked_lists:
+        if not result_list:
+            continue
+        signal = result_list[0].signal
+        for result in result_list:
+            sw = signal_weights.get(signal, 1.0)
+            tw = tier_weights.get(result.source_tier, 1.0)
+            scores.setdefault(result.doc_id, 0.0)
+            payloads.setdefault(result.doc_id, result.payload)
+            tiers.setdefault(result.doc_id, result.source_tier)
+            scores[result.doc_id] += (sw * tw) / (k + result.rank)
+    sorted_ids = sorted(scores, key=lambda d: scores[d], reverse=True)
+    return [
+        ScoredResult(d, scores[d], i + 1, payloads[d], "rrf", tiers[d])
+        for i, d in enumerate(sorted_ids)
+    ]
+```
+
+### 4. Deduplication — Compound Results
+
+After RRF, deduplicate segment+insight pairs referring to the same content into a `CompoundResult`
+taking the higher score. Full implementation in `src/podcast_scraper/search/dedup.py`: for each
+insight result, if a segment result exists whose `linked_insight_ids` (or the insight's
+`source_segment_id`) matches, merge the two; carry both, take `max` score and `min` rank;
+re-sort by score.
+
+### 5. Retrieval Layer
+
+```python
+# src/podcast_scraper/search/retrieval.py
+
+class RetrievalLayer:
+    def __init__(self, backend: SearchBackend):
+        self.backend = backend
+
+    def retrieve(self, text, embedding, filters=None, k=20,
+                 query_type="hybrid", tier="all",
+                 signal_weights=None, tier_weights=None):
+        query = SearchQuery(text=text, embedding=embedding,
+                            filters=filters or {}, k=k, tier=tier)
+        ranked_lists = []
+        if query_type in ("hybrid", "bm25"):
+            ranked_lists.append(self.backend.search_bm25(query))
+        if query_type in ("hybrid", "vector"):
+            ranked_lists.append(self.backend.search_vector(query))
+
+        # KG proximity slot — filled by RFC-091 (requires KG access + entity resolver):
+        # entity_id = self.entity_resolver.resolve(text)
+        # if entity_id:
+        #     ranked_lists.append(self.kg_proximity.search(entity_id, k=k))
+
+        if len(ranked_lists) == 1:
+            return deduplicate(ranked_lists[0])
+        fused = rrf_fuse(ranked_lists, signal_weights=signal_weights or {},
+                         tier_weights=tier_weights or TIER_WEIGHTS)
+        return deduplicate(fused)
+```
+
+### 6. Query-Type Router (Rules-Based v1)
+
+Full ML router is RFC-092. Minimal rules-based version ships here
+(`src/podcast_scraper/search/router.py`): keyword/regex routing to one of `raw_evidence`,
+`temporal_tracking`, `cross_show_synthesis`, `entity_lookup`, `semantic`, plus per-type
+`SIGNAL_WEIGHTS` and `TIER_WEIGHTS_BY_QUERY`. `raw_evidence` flips tier weights to favour segments
+(segment 1.3, insight 0.9).
+
+### 7. LanceDB Backend
+
+Two tables (`segments`, `insights`); `search_bm25` / `search_vector` route by `query.tier`.
+Implementation in `src/podcast_scraper/search/backends/lancedb_backend.py`: FTS index on `text`,
+vector index on `embedding`, `merge_insert` upserts, `where(...)` SQL filters (see OQ-3 on
+parameterisation), and a `health()` returning per-table row counts.
+
+### 8. Segment Chunking
+
+**Reuse the existing chunker** at `src/podcast_scraper/search/chunker.py` (already used by
+`indexer.py`) rather than creating a new pipeline package. Extend it to emit `SegmentDocument`s and
+to link insights by timestamp overlap:
+
+```python
+# src/podcast_scraper/search/chunker.py  (extend existing)
+
+CHUNK_WORDS = 250
+OVERLAP_WORDS = 50
+
+def link_insights_to_segments(chunks, insights, tolerance_seconds=2.0):
+    """Populate linked_insight_ids on segments and source_segment_id on insights
+    by timestamp overlap with a tolerance window. Mutates in place."""
+    for insight in insights:
+        quote_start = insight.payload.get("quote_start_time")
+        quote_end = insight.payload.get("quote_end_time")
+        if quote_start is None:
+            continue
+        for chunk in chunks:
+            if (chunk.start_time - tolerance_seconds <= quote_start
+                    and quote_end <= chunk.end_time + tolerance_seconds):
+                chunk.linked_insight_ids.append(insight.id)
+                insight.source_segment_id = chunk.id
+                break
+```
+
+### 9. Migration & Configuration
+
+A migration script (`scripts/migrate_to_lancedb_two_tier.py`) chunks each episode, links insights,
+and writes the `segments` and `insights` LanceDB tables with FTS + vector indices. Backend selected
+via `config/search.yaml` (`backend: lancedb`), with commented cloud-backend stanzas for the future
+abstraction.
+
+## Key Decisions
+
+1. **Separate ranked lists, client-side RRF.**
+   - **Decision**: Backend exposes `search_bm25()` and `search_vector()` separately; RRF lives in
+     the retrieval layer.
+   - **Rationale**: Enables KG proximity as a clean additive third list (RFC-091) without touching
+     the backend.
+2. **Two LanceDB tables, not one.**
+   - **Decision**: Separate `segments` and `insights` tables.
+   - **Rationale**: Different schemas, payloads, and FTS field requirements; one table would need
+     nullable columns and complicate FTS config.
+3. **Dedup at the retrieval layer, not the consumer.**
+   - **Decision**: `CompoundResult` produced once in the retrieval layer.
+   - **Rationale**: Consumers (viewer, MCP, autoresearch) receive a clean list.
+4. **Tier weights in RRF, not pre-filter.**
+   - **Decision**: Always search both tiers; weights adjust rank contribution.
+   - **Rationale**: Pre-filtering by tier would miss cross-tier evidence; weights are cheaper and
+     more robust.
+5. **200–300 words, 50-word overlap.**
+   - **Decision**: Standard RAG chunking over Whisper sentence segments.
+   - **Rationale**: Balances context coherence with retrieval precision; revisit if eval shows
+     boundary misalignment with grounding quotes.
+
+## Alternatives Considered
+
+1. **Single weighted index (one table, `source_tier` discriminator).**
+   - **Pros**: Simpler schema; one FTS index.
+   - **Cons**: Nullable columns, awkward FTS config, harder per-tier weighting.
+   - **Why rejected**: KD-2 — two tables are cleaner for distinct schemas.
+2. **Keep FAISS, add a separate BM25 store.**
+   - **Pros**: No new vector dependency.
+   - **Cons**: Two storage systems to keep in sync; no unified filter/upsert path; FAISS has no
+     native FTS.
+   - **Why rejected**: LanceDB unifies FTS + vector + filters behind one backend.
+3. **Cross-encoder rerank instead of RRF.**
+   - **Pros**: Potentially higher precision.
+   - **Cons**: Heavier compute; needs a reranker model; harder to add a graph signal.
+   - **Why rejected**: Deferred to post-RRF baseline (Non-Goal).
+
+## Testing Strategy
+
+**Test Coverage:**
+
+- **Unit**: RRF math (score accumulation, weighting), compound dedup logic, chunker
+  windowing/overlap, `SearchBackend` contract conformance.
+- **Integration**: `raw_evidence` queries return segment-heavy results; named-entity queries return
+  exact-match hits; compound results materialize when timestamps overlap.
+- **Eval**: Two-tier hybrid vs FAISS baseline on a held-out query set — nDCG@10, named-entity
+  recall, compound-result rate, segment-only result rate.
+
+**Test Organization:** Under `tests/unit/podcast_scraper/search/` and the existing eval harness;
+fixtures from a small committed corpus slice.
+
+**Test Execution:** Unit/integration in `ci-fast`; eval as an operator/CI job against a fixture
+index (not per-PR).
+
+## Rollout & Monitoring
+
+**Rollout Plan:**
+
+- **Phase 1 — Core abstractions + LanceDB**: schemas, `LanceDBBackend`, `rrf_fuse()`,
+  `deduplicate()`, `RetrievalLayer` (BM25 + vector, KG slot commented), chunker extension, migration
+  script, unit tests.
+- **Phase 2 — Query router + tier weights**: rules-based `classify_query()`, per-type weights,
+  wire into `RetrievalLayer`, integration tests.
+- **Phase 3 — Eval + FAISS deprecation**: baseline vs hybrid eval; deprecate FAISS on confirmed
+  improvement.
+
+**Monitoring:** `make search-health` (segment/insight counts); eval metrics tracked over time;
+log unlinked insights post-migration to inspect linking miss rate.
+
+**Success Criteria:** nDCG@10 improvement over FAISS; named-entity recall ≥ 90% @10; >20% of top-10
+segment-tier on raw-evidence queries.
+
+## Relationship to Other RFCs
+
+This RFC is the foundation of the Search initiative:
+
+1. **RFC-091 KG Proximity Signal** — fills the reserved third-signal slot; adds the KG-access and
+   entity-resolver dependencies (which do not exist yet).
+2. **RFC-092 ML Query Router** — replaces the rules-based router once eval data exists.
+3. **RFC-093 LITM Context Packs** — consumes `RetrievalLayer` output for agent-facing MCP packs.
+
+**Key Distinction:**
+
+- **RFC-090 (this)**: Two-tier index, BM25 + vector, RRF fusion, compound dedup — shippable today.
+- **RFC-091/092/093**: Additive signals/routing/packaging — gated on prerequisites.
+
+Other relationships:
+
+| RFC | Relationship |
+| --- | --- |
+| RFC-072 | Canonical IDs used as entity filters in `SearchQuery` (slug IDs today; resolver pending) |
+| RFC-088 | Enriched insight nodes are Tier 2 documents; `derived: true` is a payload field |
+| RFC-080 | Viewer Graph surface consumes `RetrievalLayer` signals (node size / edge weight) |
+
+## Benefits
+
+1. **Named-entity recall**: BM25 restores proper-noun matching that embeddings lose.
+2. **Raw evidence reachable**: Transcript segments become first-class search targets.
+3. **Extensible fusion**: RRF accepts a third signal with zero backend change.
+4. **Swappable backend**: `SearchBackend` protocol isolates storage choice.
+
+## Migration Path
+
+1. **Phase 1**: Add `lancedb`; build two-tier index via the migration script alongside the existing
+   FAISS index (no removal yet).
+2. **Phase 2**: Route viewer/MCP search through `RetrievalLayer`; keep FAISS as fallback.
+3. **Phase 3**: Deprecate FAISS once eval confirms improvement; remove `faiss-cpu` in a later PR.
+
+## Open Questions
+
+1. **OQ-1 FTS rebuild on delta upserts.** Does LanceDB FTS require full rebuild per upsert batch or
+   support incremental updates? Schedule indexing post-ingestion regardless.
+2. **OQ-2 Embedding alignment on migration.** Validate dimensionality before write; re-embed from
+   raw text if mismatch.
+3. **OQ-3 Filter SQL injection.** `_to_sql()` is naive string interpolation — parameterise before
+   any user-facing filter input reaches it.
+4. **OQ-4 Chunk boundary alignment.** 2-second tolerance in `link_insights_to_segments()` may need
+   tuning; log unlinked insights post-migration.
+5. **OQ-5 Speaker diarization integration.** `speaker_id` on segments is nullable; when diarization
+   is available, segments inherit the dominant speaker within the chunk. Separate PR.
+
+## References
+
+- **Related PRD**: `docs/prd/PRD-032-hybrid-corpus-search.md`, `docs/prd/PRD-031-search.md`
+- **Related RFC**: `docs/rfc/RFC-091-kg-proximity-signal.md`, `docs/rfc/RFC-092-ml-query-router.md`,
+  `docs/rfc/RFC-093-litm-context-packs.md`
+- **Source Code**: `src/podcast_scraper/search/` (existing FAISS pipeline, chunker, indexer),
+  `src/podcast_scraper/gi/contracts.py` (insight grounding quotes)
+- **Prerequisites**: issue #849 · **Parent epic**: issue #466 (GI/KG depth roadmap — superseded)

--- a/docs/rfc/RFC-091-kg-proximity-signal.md
+++ b/docs/rfc/RFC-091-kg-proximity-signal.md
@@ -77,19 +77,20 @@ access layer and enriching the edge set.
 > (`person:…` / `topic:…`) and are joined per episode by `bridge.json`. So the prerequisite is **not**
 > "add edges to the KG" — it is a **cross-layer graph** that unifies both via those shared IDs.
 
-1. **In-memory cross-layer corpus graph.** A graph object unifying GIL + KG nodes/edges (joined on
-   canonical IDs via the bridge) and exposing `neighbors()`, `get_node()`, and node `type`/`payload`.
-   Today only per-layer load/export/rollup helpers exist (`src/podcast_scraper/kg/`,
-   `src/podcast_scraper/gi/`); there is no traversal API and no unified graph. **Slice B of #849.**
-2. **Traversal edges — mostly already present across the two layers, not new KG edges:**
-   - `ABOUT` (insight → topic): **exists** in GIL (`src/podcast_scraper/gi/about_edges.py`).
-   - `SPEAKER_OF` (person → insight), `IN_EPISODE` (insight → episode): these reach insight nodes,
-     which **only exist in the GIL layer** — they come from GIL edges (`SPOKEN_BY`, `HAS_INSIGHT`,
-     `SUPPORTED_BY`) once the cross-layer graph exists, **not** from new KG edge types.
-   - `COVERS` (episode → topic), `MENTIONED_IN` (person → episode): semantically the existing KG
-     `MENTIONS` edge (relabel/direction only) — **Slice C of #849.**
-   - `FROM_SHOW` (episode → show): needs a **Show node type** the KG lacks today (only `feed_id`
-     property) — **Slice C of #849.**
+1. **In-memory cross-layer corpus graph.** — **SHIPPED (Slice B of #849):**
+   `src/podcast_scraper/search/corpus_graph.py`. `CorpusGraph` unifies GIL + KG nodes/edges
+   (id-keyed union on shared canonical IDs) and exposes `get_node()`, `neighbors()` (undirected),
+   `bfs()`, `degree()`, `nodes_by_type()`, plus a process-cached `get_corpus_graph()`.
+2. **Traversal edges — satisfied natively; no KG schema change (Slice C of #849, resolved):**
+   - `ABOUT` (insight ↔ topic): exists in GIL (`gi/about_edges.py`).
+   - `SPEAKER_OF` (person → insight): synthesized as an **opt-in 1-hop derived shortcut**
+     (`CorpusGraph.build(derive_speaker_links=True)`, composing `SPOKEN_BY` + `SUPPORTED_BY`); also
+     reachable in 2 hops without it.
+   - `IN_EPISODE` (insight ↔ episode): GIL `HAS_INSIGHT`.
+   - `COVERS` (topic ↔ episode), `MENTIONED_IN` (person ↔ episode): the existing KG `MENTIONS` edge
+     (undirected, so no relabel needed for traversal).
+   - `FROM_SHOW` (episode ↔ show): GIL `Podcast` nodes + `HAS_EPISODE` edges — already in the
+     unified graph; **no new Show node / KG edge type added.**
 3. **Entity resolver.** `EntityResolver.resolve(text) → canonical_id | None` —
    **SHIPPED (Slice A of #849):** `src/podcast_scraper/identity/resolver.py`, a corpus-wide registry
    over GIL + KG canonical entities with exact + fuzzy matching (reuses `bridge_builder`).

--- a/docs/rfc/RFC-091-kg-proximity-signal.md
+++ b/docs/rfc/RFC-091-kg-proximity-signal.md
@@ -1,0 +1,305 @@
+# RFC-091: KG Proximity Signal
+
+- **Status**: Draft
+- **Authors**: Marko
+- **Stakeholders**: Core team
+- **Related PRDs**:
+  - `docs/prd/PRD-032-hybrid-corpus-search.md` — hybrid corpus search
+  - `docs/prd/PRD-031-search.md` — Search product
+- **Related ADRs**:
+  - _(none yet)_
+- **Related RFCs**:
+  - `docs/rfc/RFC-090-hybrid-retrieval.md` — provides the RRF fusion slot (hard dependency)
+  - `docs/rfc/RFC-072-canonical-identity-layer-cross-layer-bridge.md` — entity resolution
+  - `docs/rfc/RFC-088-enrichment-layer-architecture.md` — contradiction signals (future edges)
+- **Related Documents**:
+  - `docs/architecture/kg/kg.schema.json` — KG edge schema (today: `MENTIONS`/`RELATED_TO`; GI also emits `ABOUT`)
+
+> **Stabilization note (2026-05-30):** Split out of an earlier combined draft (RFC-079) that bundled
+> KG proximity, the ML router, and LITM context packs under one number. This RFC is the KG-proximity
+> third signal only; the router is RFC-092 and the packs are RFC-093. **This RFC is the most
+> prerequisite-heavy of the three** — see Constraints. Its core dependencies (an in-memory KG access
+> layer, typed traversal edges, and a freeform-text → canonical-ID entity resolver) are the genuine
+> survivors of issue #466 and **do not exist in the codebase yet**.
+
+---
+
+## Abstract
+
+Add the third retrieval signal to RFC-090: KG graph proximity. For a query, resolve the most
+relevant canonical entity, traverse the knowledge graph from it over typed edges, and return
+reachable insight/segment nodes scored by inverse hop distance. This list becomes the third input
+to RRF in `RetrievalLayer.retrieve()`. It is additive — nothing in RFC-090 changes; the reserved
+slot is filled.
+
+**Architecture Alignment:** The signal plugs into the existing `RetrievalLayer` via the
+already-reserved third-list slot (RFC-090 KD-1), so no backend or fusion changes are needed.
+**However**, it introduces two new architectural dependencies that must be built first: a graph
+access layer over the KG artifacts and an entity resolver over the identity layer.
+
+## Problem Statement
+
+BM25 and dense vector are commoditized signals. Graph hop distance — computed over this project's
+specific ontology (person → topic → insight → episode → show) — is structurally unique to this
+corpus. It encodes relational context that embedding similarity cannot capture: that two insights
+are connected because they are about the same person's position on the same topic across different
+shows, not because they share words.
+
+Today the KG contributes nothing to ranking. The KG also is not currently queryable as a graph:
+it is stored as per-episode `*.kg.json` artifacts (`src/podcast_scraper/kg/`) with no in-memory
+graph object exposing `neighbors()` / `get_node()`, and the edge schema is limited to `MENTIONS` /
+`RELATED_TO` (plus `ABOUT` emitted by the GI pipeline). So this RFC is gated on building that
+access layer and enriching the edge set.
+
+**Use Cases:**
+
+1. **Relational recall**: A query about a person surfaces insights connected to them via typed
+   edges even when wording differs from the query.
+2. **Centrality boost**: Centrally-positioned, well-connected content ranks above isolated nodes
+   for a relevant entity query.
+3. **Graceful skip**: A query that references no known entity simply runs on two signals.
+
+## Goals
+
+1. **KG proximity as a third RRF signal**: scored by `1 / (hop + 1)`, max 3 hops.
+2. **Entity resolution before traversal**: resolve query text → canonical ID; skip cleanly on miss.
+3. **Zero RFC-090 disruption**: fill the reserved slot; no change to fusion or backend.
+4. **Bounded cost**: pre-computable adjacency; live BFS acceptable at current corpus scale.
+
+## Constraints & Assumptions
+
+**Constraints — Prerequisites (tracked in #849):**
+
+> **Cross-layer reality (2026-05-30 audit).** This RFC's traversal (`person → insight → episode →
+> show`) assumes a single graph, but GIL and KG are **deliberately separate layers**: insights and
+> quotes live in the GIL artifacts; entities, topics, and episodes live in the KG artifacts
+> (`docs/architecture/kg/ontology.md` enforces the separation). They share canonical IDs
+> (`person:…` / `topic:…`) and are joined per episode by `bridge.json`. So the prerequisite is **not**
+> "add edges to the KG" — it is a **cross-layer graph** that unifies both via those shared IDs.
+
+1. **In-memory cross-layer corpus graph.** A graph object unifying GIL + KG nodes/edges (joined on
+   canonical IDs via the bridge) and exposing `neighbors()`, `get_node()`, and node `type`/`payload`.
+   Today only per-layer load/export/rollup helpers exist (`src/podcast_scraper/kg/`,
+   `src/podcast_scraper/gi/`); there is no traversal API and no unified graph. **Slice B of #849.**
+2. **Traversal edges — mostly already present across the two layers, not new KG edges:**
+   - `ABOUT` (insight → topic): **exists** in GIL (`src/podcast_scraper/gi/about_edges.py`).
+   - `SPEAKER_OF` (person → insight), `IN_EPISODE` (insight → episode): these reach insight nodes,
+     which **only exist in the GIL layer** — they come from GIL edges (`SPOKEN_BY`, `HAS_INSIGHT`,
+     `SUPPORTED_BY`) once the cross-layer graph exists, **not** from new KG edge types.
+   - `COVERS` (episode → topic), `MENTIONED_IN` (person → episode): semantically the existing KG
+     `MENTIONS` edge (relabel/direction only) — **Slice C of #849.**
+   - `FROM_SHOW` (episode → show): needs a **Show node type** the KG lacks today (only `feed_id`
+     property) — **Slice C of #849.**
+3. **Entity resolver.** `EntityResolver.resolve(text) → canonical_id | None` —
+   **SHIPPED (Slice A of #849):** `src/podcast_scraper/identity/resolver.py`, a corpus-wide registry
+   over GIL + KG canonical entities with exact + fuzzy matching (reuses `bridge_builder`).
+
+**Assumptions:**
+
+- At current scale (~14 shows, ~700 episodes, ~15k insights) live BFS is fast enough; revisit if
+  p99 latency is unacceptable (OQ-1).
+- Conservative entity resolution (return `None` on low confidence) is preferred over aggressive
+  matching (OQ-2).
+
+## Design & Implementation
+
+### 1. KG Proximity Search
+
+```python
+# src/podcast_scraper/search/kg_proximity.py
+#
+# PREREQUISITE: requires an in-memory KG access layer exposing neighbors()/get_node().
+# No such class exists today (KG is artifact-based). See Constraints.
+
+class KGProximitySearch:
+    def __init__(self, kg, max_hops: int = 3):
+        self.kg = kg
+        self.max_hops = max_hops
+
+    def search(self, entity_id: str, k: int = 20, filters: dict = None):
+        """BFS from entity_id over typed edges. Returns insight/segment nodes
+        with score = 1 / (hop + 1)."""
+        visited = {}                    # node_id -> min hop distance
+        queue = [(entity_id, 0)]
+        while queue:
+            node_id, hops = queue.pop(0)
+            if node_id in visited or hops > self.max_hops:
+                continue
+            visited[node_id] = hops
+            for neighbor_id in self.kg.neighbors(node_id):
+                if neighbor_id not in visited:
+                    queue.append((neighbor_id, hops + 1))
+
+        results = []
+        for node_id, hops in visited.items():
+            node = self.kg.get_node(node_id)
+            if node is None or node.type not in ("insight", "segment"):
+                continue
+            if not self._passes_filters(node, filters):
+                continue
+            results.append(ScoredResult(
+                doc_id=node_id,
+                score=1.0 / (hops + 1),
+                rank=0,
+                payload=node.payload,
+                signal="kg",
+                source_tier=node.type,
+            ))
+        results.sort(key=lambda r: r.score, reverse=True)
+        for i, r in enumerate(results):
+            r.rank = i + 1
+        return results[:k]
+```
+
+### 2. Edge Types Used
+
+| Edge | Direction | Layer / status |
+| --- | --- | --- |
+| `ABOUT` | insight → topic | **GIL — exists** (`gi/about_edges.py`) |
+| `SPEAKER_OF` | person → insight | GIL — from `SPOKEN_BY` (insight nodes are GIL-only) |
+| `IN_EPISODE` | insight → episode | GIL — from `HAS_INSIGHT` (insight nodes are GIL-only) |
+| `COVERS` | episode → topic | KG — relabel of `MENTIONS` (Slice C) |
+| `MENTIONED_IN` | person → episode | KG — relabel of `MENTIONS` (Slice C) |
+| `FROM_SHOW` | episode → show | KG — needs a Show node type (Slice C) |
+
+The insight-reaching edges (`SPEAKER_OF`, `IN_EPISODE`, `ABOUT`) live in the **GIL** layer and the
+rest in the **KG** layer; proximity traverses the **unified cross-layer graph** (Slice B), joined
+on shared canonical IDs. Max traversal: 3 hops (score decays `1/(hop+1)`; beyond 3 hops proximity
+is noise).
+
+### 3. Entity Resolution for Queries (integration into RetrievalLayer)
+
+```python
+# src/podcast_scraper/search/retrieval.py  (RFC-090 slot filled)
+
+class RetrievalLayer:
+    def __init__(self, backend, kg, entity_resolver):
+        self.backend = backend
+        self.kg_proximity = KGProximitySearch(kg)
+        self.entity_resolver = entity_resolver      # PREREQUISITE — see Constraints
+
+    def retrieve(self, text, embedding, filters=None, k=20, query_type="hybrid",
+                 tier="all", signal_weights=None, tier_weights=None):
+        query = SearchQuery(text=text, embedding=embedding,
+                            filters=filters or {}, k=k, tier=tier)
+        ranked_lists = []
+        if query_type in ("hybrid", "bm25"):
+            ranked_lists.append(self.backend.search_bm25(query))
+        if query_type in ("hybrid", "vector"):
+            ranked_lists.append(self.backend.search_vector(query))
+
+        entity_id = self.entity_resolver.resolve(text)   # None on miss
+        if entity_id:
+            ranked_lists.append(self.kg_proximity.search(entity_id, k=k, filters=filters))
+
+        if len(ranked_lists) == 1:
+            return deduplicate(ranked_lists[0])
+        fused = rrf_fuse(ranked_lists, signal_weights=signal_weights or {},
+                         tier_weights=tier_weights or TIER_WEIGHTS)
+        return deduplicate(fused)
+```
+
+### 4. Graceful Degradation
+
+If `entity_resolver.resolve()` returns `None` (no known entity in the query), KG proximity is
+skipped and RRF runs over two signals. No error, no degradation of the BM25 + vector result.
+
+## Key Decisions
+
+1. **BFS over the KG, max 3 hops.**
+   - **Decision**: Limit traversal to 3 hops.
+   - **Rationale**: Score decays as `1/(hop+1)` (a 3-hop node contributes 0.25 vs 1.0 for a direct
+     connection); also bounds compute on large graphs.
+2. **Entity resolution before traversal; graceful skip on failure.**
+   - **Decision**: Resolve the query to a canonical entity first; skip KG entirely if unresolved.
+   - **Rationale**: KG proximity is only meaningful with a canonical entity to traverse from.
+
+## Alternatives Considered
+
+1. **Embed the KG structure into vectors (node2vec-style) instead of live traversal.**
+   - **Pros**: One vector signal; no traversal at query time.
+   - **Cons**: Requires retraining on graph change; loses exact hop semantics; opaque.
+   - **Why rejected**: Live typed-edge traversal is interpretable and cheap at this scale.
+2. **Use `MENTIONS` edges only (ship without new edge types).**
+   - **Pros**: No KG schema work.
+   - **Cons**: `MENTIONS` (topic/entity → episode) is too coarse for person-position proximity.
+   - **Why rejected**: The signal's value comes from the richer typed ontology; ship after edges.
+
+## Testing Strategy
+
+**Test Coverage:**
+
+- **Unit**: BFS traversal correctness, score decay by hop, `k`-truncation, filter application,
+  graceful skip on unresolved entity.
+- **Integration**: KG signal changes ranking for entity queries on a fixture KG; two-signal
+  fallback identical to RFC-090 output when entity unresolved.
+
+**Test Organization:** `tests/unit/podcast_scraper/search/test_kg_proximity.py`; fixture KG built
+from a small committed corpus slice with the new typed edges.
+
+**Test Execution:** Unit in `ci-fast`; eval contribution measured in the RFC-090 eval harness
+(hybrid+KG vs hybrid).
+
+## Rollout & Monitoring
+
+**Rollout Plan:**
+
+- **Phase 0 — Prerequisites (blocking)**: KG access layer, typed edges in KG extraction, entity
+  resolver. Tracked in #849.
+- **Phase 1 — KG proximity**: `KGProximitySearch`, wire into `RetrievalLayer`, signal weight for
+  `kg` in `SIGNAL_WEIGHTS`, tests.
+
+**Monitoring:** `make search-kg-index` builds/refreshes adjacency; track p99 traversal latency and
+KG-signal contribution to nDCG.
+
+**Success Criteria:** KG signal improves nDCG@10 on entity/relational queries over hybrid-only,
+with no regression on unresolved-entity queries.
+
+## Relationship to Other RFCs
+
+This RFC is signal 3 of 3 in the Search initiative.
+
+**Key Distinction:**
+
+- **RFC-090**: BM25 + vector + RRF foundation (the slot).
+- **RFC-091 (this)**: KG proximity signal (fills the slot) — gated on KG/resolver prerequisites.
+- **RFC-092 / RFC-093**: router and context packs (independent of this RFC's prerequisites).
+
+| RFC | Relationship |
+| --- | --- |
+| RFC-090 | Provides the reserved third-list slot and RRF fusion (hard dependency) |
+| RFC-072 | Entity resolver uses the canonical identity layer (Partial — resolver pending) |
+| RFC-088 | Contradiction signals; when modelled as typed KG edges, they surface via proximity |
+
+## Benefits
+
+1. **A signal no generic search tool has**: domain-specific graph proximity.
+2. **Interpretable**: exact hop semantics, not opaque graph embeddings.
+3. **Additive and safe**: fills a reserved slot; degrades gracefully to two signals.
+
+## Migration Path
+
+1. **Phase 0**: Build prerequisites (graph access, typed edges, resolver) behind feature flags.
+2. **Phase 1**: Enable KG signal in `RetrievalLayer`; A/B against hybrid-only in eval.
+3. **Phase 2**: Promote adjacency pre-computation if live BFS latency is unacceptable (OQ-1).
+
+## Open Questions
+
+1. **OQ-1 KG adjacency pre-computation.** Live BFS vs cached adjacency list (node → [(neighbor,
+   hop)]) at index-build time. Trade-off: stale cache vs live cost. Likely fine live at current
+   scale; revisit on p99 latency.
+2. **OQ-2 Entity resolver precision.** A false positive (wrong entity ID) produces a misleading
+   signal. Conservative resolution (return `None` when unsure) is safer than aggressive matching.
+3. **OQ-3 Typed-edge backfill.** Adding `SPEAKER_OF`/`IN_EPISODE`/`FROM_SHOW`/`COVERS`/
+   `MENTIONED_IN` requires re-running KG extraction over the corpus. Sequence vs the RFC-090
+   migration.
+
+## References
+
+- **Related PRD**: `docs/prd/PRD-032-hybrid-corpus-search.md`
+- **Related RFC**: `docs/rfc/RFC-090-hybrid-retrieval.md`,
+  `docs/rfc/RFC-072-canonical-identity-layer-cross-layer-bridge.md`
+- **Source Code**: `src/podcast_scraper/kg/` (artifact loaders — no traversal API yet),
+  `src/podcast_scraper/identity/slugify.py` (slug only — no resolver),
+  `src/podcast_scraper/gi/about_edges.py` (existing `ABOUT` edges)
+- **Prerequisites**: issue #849 (KG depth survivors of #466) · **Parent epic**: #466 (superseded)

--- a/docs/rfc/RFC-092-ml-query-router.md
+++ b/docs/rfc/RFC-092-ml-query-router.md
@@ -1,0 +1,209 @@
+# RFC-092: ML Query Router
+
+- **Status**: Draft
+- **Authors**: Marko
+- **Stakeholders**: Core team
+- **Related PRDs**:
+  - `docs/prd/PRD-032-hybrid-corpus-search.md` — hybrid corpus search
+  - `docs/prd/PRD-031-search.md` — Search product
+- **Related RFCs**:
+  - `docs/rfc/RFC-090-hybrid-retrieval.md` — ships the rules-based router this replaces
+  - `docs/rfc/RFC-057-autoresearch-optimization-loop.md` — eval loop that produces labeled queries
+- **Related Documents**:
+  - `config/search.yaml` — router mode switch
+
+> **Stabilization note (2026-05-30):** Split out of an earlier combined draft (RFC-079). This is the
+> ML-router concern only. Of the three RFC-079 splits, **this one has its prerequisites met** — it
+> needs labeled query data (from the eval loop), not new architecture — so it is the most readily
+> shippable once data exists. It supersedes the rules-based router in RFC-090 §3.6 via a config
+> switch; the rules router remains the default until the ML model is trained.
+
+---
+
+## Abstract
+
+Upgrade the RFC-090 rules-based query router to an ML classifier. Input is the query text; output
+is one of `{entity_lookup, raw_evidence, temporal_tracking, cross_show_synthesis, semantic}`, which
+selects signal and tier weights for retrieval. The model is a small fine-tuned sentence-transformer
+classification head exported to ONNX for local inference. Activation is config-driven; the rules
+router stays the default until the model is trained on ≥500 labeled queries.
+
+**Architecture Alignment:** Implements the existing `QueryRouter` interface
+(`src/podcast_scraper/search/router.py`) so `RulesQueryRouter` and `MLQueryRouter` are
+interchangeable behind a config flag. No retrieval-layer change. ONNX local inference keeps the
+no-cloud-dependency constraint (runs on Apple M-series via ONNX Runtime).
+
+## Problem Statement
+
+The RFC-090 rules router covers obvious cases (capitalised names → entity lookup, "compare" →
+synthesis) but has systematic blind spots: ambiguous queries, novel phrasings, and domain-specific
+language misclassify. Misclassification degrades to sub-optimal signal/tier weights (RRF is robust,
+so not wrong results — but worse ranking). An ML classifier trained on real query data is more
+robust and improves continuously as query patterns emerge from the eval loop.
+
+**Use Cases:**
+
+1. **Ambiguous phrasing**: "what did the field think about scaling laws over the last year" should
+   route to `temporal_tracking` even without an explicit date token.
+2. **Domain language**: corpus-specific terminology routes correctly without hand-written rules.
+3. **Continuous improvement**: misrouted queries corrected in the eval loop become training data.
+
+## Goals
+
+1. **Drop-in ML classifier** behind the existing `QueryRouter` interface.
+2. **Local inference** via ONNX Runtime — no cloud dependency, cheap redeploy (replace file).
+3. **Config-switchable** (`router.mode: rules | ml`) with the rules router as default.
+4. **Trained on real data** — silver labels from the rules router + human corrections.
+
+## Constraints & Assumptions
+
+**Constraints:**
+
+- Local inference only (ONNX Runtime on M-series MPS/CPU); no inference-time cloud calls.
+- Label space is fixed at 5 classes; input is short text.
+
+**Assumptions:**
+
+- The eval loop (RFC-057) and viewer Search usage can produce ≥500 labeled queries before training
+  is worthwhile.
+- A ~100M-parameter encoder with a classification head is sufficient for 5-class short-text
+  routing.
+
+## Design & Implementation
+
+### 1. Classifier Design
+
+- **Input**: query text string.
+- **Output**: one of `{entity_lookup, raw_evidence, temporal_tracking, cross_show_synthesis,
+  semantic}`.
+- **Model**: fine-tuned sentence-transformer classification head; ONNX export for local inference.
+- **Training data**: query logs from the eval loop + viewer Search usage, labeled by (1) automatic
+  silver labels from the rules router, (2) human correction of misclassified queries.
+
+### 2. Interface
+
+```python
+# src/podcast_scraper/search/router.py
+
+class QueryRouter:
+    def classify(self, text: str) -> str: ...
+    def signal_weights(self, query_type: str) -> dict: ...
+    def tier_weights(self, query_type: str) -> dict: ...
+
+class RulesQueryRouter(QueryRouter):
+    """RFC-090 rules-based implementation. Default until the ML router is trained."""
+    def classify(self, text: str) -> str:
+        ...   # existing keyword/regex logic from RFC-090 §3.6
+
+class MLQueryRouter(QueryRouter):
+    """ONNX-exported classifier. Activated via config once trained."""
+    def __init__(self, model_path: str):
+        import onnxruntime as ort
+        self.session = ort.InferenceSession(model_path)
+        self.tokenizer = ...   # matching tokenizer
+
+    def classify(self, text: str) -> str:
+        inputs = self.tokenizer(text, return_tensors="np")
+        logits = self.session.run(None, dict(inputs))[0]
+        return QUERY_TYPES[logits.argmax()]
+```
+
+### 3. Config-Driven Activation
+
+```yaml
+# config/search.yaml
+router:
+  mode: rules                                   # "rules" | "ml"
+  ml_model_path: ./models/query_router.onnx     # only used if mode: ml
+```
+
+## Key Decisions
+
+1. **ML router as ONNX, local inference.**
+   - **Decision**: Export to ONNX; run locally.
+   - **Rationale**: No cloud dependency; M-series runs ONNX Runtime efficiently; redeploy is a file
+     swap + restart.
+2. **Rules router stays the default.**
+   - **Decision**: Ship `mode: rules` until the model is trained and A/B-validated.
+   - **Rationale**: No regression risk before data exists; switch is one config line.
+
+## Alternatives Considered
+
+1. **LLM-based intent classification (API call per query).**
+   - **Pros**: No training; flexible.
+   - **Cons**: Per-query latency/cost; cloud dependency; overkill for 5 classes.
+   - **Why rejected**: Violates the local-first constraint; a small local classifier suffices.
+2. **Expand the rules router indefinitely.**
+   - **Pros**: No model.
+   - **Cons**: Rule sprawl; brittle on novel phrasings; no continuous improvement.
+   - **Why rejected**: ML generalizes from real data the rules can't anticipate.
+
+## Testing Strategy
+
+**Test Coverage:**
+
+- **Unit**: `MLQueryRouter.classify()` returns valid labels; config switch selects the right
+  implementation; tokenizer/ONNX I/O shape.
+- **Eval**: ML router vs rules router on a held-out query set with **human** labels (not
+  rules-router silver labels).
+
+**Test Organization:** `tests/unit/podcast_scraper/search/test_router.py`;
+`src/podcast_scraper/eval/router_eval.py` for the A/B harness.
+
+**Test Execution:** Unit in `ci-fast`; router eval is an operator/CI job, not per-PR.
+
+## Rollout & Monitoring
+
+**Rollout Plan:**
+
+- **Phase 1 — Data collection**: instrument query logging in the eval loop and viewer Search;
+  accumulate to ≥500 labeled queries.
+- **Phase 2 — Train + export**: silver labels + human corrections; ONNX export; A/B eval.
+- **Phase 3 — Switch**: flip `router.mode: ml` once the ML router beats rules on held-out human
+  labels.
+
+**Monitoring:** Track classification accuracy on the held-out set; track query-refinement rate
+(PRD-031 success metric) as a proxy for routing quality in production.
+
+**Success Criteria:** ML router ≥ rules router on held-out human-labeled accuracy; query-refinement
+rate trends down after the switch.
+
+## Relationship to Other RFCs
+
+**Key Distinction:**
+
+- **RFC-090**: ships the rules router (baseline) and the weight tables the router selects.
+- **RFC-092 (this)**: replaces the router's `classify()` with an ML model behind the same interface.
+
+| RFC | Relationship |
+| --- | --- |
+| RFC-090 | Defines `QueryRouter`, `SIGNAL_WEIGHTS`, `TIER_WEIGHTS_BY_QUERY`; this RFC swaps `classify()` |
+| RFC-057 | Autoresearch eval loop is the training-data source |
+
+## Benefits
+
+1. **Robust routing** on ambiguous/novel phrasings the rules miss.
+2. **Continuous improvement** as eval-loop corrections feed retraining.
+3. **No cloud dependency** — local ONNX inference; cheap redeploy.
+
+## Migration Path
+
+1. **Phase 1**: Add query logging; keep `mode: rules`.
+2. **Phase 2**: Train, export ONNX, validate A/B.
+3. **Phase 3**: Flip `mode: ml`; retain `rules` as instant rollback.
+
+## Open Questions
+
+1. **OQ-1 Training-data quality.** Silver labels from the rules router are noisy precisely on the
+   queries the ML router is meant to fix. Do a human annotation pass on a stratified sample before
+   training; eval on human labels, not rules-router labels.
+2. **OQ-2 Class boundary drift.** As query patterns evolve, the 5-class taxonomy may need a sixth
+   class (e.g. explicit `corpus_coverage`). Version the label space.
+
+## References
+
+- **Related PRD**: `docs/prd/PRD-032-hybrid-corpus-search.md`
+- **Related RFC**: `docs/rfc/RFC-090-hybrid-retrieval.md`,
+  `docs/rfc/RFC-057-autoresearch-optimization-loop.md`
+- **Source Code**: `src/podcast_scraper/search/router.py` (rules router from RFC-090)
+- **Config**: `config/search.yaml`

--- a/docs/rfc/RFC-093-litm-context-packs.md
+++ b/docs/rfc/RFC-093-litm-context-packs.md
@@ -1,0 +1,274 @@
+# RFC-093: LITM-Aware MCP Context Packs
+
+- **Status**: Draft
+- **Authors**: Marko
+- **Stakeholders**: Core team
+- **Related PRDs**:
+  - `docs/prd/PRD-032-hybrid-corpus-search.md` — hybrid corpus search
+  - `docs/prd/PRD-031-search.md` — Search product (agent endpoint, V3)
+- **Related RFCs**:
+  - `docs/rfc/RFC-090-hybrid-retrieval.md` — produces the results this packages
+  - `docs/rfc/RFC-091-kg-proximity-signal.md` — contradiction/relational inputs
+  - `docs/rfc/RFC-088-enrichment-layer-architecture.md` — contradiction signals
+- **Related Documents**:
+  - _(MCP tool layer — does not exist yet; see Constraints)_
+
+> **Stabilization note (2026-05-30):** Split out of an earlier combined draft (RFC-079). This is the
+> LITM-context-pack / MCP-tool concern only. **Blocking prerequisite:** there is no MCP tool layer
+> in this repo (`src/podcast_scraper/mcp/` does not exist, no `@mcp_tool` decorator). The original
+> draft referenced an "RFC-075 MCP integration layer" that does not exist here — that layer is
+> **[TBD — not yet specified]** and must be defined before this RFC can land its tool. The pack
+> *builder* (below) is implementable independently of MCP and is useful to the autoresearch loop
+> directly.
+
+---
+
+## Abstract
+
+Reshape RFC-090 retrieval output into a structured, token-budgeted, LITM-positioned context
+document for agent consumers. LITM (Lost-In-The-Middle) is well-validated: models attend poorly to
+the middle of long contexts. A `corpus_briefing_pack` builder positions critical grounding at the
+start and caveats at the end, extracting materially more value from the same retrieval results. The
+builder is plain Python; exposing it as an MCP tool requires an MCP layer that does not exist yet.
+
+**Architecture Alignment:** `build_briefing_pack()` consumes `RetrievalLayer` output
+(`ScoredResult` / `CompoundResult`) and produces a `CorpusBriefingPack` dataclass — no retrieval
+change. The MCP wrapper is additive and gated on the MCP layer.
+
+## Problem Statement
+
+RFC-075-style MCP tools (in the original draft's world) returned raw `ScoredResult` lists. Agents
+consuming raw lists face: no signal about what to attend to first, LITM degradation on long lists,
+no token-budget management, and no distinction between grounded insight and raw evidence. A
+briefing pack solves all four by selecting and positioning results into a fixed attention-aware
+structure within a token budget.
+
+In this repo there is an additional gap: **no MCP layer exists** to host the tool. The pack builder
+is still valuable standalone — the autoresearch loop can call it directly.
+
+**Use Cases:**
+
+1. **Research synthesis**: an agent preparing a briefing gets grounded intelligence, not a list to
+   re-rank itself.
+2. **Token-budgeted context**: the pack fits a `max_tokens` budget, positioning the strongest
+   grounding where attention is highest.
+3. **Direct autoresearch use**: the loop calls the builder without an MCP round-trip.
+
+## Goals
+
+1. **LITM-structured pack**: critical grounding first, supporting evidence middle, caveats last.
+2. **Token-budgeted**: select within `max_tokens`; report actual usage.
+3. **Tier-aware**: distinguish grounded insight from raw segment; unpack compound results.
+4. **MCP-ready (gated)**: a thin `corpus_briefing_pack` tool once an MCP layer exists.
+
+## Constraints & Assumptions
+
+**Constraints — Prerequisites:**
+
+1. **MCP tool layer does not exist** (`src/podcast_scraper/mcp/` absent; no `@mcp_tool`). The tool
+   wrapper is blocked on defining that layer **[TBD — not yet specified]**. The builder is not
+   blocked.
+2. **Contradiction content** (`top_contradiction`) requires typed contradiction KG edges, which do
+   not exist yet (RFC-088 / RFC-091 OQ). The field is `None` until then.
+3. **Coverage gaps** require a corpus-impact / coverage surface that does not exist yet
+   **[TBD]**; the field is empty until then.
+
+**Assumptions:**
+
+- `RetrievalLayer` output carries `source_tier` and per-result `payload` (`confidence`, `show_id`,
+  `episode_id`, dates) sufficient to compute coverage and confidence summaries.
+
+## Design & Implementation
+
+### 1. LITM Structure
+
+```text
+[WINDOW START — high attention]
+  Critical grounding:
+  - Canonical entity definition (who/what is being asked about)
+  - Strongest grounded insight (highest confidence, most relevant)
+  - Most significant contradiction (if any)   <- None until typed edges exist
+
+[MIDDLE — lower attention, supporting detail]
+  Supporting evidence:
+  - Top-N segment results (raw evidence with timestamps)
+  - Cross-show coverage summary (which shows, how many episodes)
+
+[WINDOW END — high attention]
+  Caveats and metadata:
+  - Coverage gaps (topics/shows not represented)   <- empty until coverage surface exists
+  - Confidence distribution
+  - Temporal range of evidence
+```
+
+### 2. Pack Builder
+
+```python
+# src/podcast_scraper/search/context_pack.py
+
+@dataclass
+class CorpusBriefingPack:
+    query: str
+    query_type: str
+    canonical_entity: dict | None          # RFC-072 canonical entity if resolved
+    top_insight: ScoredResult | None
+    top_contradiction: dict | None         # from typed KG edges (not yet built)
+    supporting_segments: list[ScoredResult]
+    coverage_summary: dict                  # show_ids, episode_count, date_range
+    coverage_gaps: list[str]                # from corpus-impact surface (not yet built)
+    confidence_p50: float
+    token_count: int
+
+def build_briefing_pack(query, query_type, results, canonical_entity, max_tokens=2000):
+    """Select and position results into a LITM-aware structure within token budget."""
+    insights  = [r for r in results if getattr(r, "source_tier", "") == "insight"]
+    segments  = [r for r in results if getattr(r, "source_tier", "") == "segment"]
+    compounds = [r for r in results if getattr(r, "source_tier", "") == "compound"]
+
+    all_insights = insights + [r.insight for r in compounds]
+    all_segments = segments + [r.segment for r in compounds]
+    top_insight = all_insights[0] if all_insights else None
+
+    coverage = {
+        "show_ids": list({r.payload.get("show_id") for r in results}),
+        "episode_count": len({r.payload.get("episode_id") for r in results}),
+        "date_range": _compute_date_range(results),
+    }
+    confs = [r.payload.get("confidence", 0) for r in all_insights if r.payload.get("confidence")]
+    p50 = sorted(confs)[len(confs) // 2] if confs else 0.0
+
+    return CorpusBriefingPack(
+        query=query, query_type=query_type, canonical_entity=canonical_entity,
+        top_insight=top_insight,
+        top_contradiction=None,              # until typed contradiction edges exist
+        supporting_segments=all_segments[:5],
+        coverage_summary=coverage,
+        coverage_gaps=[],                    # until corpus-impact surface exists
+        confidence_p50=p50, token_count=0,   # set after serialisation
+    )
+```
+
+### 3. MCP Tool (gated on MCP layer)
+
+```python
+# src/podcast_scraper/mcp/tools/corpus_briefing_pack.py   <- requires MCP layer (does not exist)
+
+@mcp_tool(
+    name="corpus_briefing_pack",
+    description="""
+    Returns a LITM-aware, token-budgeted context pack for a corpus query.
+    Use instead of raw search results for research synthesis or briefing prep.
+    Returns: canonical entity, strongest grounded insight, detected contradictions,
+    supporting raw evidence, coverage summary, confidence distribution.
+    When NOT to use: exhaustive raw results, or debugging the retrieval pipeline —
+    use corpus_search instead.
+    """,
+)
+def corpus_briefing_pack(query: str, max_tokens: int = 2000) -> CorpusBriefingPack:
+    query_type = router.classify(query)
+    results = retrieval_layer.retrieve(
+        text=query, embedding=embed(query), query_type=query_type,
+        signal_weights=SIGNAL_WEIGHTS[query_type],
+        tier_weights=TIER_WEIGHTS_BY_QUERY[query_type],
+    )
+    canonical_entity = entity_resolver.resolve(query)
+    return build_briefing_pack(query, query_type, results, canonical_entity, max_tokens)
+```
+
+## Key Decisions
+
+1. **Builder decoupled from MCP.**
+   - **Decision**: `build_briefing_pack()` is plain Python over `RetrievalLayer` output.
+   - **Rationale**: Usable by autoresearch directly; not blocked on the MCP layer.
+2. **Packs in RFC-093, not RFC-090.**
+   - **Decision**: Defer packs to this RFC.
+   - **Rationale**: Full value depends on KG proximity (contradictions) and the router
+     (query_type accuracy); shipping in RFC-090 would produce worse packs.
+3. **Contradiction/coverage fields present but null until inputs exist.**
+   - **Decision**: Keep `top_contradiction` / `coverage_gaps` in the schema, populated later.
+   - **Rationale**: Stable consumer schema; no breaking change when typed edges / coverage surface
+     land.
+
+## Alternatives Considered
+
+1. **Return raw `ScoredResult` lists to agents.**
+   - **Pros**: Simplest.
+   - **Cons**: LITM degradation; no budget; agents re-rank themselves.
+   - **Why rejected**: The whole point is shaped, attention-aware context.
+2. **Generate the pack with an LLM summarisation call.**
+   - **Pros**: Fluent prose.
+   - **Cons**: Cost/latency; hallucination risk; loses provenance.
+   - **Why rejected**: Packs must be extractive and grounded, not generated.
+
+## Testing Strategy
+
+**Test Coverage:**
+
+- **Unit**: pack structure (sections populated in order), compound unpacking into insight/segment,
+  coverage/confidence computation, null-safety for contradiction/coverage fields.
+- **Integration**: token-budget enforcement; pack built end-to-end from `RetrievalLayer` output on
+  a fixture corpus.
+
+**Test Organization:** `tests/unit/podcast_scraper/search/test_context_pack.py`.
+
+**Test Execution:** Unit in `ci-fast`; no MCP integration test until the MCP layer exists.
+
+## Rollout & Monitoring
+
+**Rollout Plan:**
+
+- **Phase 1 — Builder**: `CorpusBriefingPack` + `build_briefing_pack()` + serialisation/token
+  counting; wire into autoresearch as a direct consumer.
+- **Phase 2 — MCP tool (gated)**: once an MCP layer is defined, add the `corpus_briefing_pack`
+  wrapper.
+- **Phase 3 — Enrichment**: populate `top_contradiction` (typed edges) and `coverage_gaps`
+  (corpus-impact surface) when those exist.
+
+**Monitoring:** Track actual token usage vs budget; track agent task quality with packs vs raw
+lists in the eval loop.
+
+**Success Criteria:** Packs stay within budget; agents using packs outperform agents using raw
+lists on the eval task set.
+
+## Relationship to Other RFCs
+
+**Key Distinction:**
+
+- **RFC-090/091/092**: produce and rank results.
+- **RFC-093 (this)**: packages results for agent attention; does not retrieve.
+
+| RFC | Relationship |
+| --- | --- |
+| RFC-090 | Provides `RetrievalLayer` output consumed by the builder |
+| RFC-091 | Contradiction/relational inputs (when typed edges exist) |
+| RFC-088 | Enrichment produces contradiction signals to model as edges |
+
+## Benefits
+
+1. **More value per token** for agents via LITM positioning.
+2. **Provenance-preserving** — extractive, not generated.
+3. **Stable schema** — contradiction/coverage fields slot in later without breaking consumers.
+
+## Migration Path
+
+1. **Phase 1**: Ship the builder; autoresearch consumes it directly.
+2. **Phase 2**: Define the MCP layer (separate RFC), then add the tool wrapper.
+3. **Phase 3**: Populate contradiction/coverage fields as their inputs land.
+
+## Open Questions
+
+1. **OQ-1 MCP layer definition.** This repo has no MCP layer. Define it (separate RFC/issue) before
+   the tool wrapper; until then the builder is autoresearch-only.
+2. **OQ-2 Contradiction-edge dependency.** `top_contradiction` is `None` until typed contradiction
+   KG edges exist. Define the contradiction-as-edge RFC (extension to RFC-088) or this field is
+   permanently null.
+3. **OQ-3 Token counting accuracy.** Which tokenizer defines the budget (consumer-model-specific)?
+   Pick one canonical tokenizer for `token_count`.
+
+## References
+
+- **Related PRD**: `docs/prd/PRD-032-hybrid-corpus-search.md`
+- **Related RFC**: `docs/rfc/RFC-090-hybrid-retrieval.md`, `docs/rfc/RFC-091-kg-proximity-signal.md`,
+  `docs/rfc/RFC-088-enrichment-layer-architecture.md`
+- **Source Code**: `src/podcast_scraper/search/` (RetrievalLayer output), `autoresearch/` (direct
+  consumer); MCP layer — does not exist yet

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,9 @@ nav:
       - PRD-028 Position Tracker: prd/PRD-028-position-tracker.md
       - PRD-029 Person Profile: prd/PRD-029-person-profile.md
       - PRD-030 Viewer Operator Surface — Feeds, Config, Jobs: prd/PRD-030-viewer-feed-sources-and-pipeline-jobs.md
+      - PRD-031 Search: prd/PRD-031-search.md
+      - PRD-032 Hybrid Corpus Search: prd/PRD-032-hybrid-corpus-search.md
+      - PRD-033 Search-Powered Surface Enhancements: prd/PRD-033-search-powered-surfaces.md
       - PRD Template: prd/PRD_TEMPLATE.md
   - UX Specifications:
       - uxs/index.md
@@ -328,6 +331,11 @@ nav:
       - RFC-086 Viewer Three-Tier Test Pyramid + Production-Shaped Fixtures: rfc/RFC-086-viewer-test-pyramid-and-production-shaped-fixtures.md
       - RFC-087 VPS Public Edge and Multi-Compose Hosting: rfc/RFC-087-vps-public-edge-multi-compose.md
       - RFC-088 Enrichment Layer Architecture: rfc/RFC-088-enrichment-layer-architecture.md
+      - RFC-089 DGX Spark — Tailnet-Integrated AI Workhorse: rfc/RFC-089-dgx-spark-tailnet-integration.md
+      - RFC-090 Hybrid Retrieval Pipeline: rfc/RFC-090-hybrid-retrieval.md
+      - RFC-091 KG Proximity Signal: rfc/RFC-091-kg-proximity-signal.md
+      - RFC-092 ML Query Router: rfc/RFC-092-ml-query-router.md
+      - RFC-093 LITM-Aware MCP Context Packs: rfc/RFC-093-litm-context-packs.md
       - RFC Template: rfc/RFC_TEMPLATE.md
   - API:
       - API Overview: api/index.md

--- a/scripts/eval_entity_canonicalization.py
+++ b/scripts/eval_entity_canonicalization.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Eval the KG entity-canonicalization prompt change (#851 Slice 2).
+
+Measures, on a real corpus, whether the current KG extraction prompt collapses
+same-episode duplicate-spelling entities (e.g. "Burne Hobart" + "Byrne Hobart")
+at the source. For each episode that *currently* has near-duplicate person/org
+nodes in its committed ``*.kg.json``, this re-extracts entities from the episode
+transcript with the live prompt and reports BEFORE vs AFTER duplicate counts.
+
+This is a manual eval (live LLM calls + a local corpus), not a unit test.
+
+Requirements:
+  - A provider API key (reads ``.env`` if present, else the process env).
+  - A corpus dir with ``*.kg.json`` artifacts + their transcripts.
+
+Usage:
+  python scripts/eval_entity_canonicalization.py \
+      --corpus-dir .test_outputs/manual/my-manual-run-10 \
+      --model gpt-4o-mini --limit 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import glob
+import itertools
+import json
+import os
+import sys
+from pathlib import Path
+
+# Allow running from the repo root without installation.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from podcast_scraper.builders.bridge_builder import strip_layer_prefixes  # noqa: E402
+from podcast_scraper.kg.llm_extract import (  # noqa: E402
+    build_kg_transcript_system_prompt,
+    build_kg_user_prompt,
+    parse_kg_graph_response,
+    truncate_transcript_for_kg,
+)
+
+NEAR_DUP_RATIO = 0.85
+
+
+def load_dotenv(path: str = ".env") -> None:
+    """Load KEY=VALUE pairs from .env into os.environ (values never printed)."""
+    if not os.path.exists(path):
+        return
+    for line in open(path):
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+def _entities(artifact: dict) -> list[tuple[str, str]]:
+    """Return [(name, kind)] for person/org nodes in a kg artifact."""
+    out = []
+    for node in artifact.get("nodes", []):
+        nid = strip_layer_prefixes(str(node.get("id", "")))
+        prefix = nid.split(":", 1)[0]
+        if prefix in ("person", "org"):
+            props = node.get("properties", {}) or {}
+            name = props.get("name") or props.get("label") or ""
+            if name:
+                out.append((name, prefix))
+    return out
+
+
+def _near_dup_pairs(entities: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    pairs = []
+    for (na, ka), (nb, kb) in itertools.combinations(entities, 2):
+        if ka != kb or na.lower() == nb.lower():
+            continue
+        if difflib.SequenceMatcher(None, na.lower(), nb.lower()).ratio() >= NEAR_DUP_RATIO:
+            pairs.append((na, nb))
+    return pairs
+
+
+def _transcript_index(corpus_dir: str) -> dict[str, str]:
+    idx: dict[str, str] = {}
+    for t in glob.glob(f"{corpus_dir}/**/transcripts/*.txt", recursive=True):
+        if "reprocess-backup" in t:
+            continue
+        idx.setdefault(os.path.basename(t), t)
+    return idx
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--corpus-dir", required=True)
+    ap.add_argument("--model", default="gpt-4o-mini")
+    ap.add_argument("--limit", type=int, default=5, help="max dup episodes to re-extract")
+    ap.add_argument("--max-entities", type=int, default=15)
+    args = ap.parse_args()
+
+    load_dotenv()
+    if not os.environ.get("OPENAI_API_KEY"):
+        print("ERROR: OPENAI_API_KEY not set (add to .env or env).", file=sys.stderr)
+        return 2
+
+    tidx = _transcript_index(args.corpus_dir)
+
+    # Find episodes whose committed KG artifact already has near-duplicate entities.
+    targets: list[tuple[str, list[tuple[str, str]]]] = []
+    for f in glob.glob(f"{args.corpus_dir}/**/*.kg.json", recursive=True):
+        if "reprocess-backup" in f or "/.cache/" in f:
+            continue
+        try:
+            data = json.load(open(f))
+        except Exception:
+            continue
+        pairs = _near_dup_pairs(_entities(data))
+        if not pairs:
+            continue
+        tref = (data.get("extraction") or {}).get("transcript_ref") or ""
+        tname = os.path.basename(tref)
+        if tname in tidx:
+            targets.append((tname, pairs))
+
+    # De-dup episodes; cap to --limit.
+    seen, uniq = set(), []
+    for tname, pairs in targets:
+        if tname in seen:
+            continue
+        seen.add(tname)
+        uniq.append((tname, pairs))
+    uniq = uniq[: args.limit]
+
+    if not uniq:
+        print("No dup episodes found in corpus — nothing to eval.")
+        return 0
+
+    from openai import OpenAI
+
+    client = OpenAI()
+    print(f"Re-extracting {len(uniq)} dup episode(s) with model={args.model}\n")
+
+    before_total = after_total = 0
+    for tname, before_pairs in uniq:
+        txt = truncate_transcript_for_kg(open(tidx[tname], errors="ignore").read())
+        system = build_kg_transcript_system_prompt(5, args.max_entities)
+        user = build_kg_user_prompt(txt, "", 5, args.max_entities)  # default prompt version
+        resp = client.chat.completions.create(
+            model=args.model,
+            messages=[{"role": "system", "content": system}, {"role": "user", "content": user}],
+            temperature=0.1,
+            max_tokens=2048,
+        )
+        parsed = parse_kg_graph_response(resp.choices[0].message.content) or {}
+        fresh = [
+            (e.get("name", ""), (e.get("entity_kind") or "person"))
+            for e in parsed.get("entities", [])
+            if isinstance(e, dict) and e.get("name")
+        ]
+        after_pairs = _near_dup_pairs(fresh)
+        before_total += len(before_pairs)
+        after_total += len(after_pairs)
+        status = "PASS" if len(after_pairs) < len(before_pairs) or not after_pairs else "STILL-DUP"
+        print(f"[{status}] {tname[:60]}")
+        print(f"    before: {before_pairs}")
+        print(f"    after : {after_pairs or 'no near-dup pairs'}\n")
+
+    print(f"TOTAL near-dup pairs: before={before_total}  after={after_total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/podcast_scraper/builders/bridge_builder.py
+++ b/src/podcast_scraper/builders/bridge_builder.py
@@ -265,3 +265,12 @@ def build_bridge(
     if fuzzy_merges:
         result["fuzzy_merges"] = fuzzy_merges
     return result
+
+
+# Public aliases — shared identity helpers reused by the corpus-wide entity
+# resolver (``identity/resolver.py``). These wrap the per-episode bridge logic so
+# the resolver can aggregate identities across the whole corpus without
+# duplicating the collection / fuzzy-reconciliation machinery.
+collect_identity = _collect_identity
+fuzzy_reconcile = _fuzzy_reconcile
+strip_layer_prefixes = _strip_layer_prefixes

--- a/src/podcast_scraper/identity/resolver.py
+++ b/src/podcast_scraper/identity/resolver.py
@@ -26,6 +26,7 @@ issue #849 for the prerequisite tracking.
 from __future__ import annotations
 
 import logging
+import threading
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -306,3 +307,36 @@ class EntityResolver:
             return ResolveResult(fuzzy[0], fuzzy[1], "fuzzy")
 
         return None
+
+
+# Process-level registry cache (mirrors search/corpus_graph + embedding_loader):
+# building a registry scans the whole corpus and embeds every display name, so it
+# must not be rebuilt per query. Keyed by resolved corpus path + threshold + model.
+_entity_registries: Dict[Tuple[str, float, str], EntityRegistry] = {}
+_entity_registries_lock = threading.Lock()
+
+
+def get_entity_resolver(
+    corpus_dir: Path | str,
+    *,
+    embedder: Any = None,
+    model_id: str = DEFAULT_EMBED_MODEL_ID,
+    fuzzy_threshold: float = DEFAULT_FUZZY_THRESHOLD,
+) -> EntityResolver:
+    """Return an ``EntityResolver`` backed by a process-cached corpus registry."""
+    key = (str(Path(corpus_dir).resolve()), float(fuzzy_threshold), str(model_id))
+    with _entity_registries_lock:
+        if key not in _entity_registries:
+            _entity_registries[key] = build_entity_registry(
+                corpus_dir,
+                embedder=embedder,
+                model_id=model_id,
+                fuzzy_threshold=fuzzy_threshold,
+            )
+        return EntityResolver(_entity_registries[key])
+
+
+def clear_entity_resolver_cache() -> None:
+    """Clear the registry cache (tests / after corpus re-index)."""
+    with _entity_registries_lock:
+        _entity_registries.clear()

--- a/src/podcast_scraper/identity/resolver.py
+++ b/src/podcast_scraper/identity/resolver.py
@@ -86,6 +86,7 @@ class EntityRegistry:
         model_id: str = DEFAULT_EMBED_MODEL_ID,
         fuzzy_threshold: float = DEFAULT_FUZZY_THRESHOLD,
     ) -> "EntityRegistry":
+        """Build a registry from a merged ``identities`` map + episode frequencies."""
         records: Dict[str, Dict[str, Any]] = {}
         name_index: Dict[str, str] = {}
 
@@ -260,6 +261,7 @@ class EntityResolver:
         model_id: str = DEFAULT_EMBED_MODEL_ID,
         fuzzy_threshold: float = DEFAULT_FUZZY_THRESHOLD,
     ) -> "EntityResolver":
+        """Build a resolver from a corpus directory (convenience over ``build_entity_registry``)."""
         return cls(
             build_entity_registry(
                 corpus_dir,

--- a/src/podcast_scraper/identity/resolver.py
+++ b/src/podcast_scraper/identity/resolver.py
@@ -1,0 +1,308 @@
+"""File-local entity resolver — freeform text → canonical CIL id.
+
+Maps a query/mention string (e.g. ``"Sam Altman"``, ``"OpenAI"``,
+``"AI regulation"``) to a canonical identity id (``person:…`` / ``org:…`` /
+``topic:…``) by matching against a corpus-wide registry of canonical entities.
+
+The registry is aggregated from the per-episode GI and KG artifacts, reusing the
+identity-collection and fuzzy-reconciliation machinery already proven in
+``builders/bridge_builder.py`` (the per-episode bridge). The resolver is
+**conservative**: it returns ``None`` rather than guess when no confident match
+exists, because a false positive produces a misleading downstream signal (e.g.
+the KG-proximity seed in RFC-091).
+
+Resolution is layered cheap→fuzzy:
+
+1. exact canonical id (``text`` already looks like ``type:slug`` and is known)
+2. exact slug (``slugify(text)`` → ``person:/org:/topic:{slug}``)
+3. exact display-name / alias (normalized inverted-index lookup)
+4. fuzzy embedding match (cosine ≥ threshold over registry display names)
+
+See ``docs/rfc/RFC-090-hybrid-retrieval.md`` (entity filters) and
+``docs/rfc/RFC-091-kg-proximity-signal.md`` (traversal seed) for consumers, and
+issue #849 for the prerequisite tracking.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..builders.bridge_builder import (
+    collect_identity,
+    fuzzy_reconcile,
+    strip_layer_prefixes,
+)
+from .slugify import slugify
+
+logger = logging.getLogger(__name__)
+
+CIL_PREFIXES = ("person:", "org:", "topic:")
+_TYPE_PRECEDENCE = ("person", "org", "topic")
+DEFAULT_FUZZY_THRESHOLD = 0.75
+DEFAULT_EMBED_MODEL_ID = "minilm-l6"
+
+
+def _norm(text: str) -> str:
+    """Normalize a name for exact lookup: lowercase, collapse whitespace."""
+    return " ".join(str(text).lower().split())
+
+
+@dataclass
+class ResolveResult:
+    """A resolved match with provenance for debugging / eval."""
+
+    id: str
+    score: float
+    method: str  # "exact_id" | "slug" | "alias" | "fuzzy"
+
+
+@dataclass
+class EntityRegistry:
+    """Corpus-wide canonical-entity registry with exact + fuzzy lookup."""
+
+    records: Dict[str, Dict[str, Any]]  # canonical id -> {id, type, display_name, aliases, freq}
+    name_index: Dict[str, str]  # normalized display-name/alias -> canonical id
+    fuzzy_threshold: float = DEFAULT_FUZZY_THRESHOLD
+    _fuzzy_ids: List[str] = field(default_factory=list)
+    _fuzzy_matrix: Any = None  # np.ndarray (N, dim) of L2-normalized display-name embeddings
+    _model_id: str = DEFAULT_EMBED_MODEL_ID
+    _embedder: Any = None
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    @classmethod
+    def from_identities(
+        cls,
+        identities: Dict[str, Dict[str, Any]],
+        freq: Counter,
+        *,
+        embedder: Any = None,
+        model_id: str = DEFAULT_EMBED_MODEL_ID,
+        fuzzy_threshold: float = DEFAULT_FUZZY_THRESHOLD,
+    ) -> "EntityRegistry":
+        records: Dict[str, Dict[str, Any]] = {}
+        name_index: Dict[str, str] = {}
+
+        for cid, rec in identities.items():
+            display = str(rec.get("display_name", "") or "")
+            aliases = [a for a in (rec.get("aliases") or []) if isinstance(a, str)]
+            record = {
+                "id": cid,
+                "type": str(rec.get("type", "")),
+                "display_name": display,
+                "aliases": aliases,
+                "freq": int(freq.get(cid, 0)),
+            }
+            records[cid] = record
+
+            # Inverted index over display name + aliases (skip id-shaped aliases,
+            # which bridge fuzzy-merge adds purely for traceability).
+            names = [display, *aliases]
+            for name in names:
+                if not name or name.startswith(CIL_PREFIXES):
+                    continue
+                key = _norm(name)
+                if not key:
+                    continue
+                existing = name_index.get(key)
+                if existing is None or record["freq"] > records[existing]["freq"]:
+                    name_index[key] = cid
+
+        registry = cls(
+            records=records,
+            name_index=name_index,
+            fuzzy_threshold=fuzzy_threshold,
+            _model_id=model_id,
+            _embedder=embedder,
+        )
+        registry._build_fuzzy_index()
+        return registry
+
+    def _build_fuzzy_index(self) -> None:
+        """Precompute L2-normalized embeddings of display names for fuzzy match.
+
+        Degrades gracefully (fuzzy disabled) if the embedding model or numpy is
+        unavailable — mirrors ``bridge_builder`` behavior.
+        """
+        ids: List[str] = []
+        names: List[str] = []
+        for cid, rec in self.records.items():
+            display = rec.get("display_name") or ""
+            if display:
+                ids.append(cid)
+                names.append(display)
+        if not names:
+            return
+        try:
+            import numpy as np
+
+            if self._embedder is not None:
+                matrix = np.asarray(
+                    self._embedder.encode(names, normalize_embeddings=True), dtype=float
+                )
+            else:
+                from ..providers.ml.embedding_loader import encode
+
+                matrix = np.asarray(
+                    encode(names, self._model_id, normalize=True, return_numpy=True),
+                    dtype=float,
+                )
+        except Exception as exc:  # noqa: BLE001 — fuzzy is best-effort
+            logger.debug("Fuzzy index unavailable; exact-only resolution: %s", exc)
+            return
+        self._fuzzy_ids = ids
+        self._fuzzy_matrix = matrix
+
+    def _fuzzy_lookup(self, text: str) -> Optional[Tuple[str, float]]:
+        if self._fuzzy_matrix is None or not self._fuzzy_ids:
+            return None
+        try:
+            import numpy as np
+
+            from ..providers.ml.embedding_loader import encode
+
+            if self._embedder is not None:
+                qvec = np.asarray(
+                    self._embedder.encode([text], normalize_embeddings=True), dtype=float
+                )[0]
+            else:
+                qvec = np.asarray(
+                    encode(text, self._model_id, normalize=True, return_numpy=True), dtype=float
+                )
+            sims = self._fuzzy_matrix @ qvec
+            best_idx = int(sims.argmax())
+            best_score = float(sims[best_idx])
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Fuzzy lookup failed: %s", exc)
+            return None
+        if best_score >= self.fuzzy_threshold:
+            return self._fuzzy_ids[best_idx], best_score
+        return None
+
+
+def _iter_loaded(corpus_dir: Path):
+    """Yield ``(source, artifact_dict)`` for every GI and KG artifact under *corpus_dir*."""
+    from ..gi.corpus import load_gi_artifacts
+    from ..gi.explore import scan_artifact_paths as scan_gi_paths
+    from ..kg.corpus import load_kg_artifacts, scan_kg_artifact_paths
+
+    for _path, data in load_kg_artifacts(scan_kg_artifact_paths(corpus_dir)):
+        yield "kg", data
+    for _path, data in load_gi_artifacts(scan_gi_paths(corpus_dir)):
+        yield "gi", data
+
+
+def build_entity_registry(
+    corpus_dir: Path | str,
+    *,
+    embedder: Any = None,
+    model_id: str = DEFAULT_EMBED_MODEL_ID,
+    fuzzy_threshold: float = DEFAULT_FUZZY_THRESHOLD,
+    do_fuzzy_reconcile: bool = True,
+) -> EntityRegistry:
+    """Aggregate a corpus-wide canonical-entity registry from GI + KG artifacts.
+
+    Builds directly from artifacts (does not require ``bridge.json`` to have been
+    generated). Reuses ``bridge_builder.collect_identity`` to fold every
+    ``person:``/``org:``/``topic:`` node into one identity map, then runs
+    ``fuzzy_reconcile`` once at corpus scope to merge single-layer near-duplicates.
+    """
+    corpus_dir = Path(corpus_dir)
+    identities: Dict[str, Dict[str, Any]] = {}
+    freq: Counter = Counter()
+
+    for source, data in _iter_loaded(corpus_dir):
+        for node in data.get("nodes") or []:
+            if not isinstance(node, dict):
+                continue
+            nid_raw = node.get("id")
+            if nid_raw is None:
+                continue
+            sid = strip_layer_prefixes(str(nid_raw))
+            if not sid.startswith(CIL_PREFIXES):
+                continue
+            collect_identity(identities, node, source=source)
+            freq[sid] += 1
+
+    if do_fuzzy_reconcile and identities:
+        try:
+            fuzzy_reconcile(identities, threshold=fuzzy_threshold, embedder=embedder)
+        except Exception as exc:  # noqa: BLE001 — reconciliation is best-effort
+            logger.debug("Corpus fuzzy reconciliation skipped: %s", exc)
+
+    return EntityRegistry.from_identities(
+        identities,
+        freq,
+        embedder=embedder,
+        model_id=model_id,
+        fuzzy_threshold=fuzzy_threshold,
+    )
+
+
+class EntityResolver:
+    """Resolve freeform text to a canonical CIL id against a corpus registry."""
+
+    def __init__(self, registry: EntityRegistry):
+        self.registry = registry
+
+    @classmethod
+    def from_corpus(
+        cls,
+        corpus_dir: Path | str,
+        *,
+        embedder: Any = None,
+        model_id: str = DEFAULT_EMBED_MODEL_ID,
+        fuzzy_threshold: float = DEFAULT_FUZZY_THRESHOLD,
+    ) -> "EntityResolver":
+        return cls(
+            build_entity_registry(
+                corpus_dir,
+                embedder=embedder,
+                model_id=model_id,
+                fuzzy_threshold=fuzzy_threshold,
+            )
+        )
+
+    def resolve(self, text: str) -> Optional[str]:
+        """Return the canonical id for *text*, or ``None`` (conservative)."""
+        result = self.resolve_detail(text)
+        return result.id if result else None
+
+    def resolve_detail(self, text: str) -> Optional[ResolveResult]:
+        """Resolve with provenance: ``(id, score, method)`` or ``None``."""
+        t = (text or "").strip()
+        if not t:
+            return None
+        records = self.registry.records
+
+        # 1. Exact canonical id.
+        if t.startswith(CIL_PREFIXES) and t in records:
+            return ResolveResult(t, 1.0, "exact_id")
+
+        # 2. Exact slug → typed candidate (precedence person > org > topic).
+        try:
+            slug = slugify(t)
+        except ValueError:
+            slug = ""
+        if slug:
+            for typ in _TYPE_PRECEDENCE:
+                cid = f"{typ}:{slug}"
+                if cid in records:
+                    return ResolveResult(cid, 1.0, "slug")
+
+        # 3. Exact display-name / alias.
+        alias_id = self.registry.name_index.get(_norm(t))
+        if alias_id is not None:
+            return ResolveResult(alias_id, 1.0, "alias")
+
+        # 4. Fuzzy embedding match.
+        fuzzy = self.registry._fuzzy_lookup(t)
+        if fuzzy is not None:
+            return ResolveResult(fuzzy[0], fuzzy[1], "fuzzy")
+
+        return None

--- a/src/podcast_scraper/kg/entity_clusters.py
+++ b/src/podcast_scraper/kg/entity_clusters.py
@@ -1,0 +1,231 @@
+"""Corpus-wide entity canonicalization — cross-episode spelling drift (#852).
+
+The same person/org appears under different slugs across episodes of a show
+(`Cargil`/`Cargill`, `Data Bricks`/`Databricks`, `Tracy`/`Tracey Alloway`) — ASR
+proper-noun drift the within-episode fix (#851) and the per-episode bridge can't
+catch. This builds a corpus-wide ``variant_id → canonical_id`` map, the missing
+analog to topic clustering (RFC-075) for entities.
+
+Design (evidence: ~95% of drift is same-show, frequency-dominant canonical):
+
+- **Conservative, string-based** — names drift by *spelling*, not semantics, so we
+  cluster by string similarity, not embeddings.
+- **Same-show required** — two variants merge only if they share a podcast (cuts
+  false merges; 95% of drift is same-show anyway).
+- **Canonical = highest frequency** — the spelling in the most episodes wins
+  (`Odd Lots` ×13 over the 1-episode garbles).
+- **Guards (the balanced check):** acronym guard (`UPS` ≠ `USPS`); version /
+  distinguishing-token guard (`Claude` ≠ `Claude 3`); a differing *content* token
+  that is not itself a spelling variant blocks the merge (`Bloomberg Audio` ≠
+  `Bloomberg Media Studios`).
+
+The map is applied at read-time via ``CorpusGraph.build(identity_map=…)`` —
+reversible, no artifact rewrite. Threshold precision tuning is deferred to
+autoresearch. See issue #852.
+"""
+
+from __future__ import annotations
+
+import difflib
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Set, Tuple
+
+from ..builders.bridge_builder import strip_layer_prefixes
+from .filters import _clean_entity_name, _is_acronymish
+
+logger = logging.getLogger(__name__)
+
+ENTITY_CLUSTERS_SCHEMA_VERSION = "1.0"
+
+# Conservative thresholds (tunable → autoresearch).
+_TOKEN_RATIO = 0.78  # per-aligned-token spelling-variant floor
+_OVERALL_RATIO = 0.85  # whole-string floor
+_VERSION_TOKEN_RE = re.compile(r"\d")  # a differing token containing a digit blocks merge
+
+
+@dataclass
+class EntityCandidate:
+    """One canonical entity id observed across the corpus."""
+
+    id: str
+    kind: str  # "person" | "org"
+    name: str  # representative display name (most frequent)
+    episodes: Set[str] = field(default_factory=set)
+    shows: Set[str] = field(default_factory=set)
+    _name_counts: Dict[str, int] = field(default_factory=dict)
+
+    @property
+    def freq(self) -> int:
+        return len(self.episodes)
+
+
+def _ratio(a: str, b: str) -> float:
+    return difflib.SequenceMatcher(None, a, b).ratio()
+
+
+def _are_xep_variants(name_a: str, name_b: str, kind: str) -> bool:
+    """Conservative cross-episode variant test (spelling drift, not distinct names)."""
+    a, b = _clean_entity_name(name_a), _clean_entity_name(name_b)
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    # Acronyms never fuzzy-merge (UPS != USPS).
+    if _is_acronymish(name_a, a) or _is_acronymish(name_b, b):
+        return False
+    # Spacing variants: "Data Bricks" == "Databricks", "Chat GPT" == "ChatGPT".
+    if a.replace(" ", "") == b.replace(" ", "") and a.replace(" ", ""):
+        return True
+    ta, tb = a.split(), b.split()
+    # Different token counts → only the despaced case above may merge; otherwise a
+    # version/extra token (Claude vs Claude 3) → do not merge.
+    if len(ta) != len(tb):
+        return False
+    if _ratio(a, b) < _OVERALL_RATIO:
+        return False
+    # Token-aligned: every differing token pair must be a spelling variant, not a
+    # distinct content word (audio vs media) or a version token (3, v2).
+    for x, y in zip(ta, tb):
+        if x == y:
+            continue
+        if _VERSION_TOKEN_RE.search(x) or _VERSION_TOKEN_RE.search(y):
+            return False  # numeric/version distinction
+        if _ratio(x, y) < _TOKEN_RATIO:
+            return False  # distinct words, not a spelling variant
+    return True
+
+
+def collect_entity_candidates(corpus_dir: Path | str) -> Dict[str, EntityCandidate]:
+    """Aggregate person/org entities corpus-wide with episode frequency + shows."""
+    from .corpus import load_kg_artifacts, scan_kg_artifact_paths
+
+    out: Dict[str, EntityCandidate] = {}
+    for _path, data in load_kg_artifacts(scan_kg_artifact_paths(Path(corpus_dir))):
+        episode_id = str(data.get("episode_id") or "")
+        show = ""
+        for node in data.get("nodes") or []:
+            if isinstance(node, dict) and node.get("type") == "Episode":
+                props = node.get("properties") or {}
+                show = str(props.get("podcast_id") or props.get("feed_id") or "")
+                break
+        for node in data.get("nodes") or []:
+            if not isinstance(node, dict):
+                continue
+            nid = strip_layer_prefixes(str(node.get("id") or ""))
+            kind = nid.split(":", 1)[0]
+            if kind not in ("person", "org"):
+                continue
+            props = node.get("properties") or {}
+            name = str(props.get("name") or props.get("label") or "").strip()
+            if not name:
+                continue
+            cand = out.get(nid)
+            if cand is None:
+                cand = EntityCandidate(id=nid, kind=kind, name=name)
+                out[nid] = cand
+            if episode_id:
+                cand.episodes.add(episode_id)
+            if show:
+                cand.shows.add(show)
+            cand._name_counts[name] = cand._name_counts.get(name, 0) + 1
+    # Representative display name = most frequent surface form.
+    for cand in out.values():
+        if cand._name_counts:
+            cand.name = max(cand._name_counts.items(), key=lambda kv: (kv[1], len(kv[0])))[0]
+    return out
+
+
+def _pick_canonical(members: List[EntityCandidate]) -> EntityCandidate:
+    """Highest frequency wins; tie → longest name, then lexical."""
+    return sorted(members, key=lambda c: (-c.freq, -len(c.name), c.name.lower()))[0]
+
+
+def build_entity_canonical_map(
+    candidates: Dict[str, EntityCandidate],
+    *,
+    same_show_required: bool = True,
+) -> Tuple[Dict[str, Any], Dict[str, str]]:
+    """Cluster variants and return ``(entity_clusters_payload, variant→canonical map)``."""
+    by_kind: Dict[str, List[EntityCandidate]] = {}
+    for cand in candidates.values():
+        by_kind.setdefault(cand.kind, []).append(cand)
+
+    id_map: Dict[str, str] = {}
+    clusters_out: List[Dict[str, Any]] = []
+
+    for kind, items in sorted(by_kind.items()):
+        # High-frequency first so the dominant spelling seeds (and wins) each cluster.
+        items_sorted = sorted(items, key=lambda c: (-c.freq, c.name.lower()))
+        clusters: List[List[EntityCandidate]] = []
+        for cand in items_sorted:
+            for cluster in clusters:
+                if same_show_required and not any(cand.shows & m.shows for m in cluster):
+                    continue
+                if any(_are_xep_variants(cand.name, m.name, kind) for m in cluster):
+                    cluster.append(cand)
+                    break
+            else:
+                clusters.append([cand])
+
+        for cluster in clusters:
+            if len(cluster) < 2:
+                continue
+            canonical = _pick_canonical(cluster)
+            members_json = []
+            for m in sorted(cluster, key=lambda c: (-c.freq, c.id)):
+                if m.id != canonical.id:
+                    id_map[m.id] = canonical.id
+                members_json.append({"id": m.id, "name": m.name, "episode_count": m.freq})
+            clusters_out.append(
+                {
+                    "canonical_id": canonical.id,
+                    "canonical_name": canonical.name,
+                    "member_count": len(cluster),
+                    "members": members_json,
+                }
+            )
+
+    payload = {
+        "schema_version": ENTITY_CLUSTERS_SCHEMA_VERSION,
+        "same_show_required": same_show_required,
+        "entity_count": len(candidates),
+        "cluster_count": len(clusters_out),
+        "merged_variants": len(id_map),
+        "clusters": clusters_out,
+    }
+    return payload, id_map
+
+
+def build_entity_id_map(
+    corpus_dir: Path | str, *, same_show_required: bool = True
+) -> Dict[str, str]:
+    """Convenience: corpus → ``variant_id → canonical_id`` map for ``CorpusGraph``."""
+    candidates = collect_entity_candidates(corpus_dir)
+    _payload, id_map = build_entity_canonical_map(candidates, same_show_required=same_show_required)
+    return id_map
+
+
+def id_map_from_clusters_payload(payload: Dict[str, Any]) -> Dict[str, str]:
+    """Reconstruct the ``variant_id → canonical_id`` map from a saved payload."""
+    out: Dict[str, str] = {}
+    for cluster in payload.get("clusters") or []:
+        canonical = cluster.get("canonical_id")
+        if not canonical:
+            continue
+        for member in cluster.get("members") or []:
+            mid = member.get("id")
+            if mid and mid != canonical:
+                out[mid] = canonical
+    return out
+
+
+__all__ = [
+    "EntityCandidate",
+    "build_entity_canonical_map",
+    "build_entity_id_map",
+    "collect_entity_candidates",
+    "id_map_from_clusters_payload",
+]

--- a/src/podcast_scraper/kg/filters.py
+++ b/src/podcast_scraper/kg/filters.py
@@ -17,8 +17,9 @@ Two filters that run on the final topic/entity lists regardless of source
 
 from __future__ import annotations
 
+import difflib
 import re
-from typing import List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 # ---------------------------------------------------------------------------
 # Topic normalizer (Finding 2)
@@ -185,8 +186,154 @@ def repair_entity_kind(entities: Sequence[dict]) -> Tuple[List[dict], int]:
     return out, repaired
 
 
+# ---------------------------------------------------------------------------
+# Entity name consolidation (#851) — within-episode duplicate-spelling merge
+# ---------------------------------------------------------------------------
+#
+# The KG LLM frequently emits the SAME real entity under two spellings in one
+# episode (often the transcript's literal form AND the real-world-correct name),
+# e.g. "Burne Hobart" + "Byrne Hobart". Topic normalization (#652) dedupes by
+# exact normalized-form equality, which cannot collapse spelling variants. This
+# is the deterministic safety net: a conservative, entity-type-aware, within-
+# episode merge. The extraction prompt (#851 primary) is responsible for the
+# CORRECT surviving spelling; this pass only guarantees one node per entity.
+#
+# Thresholds are deliberately conservative and centralized for later tuning.
+# The within-episode scope is itself a safety feature: two genuinely-different
+# similar-named people rarely co-occur in one episode. The acronym guard keeps
+# UPS ≠ USPS (the confirmed false-merge landmine).
+
+_PERSON_SURNAME_RATIO = 0.82  # surname similarity to call two person names variants
+_PERSON_SURNAME_RATIO_RELAXED = 0.75  # relaxed when first names are identical
+_PERSON_FIRST_RATIO = 0.70  # first-name similarity floor
+_PERSON_OVERALL_RATIO = 0.80  # whole-string similarity floor
+_SINGLE_TOKEN_RATIO = 0.90  # single-token names (non-acronym)
+_ORG_RATIO = 0.92  # orgs: strict; only very-high similarity merges
+_ACRONYM_MAX_LEN = 5  # single token ≤ this length is treated as an acronym
+
+
+def _clean_entity_name(name: str) -> str:
+    """Lowercase, strip punctuation (keep ``&``/``-``), collapse whitespace."""
+    text = _APOSTROPHE_RE.sub("", str(name or "").lower())
+    text = _PUNCTUATION_RE.sub(" ", text)
+    return _MULTI_WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _ratio(a: str, b: str) -> float:
+    return difflib.SequenceMatcher(None, a, b).ratio()
+
+
+def _is_acronymish(raw: str, clean: str) -> bool:
+    """Single short token, or an all-caps short string — never fuzzy-merged."""
+    tokens = clean.split()
+    if len(tokens) == 1 and len(clean) <= _ACRONYM_MAX_LEN:
+        return True
+    raw_compact = re.sub(r"[^A-Za-z]", "", str(raw or ""))
+    return bool(raw_compact) and raw_compact.isupper() and len(raw_compact) <= _ACRONYM_MAX_LEN + 1
+
+
+def _normalize_kind(kind: object) -> str:
+    return "org" if str(kind or "").strip().lower() in ("org", "organization") else "person"
+
+
+def _are_entity_variants(a_raw: str, b_raw: str, kind: str) -> bool:
+    """Conservative, type-aware test: are two names the same entity, variant-spelled?"""
+    a, b = _clean_entity_name(a_raw), _clean_entity_name(b_raw)
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    # Acronym / short-token guard — the UPS vs USPS landmine.
+    if _is_acronymish(a_raw, a) or _is_acronymish(b_raw, b):
+        return False
+    ta, tb = a.split(), b.split()
+    if kind == "org":
+        return _ratio(a, b) >= _ORG_RATIO
+    # Persons: token-structure aware (surname is the discriminator).
+    if len(ta) >= 2 and len(tb) >= 2 and len(ta) == len(tb):
+        fa, fb, sa, sb = ta[0], tb[0], ta[-1], tb[-1]
+        first_ok = (
+            fa == fb
+            or fa.startswith(fb)
+            or fb.startswith(fa)
+            or _ratio(fa, fb) >= _PERSON_FIRST_RATIO
+        )
+        if (
+            first_ok
+            and _ratio(sa, sb) >= _PERSON_SURNAME_RATIO
+            and _ratio(a, b) >= _PERSON_OVERALL_RATIO
+        ):
+            return True
+        # Strong corroboration: identical first name + close surname.
+        if fa == fb and _ratio(sa, sb) >= _PERSON_SURNAME_RATIO_RELAXED:
+            return True
+        return False
+    if len(ta) == 1 and len(tb) == 1:
+        return _ratio(a, b) >= _SINGLE_TOKEN_RATIO
+    return False
+
+
+def _pick_canonical(members: List[Dict]) -> Dict:
+    """Pick the surviving entity: longest name (most complete), tie → lexical.
+
+    Backfills missing/empty fields (e.g. ``description``) from the merged-away
+    members so consolidation never drops data. The chosen *name* still wins; only
+    absent fields are filled. Note this guarantees *a* spelling, not the correct
+    one — the extraction prompt (#851 primary) owns correctness, this pass owns
+    deduplication.
+    """
+    chosen = min(
+        members, key=lambda e: (-len(str(e.get("name") or "")), str(e.get("name") or "").lower())
+    )
+    if len(members) == 1:
+        return chosen
+    merged = dict(chosen)
+    for other in members:
+        if other is chosen:
+            continue
+        for key, value in other.items():
+            if key == "name":
+                continue
+            if merged.get(key) in (None, "") and value not in (None, ""):
+                merged[key] = value
+    return merged
+
+
+def consolidate_entity_names(entities: Sequence[dict]) -> Tuple[List[dict], int]:
+    """Merge within-episode duplicate-spelling entities. Returns ``(entities, merged_count)``.
+
+    Groups same-kind entities into variant clusters (conservative, type-aware) and
+    emits one canonical entity per cluster, preserving the canonical dict's fields
+    (``entity_kind``, ``description``, …). First-cluster order preserved.
+    """
+    clusters: List[Dict] = []  # {"kind": str, "names": [str], "members": [dict]}
+    passthrough: List[dict] = []
+    for ent in entities:
+        name = str(ent.get("name") or "").strip() if isinstance(ent, dict) else ""
+        if not name:
+            passthrough.append(ent)
+            continue
+        kind = _normalize_kind(ent.get("entity_kind"))
+        for cl in clusters:
+            if cl["kind"] == kind and any(_are_entity_variants(name, n, kind) for n in cl["names"]):
+                cl["names"].append(name)
+                cl["members"].append(ent)
+                break
+        else:
+            clusters.append({"kind": kind, "names": [name], "members": [ent]})
+
+    out: List[dict] = []
+    merged = 0
+    for cl in clusters:
+        out.append(_pick_canonical(cl["members"]))
+        merged += len(cl["members"]) - 1
+    out.extend(passthrough)
+    return out, merged
+
+
 __all__ = [
     "KNOWN_ORGS",
+    "consolidate_entity_names",
     "normalize_topic_labels",
     "repair_entity_kind",
 ]

--- a/src/podcast_scraper/kg/llm_extract.py
+++ b/src/podcast_scraper/kg/llm_extract.py
@@ -34,6 +34,10 @@ def build_kg_transcript_system_prompt(max_topics: int, max_entities: int) -> str
         'or relevance here"}]}\n'
         "Omit description keys when not useful. "
         'entity_kind must be "person" or "organization" only. '
+        "Use one canonical spelling per entity: if a name is spelled inconsistently "
+        "in the transcript, pick the single most likely correct spelling and emit it "
+        "once — do not also emit the variant as a separate entity. Keep genuinely "
+        "different entities (e.g. UPS vs USPS) separate. "
         "Each topic label should be a compact heading: prefer about 2–8 words, "
         "noun-phrase style (hard cap 200 characters). Avoid long sentences, "
         'comma stacks, leading clauses ("How …", "Why …"), or pasting raw '
@@ -58,6 +62,9 @@ def build_kg_from_bullets_system_prompt(max_topics: int, max_entities: int) -> s
         '"description":"optional context"}]}\n'
         "Omit description when not useful. "
         'entity_kind must be "person" or "organization" only. '
+        "Use one canonical spelling per entity — never list the same person or "
+        "organization twice under variant spellings; keep genuinely different "
+        "entities separate. "
         "Topic labels must be short thematic headings: about 2–8 words, "
         "noun-phrase style — never a full bullet sentence pasted as one label. "
         "Prefer one stable phrase per theme so the same subject reads similarly "
@@ -111,7 +118,7 @@ def build_kg_user_prompt(
     title: str,
     max_topics: int,
     max_entities: int,
-    prompt_version: str = "v3",  # v3: stricter noun-phrase enforcement (#590)
+    prompt_version: str = "v4",  # v4: entity canonicalization (#851); v3 noun-phrase (#590)
 ) -> str:
     """Render shared Jinja prompt for KG extraction."""
     from ..prompts.store import render_prompt

--- a/src/podcast_scraper/kg/pipeline.py
+++ b/src/podcast_scraper/kg/pipeline.py
@@ -63,7 +63,7 @@ def _apply_kg_filters(
     untouched. Wires into pipeline_metrics counters when available. Kept out
     of ``build_artifact`` to keep its cyclomatic complexity within budget.
     """
-    from .filters import normalize_topic_labels, repair_entity_kind
+    from .filters import consolidate_entity_names, normalize_topic_labels, repair_entity_kind
 
     raw_topic_dicts = [t for t in (llm_partial.get("topics") or []) if isinstance(t, dict)]
     raw_topic_labels = [str(t.get("label") or "").strip() for t in raw_topic_dicts]
@@ -104,6 +104,19 @@ def _apply_kg_filters(
             pipeline_metrics, "record_entity_kinds_repaired"
         ):
             pipeline_metrics.record_entity_kinds_repaired(ents_repaired)
+
+    # #851 — consolidate within-episode duplicate-spelling entities (runs after
+    # kind repair so the merge is kind-aware). Conservative + type-aware; the
+    # extraction prompt owns the correct surviving spelling.
+    ent_dicts = [e for e in (llm_partial.get("entities") or []) if isinstance(e, dict)]
+    consolidated, ents_merged = consolidate_entity_names(ent_dicts)
+    if ents_merged:
+        llm_partial = dict(llm_partial)
+        llm_partial["entities"] = consolidated
+        if pipeline_metrics is not None and hasattr(
+            pipeline_metrics, "record_entities_consolidated"
+        ):
+            pipeline_metrics.record_entities_consolidated(ents_merged)
 
     return llm_partial
 

--- a/src/podcast_scraper/prompts/shared/kg_graph_extraction/v4.j2
+++ b/src/podcast_scraper/prompts/shared/kg_graph_extraction/v4.j2
@@ -1,0 +1,41 @@
+{# Shared KG graph extraction prompt v4 — entity canonicalization (#851). Builds on v3 (#590). #}
+Episode title: {{ title | default("", true) }}
+
+Extract up to {{ max_topics }} distinct **topics** and up to {{ max_entities }} **named entities** (people or organizations) from the transcript.
+
+**Topic label rules (STRICT — follow EXACTLY):**
+- Each label MUST be a **noun phrase**: a noun with optional modifiers
+- Labels must be 2–6 words. Start with a noun or gerund (e.g., "braking technique", "managing risk")
+- Do NOT write sentences, claims, opinions, or verb phrases
+- Do NOT start labels with "How", "Why", "This", "The importance of"
+- Put ALL context, claims, and explanations in the **description** field
+
+**Correct examples:**
+✅ "tire pressure selection" — noun phrase, 3 words
+✅ "on-call rotation design" — noun phrase, 4 words
+✅ "investment fee management" — noun phrase, 3 words
+✅ "quantum error correction" — noun phrase, 3 words
+
+**Incorrect examples (DO NOT write these):**
+❌ "Security as easiest path" — this is a claim, not a topic
+❌ "Error budgets change behavior" — this is a sentence
+❌ "Healthy systems treat failures" — this is a claim
+❌ "The importance of proper braking" — too wordy, use "braking technique"
+
+**Entity rules:**
+- Include all people mentioned by name (hosts, guests, experts)
+- Include organizations, companies, show/podcast names
+- Use "person" or "organization" for entity_kind
+- **One canonical spelling per entity.** Transcripts often misspell names. If the same person or organization appears under more than one spelling, pick the SINGLE most likely correct spelling and emit it ONCE — do NOT also list the variant as a separate entity (e.g. emit "Byrne Hobart" once, never both "Byrne Hobart" and "Burne Hobart").
+- Keep genuinely different entities separate — do NOT merge distinct names that merely look alike (e.g. "UPS" and "USPS" are different organizations).
+
+Put the strongest items first. Do not exceed the counts.
+
+Return JSON:
+{
+  "topics": [{"label": "noun phrase", "description": "1-2 sentence context"}],
+  "entities": [{"name": "Full Name", "entity_kind": "person", "description": "context"}]
+}
+
+Transcript:
+{{ transcript }}

--- a/src/podcast_scraper/search/corpus_graph.py
+++ b/src/podcast_scraper/search/corpus_graph.py
@@ -232,19 +232,38 @@ class CorpusGraph:
 
 # Process-level cache (mirrors providers/ml/embedding_loader.py): graphs are
 # expensive to build and reused across searches. Keyed by resolved corpus path.
-_corpus_graphs: Dict[tuple[str, bool], CorpusGraph] = {}
+_corpus_graphs: Dict[tuple[str, bool, bool], CorpusGraph] = {}
 _corpus_graphs_lock = threading.Lock()
 
 
 def get_corpus_graph(
-    corpus_dir: Path | str, *, validate: bool = False, derive_speaker_links: bool = False
+    corpus_dir: Path | str,
+    *,
+    validate: bool = False,
+    derive_speaker_links: bool = False,
+    canonicalize_entities: bool = True,
 ) -> CorpusGraph:
-    """Return the cached cross-layer graph for *corpus_dir*, building it once."""
-    key = (str(Path(corpus_dir).resolve()), derive_speaker_links)
+    """Return the cached cross-layer graph for *corpus_dir*, building it once.
+
+    ``canonicalize_entities`` (default True — the production path) builds the
+    cross-episode entity canonical map (#852) from the corpus and applies it so
+    spelling variants (`Tracy`/`Tracey Alloway`) collapse to one node. The map is
+    derived deterministically from ``corpus_dir``, so it stays out of the cache key.
+    Pass False for a faithful artifact union.
+    """
+    key = (str(Path(corpus_dir).resolve()), derive_speaker_links, canonicalize_entities)
     with _corpus_graphs_lock:
         if key not in _corpus_graphs:
+            identity_map: Optional[Dict[str, str]] = None
+            if canonicalize_entities:
+                from ..kg.entity_clusters import build_entity_id_map
+
+                identity_map = build_entity_id_map(corpus_dir)
             _corpus_graphs[key] = CorpusGraph.build(
-                corpus_dir, validate=validate, derive_speaker_links=derive_speaker_links
+                corpus_dir,
+                validate=validate,
+                derive_speaker_links=derive_speaker_links,
+                identity_map=identity_map,
             )
         return _corpus_graphs[key]
 

--- a/src/podcast_scraper/search/corpus_graph.py
+++ b/src/podcast_scraper/search/corpus_graph.py
@@ -72,11 +72,17 @@ class Node:
 class CorpusGraph:
     """Undirected, in-memory union of the GIL and KG artifact graphs."""
 
-    def __init__(self) -> None:
+    def __init__(self, identity_map: Optional[Dict[str, str]] = None) -> None:
         self._nodes: Dict[str, Node] = {}
         self._adj: Dict[str, Set[str]] = {}
+        # variant_id -> canonical_id (#852). Collapses cross-episode entity-spelling
+        # variants at read-time; empty = faithful artifact union.
+        self._id_map: Dict[str, str] = dict(identity_map or {})
 
     # --- construction ----------------------------------------------------------
+
+    def _canon(self, node_id: str) -> str:
+        return self._id_map.get(node_id, node_id)
 
     def _upsert_node(self, node_id: str, ntype: str, props: Dict[str, Any], source: str) -> None:
         node = self._nodes.get(node_id)
@@ -103,7 +109,7 @@ class CorpusGraph:
             raw_id = node.get("id")
             if raw_id is None:
                 continue
-            nid = strip_layer_prefixes(str(raw_id))
+            nid = self._canon(strip_layer_prefixes(str(raw_id)))
             props_any = node.get("properties")
             props = props_any if isinstance(props_any, dict) else {}
             self._upsert_node(nid, _normalize_type(nid, node.get("type")), props, source)
@@ -114,7 +120,10 @@ class CorpusGraph:
             to = edge.get("to")
             if frm is None or to is None:
                 continue
-            self._add_edge(strip_layer_prefixes(str(frm)), strip_layer_prefixes(str(to)))
+            self._add_edge(
+                self._canon(strip_layer_prefixes(str(frm))),
+                self._canon(strip_layer_prefixes(str(to))),
+            )
 
     def _derive_speaker_links(self) -> None:
         """Add direct ``person ↔ insight`` edges via a shared quote (#849 Slice C).
@@ -146,19 +155,24 @@ class CorpusGraph:
         *,
         validate: bool = False,
         derive_speaker_links: bool = False,
+        identity_map: Optional[Dict[str, str]] = None,
     ) -> "CorpusGraph":
         """Build the unified graph from all GI + KG artifacts under *corpus_dir*.
 
         When ``derive_speaker_links`` is True, add 1-hop ``person ↔ insight``
         shortcuts (see ``_derive_speaker_links``). Off by default so the graph is
         a faithful union of the artifacts; RFC-091's proximity layer opts in.
+
+        ``identity_map`` (#852) is an optional ``variant_id → canonical_id`` map
+        (e.g. from entity canonicalization) applied at ingest so cross-episode
+        spelling variants collapse to one node.
         """
         from ..gi.corpus import load_gi_artifacts
         from ..gi.explore import scan_artifact_paths as scan_gi_paths
         from ..kg.corpus import load_kg_artifacts, scan_kg_artifact_paths
 
         corpus_dir = Path(corpus_dir)
-        graph = cls()
+        graph = cls(identity_map=identity_map)
         # KG first, then GI: GI payloads win on overlap (see _upsert_node).
         for _path, data in load_kg_artifacts(scan_kg_artifact_paths(corpus_dir), validate=validate):
             graph._ingest(data, "kg")

--- a/src/podcast_scraper/search/corpus_graph.py
+++ b/src/podcast_scraper/search/corpus_graph.py
@@ -116,9 +116,43 @@ class CorpusGraph:
                 continue
             self._add_edge(strip_layer_prefixes(str(frm)), strip_layer_prefixes(str(to)))
 
+    def _derive_speaker_links(self) -> None:
+        """Add direct ``person ↔ insight`` edges via a shared quote (#849 Slice C).
+
+        The KG/GIL artifacts have no `SPEAKER_OF` edge — a person reaches an
+        insight only in 2 hops (person—`SPOKEN_BY`—quote—`SUPPORTED_BY`—insight).
+        For the RFC-091 proximity signal the person→insight path is the most
+        valuable, so we synthesize a 1-hop shortcut. This is purely structural
+        (person→quote→insight via node types), so it needs no new artifact edge
+        types — which is why Slice C does **not** touch the KG schema.
+        """
+        for nid, node in list(self._nodes.items()):
+            if node.type != "person":
+                continue
+            # Snapshot neighbor sets — _add_edge mutates self._adj[nid] below.
+            for quote_id in list(self._adj.get(nid, set())):
+                q = self._nodes.get(quote_id)
+                if q is None or q.type != "quote":
+                    continue
+                for insight_id in list(self._adj.get(quote_id, set())):
+                    ins = self._nodes.get(insight_id)
+                    if ins is not None and ins.type == "insight":
+                        self._add_edge(nid, insight_id)
+
     @classmethod
-    def build(cls, corpus_dir: Path | str, *, validate: bool = False) -> "CorpusGraph":
-        """Build the unified graph from all GI + KG artifacts under *corpus_dir*."""
+    def build(
+        cls,
+        corpus_dir: Path | str,
+        *,
+        validate: bool = False,
+        derive_speaker_links: bool = False,
+    ) -> "CorpusGraph":
+        """Build the unified graph from all GI + KG artifacts under *corpus_dir*.
+
+        When ``derive_speaker_links`` is True, add 1-hop ``person ↔ insight``
+        shortcuts (see ``_derive_speaker_links``). Off by default so the graph is
+        a faithful union of the artifacts; RFC-091's proximity layer opts in.
+        """
         from ..gi.corpus import load_gi_artifacts
         from ..gi.explore import scan_artifact_paths as scan_gi_paths
         from ..kg.corpus import load_kg_artifacts, scan_kg_artifact_paths
@@ -130,6 +164,8 @@ class CorpusGraph:
             graph._ingest(data, "kg")
         for _path, data in load_gi_artifacts(scan_gi_paths(corpus_dir), validate=validate):
             graph._ingest(data, "gi")
+        if derive_speaker_links:
+            graph._derive_speaker_links()
         logger.debug(
             "Built corpus graph: %d nodes, %d adjacency entries",
             len(graph._nodes),
@@ -182,16 +218,20 @@ class CorpusGraph:
 
 # Process-level cache (mirrors providers/ml/embedding_loader.py): graphs are
 # expensive to build and reused across searches. Keyed by resolved corpus path.
-_corpus_graphs: Dict[str, CorpusGraph] = {}
+_corpus_graphs: Dict[tuple[str, bool], CorpusGraph] = {}
 _corpus_graphs_lock = threading.Lock()
 
 
-def get_corpus_graph(corpus_dir: Path | str, *, validate: bool = False) -> CorpusGraph:
+def get_corpus_graph(
+    corpus_dir: Path | str, *, validate: bool = False, derive_speaker_links: bool = False
+) -> CorpusGraph:
     """Return the cached cross-layer graph for *corpus_dir*, building it once."""
-    key = str(Path(corpus_dir).resolve())
+    key = (str(Path(corpus_dir).resolve()), derive_speaker_links)
     with _corpus_graphs_lock:
         if key not in _corpus_graphs:
-            _corpus_graphs[key] = CorpusGraph.build(corpus_dir, validate=validate)
+            _corpus_graphs[key] = CorpusGraph.build(
+                corpus_dir, validate=validate, derive_speaker_links=derive_speaker_links
+            )
         return _corpus_graphs[key]
 
 

--- a/src/podcast_scraper/search/corpus_graph.py
+++ b/src/podcast_scraper/search/corpus_graph.py
@@ -190,6 +190,7 @@ class CorpusGraph:
     # --- access ----------------------------------------------------------------
 
     def get_node(self, node_id: Optional[str]) -> Optional[Node]:
+        """Return the node for *node_id*, or ``None`` if absent/``None``."""
         if node_id is None:
             return None
         return self._nodes.get(node_id)
@@ -199,9 +200,11 @@ class CorpusGraph:
         return sorted(self._adj.get(node_id, set()))
 
     def degree(self, node_id: str) -> int:
+        """Number of (undirected) neighbors of *node_id*."""
         return len(self._adj.get(node_id, ()))
 
     def nodes_by_type(self, node_type: str) -> List[str]:
+        """Sorted ids of all nodes whose normalized type is *node_type*."""
         return sorted(nid for nid, n in self._nodes.items() if n.type == node_type)
 
     def bfs(self, start_id: str, max_hops: int = 3) -> Dict[str, int]:

--- a/src/podcast_scraper/search/corpus_graph.py
+++ b/src/podcast_scraper/search/corpus_graph.py
@@ -1,0 +1,201 @@
+"""In-memory cross-layer corpus graph — unified GIL + KG traversal (#849 Slice B).
+
+RFC-091's KG-proximity signal needs to traverse from a query entity to the
+*insight* nodes that retrieval ranks. Insights live only in the GIL layer, while
+entities/episodes/topics live in the KG layer; the two are joined on **exact
+shared canonical IDs** (`person:{slug}`, `org:{slug}`, `topic:{slug}`,
+`episode:{episode_id}` are identical across `*.gi.json` and `*.kg.json`,
+RFC-072). This module loads both layers and unifies them into one undirected
+in-memory graph with `neighbors()` / `get_node()` / `bfs()`.
+
+Design notes:
+
+- **Undirected adjacency.** Proximity is reachability, so an edge connects its
+  endpoints in both directions (a 2-hop person→episode→insight path is what the
+  signal exploits).
+- **Type from id prefix.** Node `type` is derived from the canonical id prefix so
+  the GIL `Person` node and the KG `Entity(kind=person)` node unify into one
+  `person` node, and RFC-091's `type in ("insight", "segment")` check works.
+- **Hand-rolled adjacency, live BFS.** At corpus scale (~700 episodes, ~15k
+  insights, ~20–30k nodes) a dict adjacency with live ≤3-hop BFS is sufficient;
+  no graph library or precomputed adjacency cache is needed (RFC-091 OQ-1).
+
+Consumer: RFC-091 `KGProximitySearch` (separate module, builds on `bfs()`).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import deque
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from ..builders.bridge_builder import strip_layer_prefixes
+
+logger = logging.getLogger(__name__)
+
+# Canonical id prefix → normalized node type. Keeps GIL `Person` and KG
+# `Entity(kind=person)` as one `person` node, etc.
+_TYPE_BY_PREFIX = {
+    "person": "person",
+    "org": "org",
+    "topic": "topic",
+    "episode": "episode",
+    "insight": "insight",
+    "quote": "quote",
+    "podcast": "podcast",
+    "segment": "segment",
+}
+
+
+def _normalize_type(node_id: str, raw_type: Any) -> str:
+    """Derive node type from the canonical id prefix; fall back to artifact type."""
+    prefix = node_id.split(":", 1)[0] if ":" in node_id else ""
+    mapped = _TYPE_BY_PREFIX.get(prefix)
+    if mapped:
+        return mapped
+    return str(raw_type or "").lower()
+
+
+@dataclass
+class Node:
+    """A unified corpus-graph node."""
+
+    id: str
+    type: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    layers: Set[str] = field(default_factory=set)  # {"gi", "kg"}
+
+
+class CorpusGraph:
+    """Undirected, in-memory union of the GIL and KG artifact graphs."""
+
+    def __init__(self) -> None:
+        self._nodes: Dict[str, Node] = {}
+        self._adj: Dict[str, Set[str]] = {}
+
+    # --- construction ----------------------------------------------------------
+
+    def _upsert_node(self, node_id: str, ntype: str, props: Dict[str, Any], source: str) -> None:
+        node = self._nodes.get(node_id)
+        if node is None:
+            self._nodes[node_id] = Node(
+                id=node_id, type=ntype, payload=dict(props), layers={source}
+            )
+            return
+        # Later source (GI is ingested after KG) wins on overlapping keys — GIL
+        # payloads are richer for insights/quotes/persons.
+        node.payload.update(props)
+        node.layers.add(source)
+        if not node.type and ntype:
+            node.type = ntype
+
+    def _add_edge(self, frm: str, to: str) -> None:
+        self._adj.setdefault(frm, set()).add(to)
+        self._adj.setdefault(to, set()).add(frm)  # undirected
+
+    def _ingest(self, artifact: Dict[str, Any], source: str) -> None:
+        for node in artifact.get("nodes") or []:
+            if not isinstance(node, dict):
+                continue
+            raw_id = node.get("id")
+            if raw_id is None:
+                continue
+            nid = strip_layer_prefixes(str(raw_id))
+            props_any = node.get("properties")
+            props = props_any if isinstance(props_any, dict) else {}
+            self._upsert_node(nid, _normalize_type(nid, node.get("type")), props, source)
+        for edge in artifact.get("edges") or []:
+            if not isinstance(edge, dict):
+                continue
+            frm = edge.get("from")
+            to = edge.get("to")
+            if frm is None or to is None:
+                continue
+            self._add_edge(strip_layer_prefixes(str(frm)), strip_layer_prefixes(str(to)))
+
+    @classmethod
+    def build(cls, corpus_dir: Path | str, *, validate: bool = False) -> "CorpusGraph":
+        """Build the unified graph from all GI + KG artifacts under *corpus_dir*."""
+        from ..gi.corpus import load_gi_artifacts
+        from ..gi.explore import scan_artifact_paths as scan_gi_paths
+        from ..kg.corpus import load_kg_artifacts, scan_kg_artifact_paths
+
+        corpus_dir = Path(corpus_dir)
+        graph = cls()
+        # KG first, then GI: GI payloads win on overlap (see _upsert_node).
+        for _path, data in load_kg_artifacts(scan_kg_artifact_paths(corpus_dir), validate=validate):
+            graph._ingest(data, "kg")
+        for _path, data in load_gi_artifacts(scan_gi_paths(corpus_dir), validate=validate):
+            graph._ingest(data, "gi")
+        logger.debug(
+            "Built corpus graph: %d nodes, %d adjacency entries",
+            len(graph._nodes),
+            len(graph._adj),
+        )
+        return graph
+
+    # --- access ----------------------------------------------------------------
+
+    def get_node(self, node_id: Optional[str]) -> Optional[Node]:
+        if node_id is None:
+            return None
+        return self._nodes.get(node_id)
+
+    def neighbors(self, node_id: str) -> List[str]:
+        """Undirected neighbors of *node_id* (sorted for determinism)."""
+        return sorted(self._adj.get(node_id, set()))
+
+    def degree(self, node_id: str) -> int:
+        return len(self._adj.get(node_id, ()))
+
+    def nodes_by_type(self, node_type: str) -> List[str]:
+        return sorted(nid for nid, n in self._nodes.items() if n.type == node_type)
+
+    def bfs(self, start_id: str, max_hops: int = 3) -> Dict[str, int]:
+        """BFS hop-distances from *start_id* (inclusive), bounded by *max_hops*.
+
+        Returns ``{node_id: hop_distance}`` for every node reachable within
+        ``max_hops`` (start at hop 0). The primitive RFC-091 scores as
+        ``1 / (hop + 1)``.
+        """
+        if start_id not in self._adj and start_id not in self._nodes:
+            return {}
+        dist: Dict[str, int] = {start_id: 0}
+        queue: deque[str] = deque([start_id])
+        while queue:
+            cur = queue.popleft()
+            hop = dist[cur]
+            if hop >= max_hops:
+                continue
+            for nbr in self._adj.get(cur, ()):  # noqa: SIM118 - set membership iter
+                if nbr not in dist:
+                    dist[nbr] = hop + 1
+                    queue.append(nbr)
+        return dist
+
+    def __len__(self) -> int:
+        return len(self._nodes)
+
+
+# Process-level cache (mirrors providers/ml/embedding_loader.py): graphs are
+# expensive to build and reused across searches. Keyed by resolved corpus path.
+_corpus_graphs: Dict[str, CorpusGraph] = {}
+_corpus_graphs_lock = threading.Lock()
+
+
+def get_corpus_graph(corpus_dir: Path | str, *, validate: bool = False) -> CorpusGraph:
+    """Return the cached cross-layer graph for *corpus_dir*, building it once."""
+    key = str(Path(corpus_dir).resolve())
+    with _corpus_graphs_lock:
+        if key not in _corpus_graphs:
+            _corpus_graphs[key] = CorpusGraph.build(corpus_dir, validate=validate)
+        return _corpus_graphs[key]
+
+
+def clear_corpus_graph_cache() -> None:
+    """Clear the process cache (tests / after corpus re-index)."""
+    with _corpus_graphs_lock:
+        _corpus_graphs.clear()

--- a/tests/unit/identity/test_resolver.py
+++ b/tests/unit/identity/test_resolver.py
@@ -1,0 +1,175 @@
+"""Unit tests for the file-local entity resolver (identity/resolver.py, #849)."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from podcast_scraper.identity.resolver import (
+    build_entity_registry,
+    EntityRegistry,
+    EntityResolver,
+    ResolveResult,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class FakeEmbedder:
+    """Deterministic embedder so exact + fuzzy paths are reproducible offline.
+
+    Maps a few known strings near the "altman" axis (so a misspelling resolves
+    fuzzily) and everything else to an orthogonal axis (cosine 0 → no match).
+    """
+
+    # 5-dim so each known registry name gets its own axis and unknown text lands
+    # on a reserved axis (e3) orthogonal to every known name → cosine 0 → no match.
+    _MAP = {
+        "samuel altman": [1.0, 0.0, 0.0, 0.0, 0.0],
+        "sam altman": [0.99, 0.0, 0.0, 0.0, 0.14],
+        "samuel altmann": [0.97, 0.0, 0.0, 0.0, 0.24],  # misspelling → still near e0
+        "openai": [0.0, 1.0, 0.0, 0.0, 0.0],
+        "ai regulation": [0.0, 0.0, 1.0, 0.0, 0.0],
+    }
+    _UNKNOWN = [0.0, 0.0, 0.0, 1.0, 0.0]
+
+    def _vec(self, text: str) -> list[float]:
+        return self._MAP.get(" ".join(str(text).lower().split()), list(self._UNKNOWN))
+
+    def encode(self, texts, normalize_embeddings=True):  # noqa: D401 - mimic ST signature
+        items = [texts] if isinstance(texts, str) else list(texts)
+        arr = np.asarray([self._vec(t) for t in items], dtype=float)
+        if normalize_embeddings:
+            norms = np.linalg.norm(arr, axis=1, keepdims=True)
+            norms[norms == 0] = 1.0
+            arr = arr / norms
+        return arr
+
+
+def _identity(cid, type_, display, aliases=None):
+    return {
+        "id": cid,
+        "type": type_,
+        "display_name": display,
+        "aliases": list(aliases or []),
+        "sources": {"gi": True, "kg": False},
+    }
+
+
+def _registry(**kwargs) -> EntityRegistry:
+    identities = {
+        "person:samuel-altman": _identity(
+            "person:samuel-altman", "person", "Samuel Altman", ["Sam Altman", "sama"]
+        ),
+        "org:openai": _identity("org:openai", "org", "OpenAI"),
+        "topic:ai-regulation": _identity("topic:ai-regulation", "topic", "AI regulation"),
+    }
+    freq = Counter({"person:samuel-altman": 5, "org:openai": 3, "topic:ai-regulation": 2})
+    return EntityRegistry.from_identities(identities, freq, embedder=FakeEmbedder(), **kwargs)
+
+
+def _resolver(**kwargs) -> EntityResolver:
+    return EntityResolver(_registry(**kwargs))
+
+
+# --- exact tiers ---------------------------------------------------------------
+
+
+def test_resolve_exact_canonical_id():
+    r = _resolver()
+    assert r.resolve("person:samuel-altman") == "person:samuel-altman"
+    assert r.resolve_detail("person:samuel-altman").method == "exact_id"
+
+
+def test_resolve_slug_match():
+    r = _resolver()
+    # slugify("OpenAI") == "openai" -> org:openai
+    res = r.resolve_detail("OpenAI")
+    assert res.id == "org:openai"
+    assert res.method == "slug"
+    assert r.resolve("AI regulation") == "topic:ai-regulation"
+
+
+def test_resolve_alias_match():
+    r = _resolver()
+    res = r.resolve_detail("Sam Altman")  # alias of person:samuel-altman
+    assert res.id == "person:samuel-altman"
+    assert res.method == "alias"
+
+
+# --- fuzzy + conservative ------------------------------------------------------
+
+
+def test_resolve_fuzzy_hit():
+    r = _resolver()
+    res = r.resolve_detail("Samuel Altmann")  # misspelling, not an exact name/slug
+    assert res is not None
+    assert res.id == "person:samuel-altman"
+    assert res.method == "fuzzy"
+    assert res.score >= 0.75
+
+
+def test_resolve_fuzzy_miss_returns_none():
+    r = _resolver()
+    assert r.resolve("zxcvb qwerty nonsense") is None
+
+
+def test_resolve_empty_and_blank_return_none():
+    r = _resolver()
+    assert r.resolve("") is None
+    assert r.resolve("   ") is None
+    assert r.resolve_detail("") is None
+
+
+def test_resolve_below_threshold_is_conservative():
+    # Raise threshold above the misspelling similarity → no fuzzy match.
+    r = _resolver(fuzzy_threshold=0.999)
+    assert r.resolve("Samuel Altmann") is None
+
+
+# --- precedence + tie-break ----------------------------------------------------
+
+
+def test_slug_precedence_person_over_topic():
+    identities = {
+        "person:dup-term": _identity("person:dup-term", "person", "Dup Person"),
+        "topic:dup-term": _identity("topic:dup-term", "topic", "Dup Topic"),
+    }
+    reg = EntityRegistry.from_identities(
+        identities, Counter({"person:dup-term": 1, "topic:dup-term": 9}), embedder=FakeEmbedder()
+    )
+    res = EntityResolver(reg).resolve_detail("Dup Term")  # slug "dup-term"
+    assert res.id == "person:dup-term"  # person wins regardless of topic freq
+    assert res.method == "slug"
+
+
+def test_alias_collision_prefers_higher_frequency():
+    identities = {
+        "person:acme-a": _identity("person:acme-a", "person", "AcmeA", ["Acme"]),
+        "person:acme-b": _identity("person:acme-b", "person", "AcmeB", ["Acme"]),
+    }
+    reg = EntityRegistry.from_identities(
+        identities, Counter({"person:acme-a": 2, "person:acme-b": 5}), embedder=FakeEmbedder()
+    )
+    assert EntityResolver(reg).resolve("Acme") == "person:acme-b"
+
+
+# --- registry build from real artifacts ----------------------------------------
+
+
+def test_build_registry_from_fixture_corpus():
+    corpus = Path("tests/fixtures/gil_kg_ci_enforce")
+    reg = build_entity_registry(corpus, embedder=FakeEmbedder())
+    assert len(reg) >= 1
+    # The fixture gi.json carries Topic node topic:ci-policy (label "Climate policy").
+    assert "topic:ci-policy" in reg.records
+    assert EntityResolver(reg).resolve("Climate policy") == "topic:ci-policy"
+
+
+def test_resolve_detail_returns_resolveresult_type():
+    r = _resolver()
+    assert isinstance(r.resolve_detail("person:samuel-altman"), ResolveResult)
+    assert r.resolve_detail("definitely not present") is None

--- a/tests/unit/identity/test_resolver.py
+++ b/tests/unit/identity/test_resolver.py
@@ -10,8 +10,10 @@ import pytest
 
 from podcast_scraper.identity.resolver import (
     build_entity_registry,
+    clear_entity_resolver_cache,
     EntityRegistry,
     EntityResolver,
+    get_entity_resolver,
     ResolveResult,
 )
 
@@ -173,3 +175,14 @@ def test_resolve_detail_returns_resolveresult_type():
     r = _resolver()
     assert isinstance(r.resolve_detail("person:samuel-altman"), ResolveResult)
     assert r.resolve_detail("definitely not present") is None
+
+
+def test_get_entity_resolver_caches_registry():
+    corpus = "tests/fixtures/gil_kg_ci_enforce"
+    clear_entity_resolver_cache()
+    r1 = get_entity_resolver(corpus, embedder=FakeEmbedder())
+    r2 = get_entity_resolver(corpus, embedder=FakeEmbedder())
+    assert r1.registry is r2.registry  # registry built once, reused
+    clear_entity_resolver_cache()
+    r3 = get_entity_resolver(corpus, embedder=FakeEmbedder())
+    assert r3.registry is not r1.registry

--- a/tests/unit/podcast_scraper/kg/test_entity_clusters.py
+++ b/tests/unit/podcast_scraper/kg/test_entity_clusters.py
@@ -1,0 +1,138 @@
+"""Unit tests for cross-episode entity canonicalization (kg/entity_clusters.py, #852)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from podcast_scraper.kg.entity_clusters import (
+    _are_xep_variants,
+    build_entity_canonical_map,
+    build_entity_id_map,
+    collect_entity_candidates,
+    EntityCandidate,
+    id_map_from_clusters_payload,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _cand(cid, kind, name, eps, shows):
+    return EntityCandidate(id=cid, kind=kind, name=name, episodes=set(eps), shows=set(shows))
+
+
+# --- variant rule: MERGE real drift ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "a,b,kind",
+    [
+        ("Cargil", "Cargill", "org"),
+        ("Data Bricks", "Databricks", "org"),
+        ("Chat GPT", "ChatGPT", "org"),
+        ("Byrne Hobart", "Burne Hobart", "person"),
+        ("Tracy Alloway", "Tracey Alloway", "person"),
+        ("Donald Mackenzie", "Donald McKenzie", "person"),
+        ("David Shor", "David Shore", "person"),
+    ],
+)
+def test_xep_variants_merge_real_drift(a, b, kind):
+    assert _are_xep_variants(a, b, kind) is True
+
+
+# --- variant rule: REJECT the landmines -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "a,b,kind",
+    [
+        ("UPS", "USPS", "org"),  # acronyms
+        ("Claude", "Claude 3", "org"),  # version token
+        ("GPT-4", "GPT-4o", "org"),  # version-ish
+        ("Bloomberg Audio Studios", "Bloomberg Media Studios", "org"),  # distinct content word
+        ("Sam Altman", "Tim Cook", "person"),  # different people
+        ("John Smith", "Jane Smith", "person"),  # different first names
+    ],
+)
+def test_xep_variants_reject_landmines(a, b, kind):
+    assert _are_xep_variants(a, b, kind) is False
+
+
+# --- canonical map: frequency + same-show ---------------------------------------
+
+
+def test_canonical_is_highest_frequency():
+    cands = {
+        "org:cargill": _cand("org:cargill", "org", "Cargill", ["e1", "e2"], ["showA"]),
+        "org:cargil": _cand("org:cargil", "org", "Cargil", ["e3"], ["showA"]),
+    }
+    payload, id_map = build_entity_canonical_map(cands)
+    # Lower-frequency variant maps to the higher-frequency canonical.
+    assert id_map == {"org:cargil": "org:cargill"}
+    assert payload["merged_variants"] == 1
+    assert payload["clusters"][0]["canonical_id"] == "org:cargill"
+
+
+def test_same_show_required_blocks_cross_show_merge():
+    cands = {
+        "org:cargill": _cand("org:cargill", "org", "Cargill", ["e1", "e2"], ["showA"]),
+        "org:cargil": _cand("org:cargil", "org", "Cargil", ["e3"], ["showB"]),  # other show
+    }
+    _, id_map = build_entity_canonical_map(cands, same_show_required=True)
+    assert id_map == {}
+
+
+def test_landmines_not_merged_in_map():
+    cands = {
+        "org:claude": _cand("org:claude", "org", "Claude", ["e1", "e2"], ["showA"]),
+        "org:claude-3": _cand("org:claude-3", "org", "Claude 3", ["e1"], ["showA"]),
+        "org:ups": _cand("org:ups", "org", "UPS", ["e1"], ["showA"]),
+        "org:usps": _cand("org:usps", "org", "USPS", ["e1"], ["showA"]),
+    }
+    _, id_map = build_entity_canonical_map(cands)
+    assert id_map == {}
+
+
+def test_kind_aware_no_cross_kind_merge():
+    cands = {
+        "person:cargill": _cand("person:cargill", "person", "Cargill", ["e1"], ["showA"]),
+        "org:cargil": _cand("org:cargil", "org", "Cargil", ["e1"], ["showA"]),
+    }
+    _, id_map = build_entity_canonical_map(cands)
+    assert id_map == {}
+
+
+# --- collect + end-to-end on a synthetic corpus ---------------------------------
+
+
+def _write_kg(path: Path, episode_id: str, show: str, entities):
+    nodes = [{"id": f"episode:{episode_id}", "type": "Episode", "properties": {"podcast_id": show}}]
+    for eid, name in entities:
+        nodes.append({"id": eid, "type": "Entity", "properties": {"name": name}})
+    path.write_text(json.dumps({"episode_id": episode_id, "nodes": nodes, "edges": []}))
+
+
+def test_collect_and_build_id_map_from_corpus(tmp_path):
+    # Same show, two episodes: Cargill (ep1, ep2) + Cargil (ep3) → collapse.
+    _write_kg(tmp_path / "e1.kg.json", "e1", "showA", [("org:cargill", "Cargill")])
+    _write_kg(tmp_path / "e2.kg.json", "e2", "showA", [("org:cargill", "Cargill")])
+    _write_kg(tmp_path / "e3.kg.json", "e3", "showA", [("org:cargil", "Cargil")])
+
+    cands = collect_entity_candidates(tmp_path)
+    assert cands["org:cargill"].freq == 2
+    assert cands["org:cargil"].freq == 1
+    assert cands["org:cargill"].shows == {"showA"}
+
+    id_map = build_entity_id_map(tmp_path)
+    assert id_map == {"org:cargil": "org:cargill"}
+
+
+def test_id_map_from_payload_roundtrip():
+    cands = {
+        "org:cargill": _cand("org:cargill", "org", "Cargill", ["e1", "e2"], ["showA"]),
+        "org:cargil": _cand("org:cargil", "org", "Cargil", ["e3"], ["showA"]),
+    }
+    payload, id_map = build_entity_canonical_map(cands)
+    assert id_map_from_clusters_payload(payload) == id_map

--- a/tests/unit/podcast_scraper/kg/test_kg_llm_extract.py
+++ b/tests/unit/podcast_scraper/kg/test_kg_llm_extract.py
@@ -89,3 +89,25 @@ class TestKgLlmExtract(unittest.TestCase):
         s = build_kg_from_bullets_system_prompt(5, 10)
         self.assertIn("2–8 words", s)
         self.assertIn("noun-phrase", s)
+
+    def test_system_prompts_request_one_canonical_spelling_per_entity(self) -> None:
+        """#851 — both extraction system prompts must ask for canonical entity
+        spelling (one node per real entity), the primary same-episode dedup lever."""
+        for s in (
+            build_kg_transcript_system_prompt(5, 10),
+            build_kg_from_bullets_system_prompt(5, 10),
+        ):
+            self.assertIn("canonical spelling", s)
+
+    def test_transcript_system_prompt_keeps_distinct_entities_separate(self) -> None:
+        # The prompt must also guard against over-merging (UPS vs USPS).
+        s = build_kg_transcript_system_prompt(5, 10)
+        self.assertIn("UPS vs USPS", s)
+
+    def test_kg_user_prompt_defaults_to_v4_with_canonicalization(self) -> None:
+        """#851 — default KG extraction template is v4 and carries the rule."""
+        from podcast_scraper.kg.llm_extract import build_kg_user_prompt
+
+        rendered = build_kg_user_prompt("some transcript", "Title", 5, 10)
+        self.assertIn("One canonical spelling per entity", rendered)
+        self.assertIn("USPS", rendered)  # do-not-over-merge guard present

--- a/tests/unit/podcast_scraper/kg/test_topic_entity_filters.py
+++ b/tests/unit/podcast_scraper/kg/test_topic_entity_filters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from podcast_scraper.kg.filters import (
+    consolidate_entity_names,
     KNOWN_ORGS,
     normalize_topic_labels,
     repair_entity_kind,
@@ -134,3 +135,109 @@ class TestRepairEntityKind:
         assert len(KNOWN_ORGS) > 0
         for name in KNOWN_ORGS:
             assert name == name.lower().strip()
+
+
+def _person(name):
+    return {"name": name, "entity_kind": "person"}
+
+
+def _names(entities):
+    return sorted(str(e.get("name")) for e in entities)
+
+
+class TestConsolidateEntityNames:
+    """#851 — within-episode duplicate-spelling entity merge. Cases are the real
+    pairs found in `my-manual-run-10` (root-caused against transcripts)."""
+
+    # --- MERGE (persons): real variants from the corpus -------------------------
+
+    def test_merge_identical_surname_variant_first(self):
+        # "Burne Hobart" (transcript) + "Byrne Hobart" (LLM corrected) -> one node.
+        out, merged = consolidate_entity_names([_person("Burne Hobart"), _person("Byrne Hobart")])
+        assert len(out) == 1
+        assert merged == 1
+
+    @pytest.mark.parametrize(
+        "a,b",
+        [
+            ("David Shor", "David Shore"),
+            ("Ryan Petersen", "Ryan Peterson"),
+            ("Henry Blodget", "Henry Blodgett"),
+        ],
+    )
+    def test_merge_one_char_surname_variant(self, a, b):
+        out, merged = consolidate_entity_names([_person(a), _person(b)])
+        assert len(out) == 1 and merged == 1
+
+    def test_merge_first_name_prefix(self):
+        # "Greg Brew" / "Gregory Brew" -> one; canonical is the longer (fuller) name.
+        out, merged = consolidate_entity_names([_person("Greg Brew"), _person("Gregory Brew")])
+        assert len(out) == 1 and merged == 1
+        assert out[0]["name"] == "Gregory Brew"
+
+    def test_merge_identical_first_close_surname(self):
+        # "Noah Brier" / "Noah Bryer" — relaxed surname threshold when first name matches.
+        out, merged = consolidate_entity_names([_person("Noah Brier"), _person("Noah Bryer")])
+        assert len(out) == 1 and merged == 1
+
+    # --- DO NOT MERGE: the landmines -------------------------------------------
+
+    def test_does_not_merge_acronym_orgs_ups_usps(self):
+        # The confirmed false-merge landmine: UPS != USPS.
+        ents = [
+            {"name": "UPS", "entity_kind": "org"},
+            {"name": "USPS", "entity_kind": "org"},
+        ]
+        out, merged = consolidate_entity_names(ents)
+        assert len(out) == 2 and merged == 0
+        assert _names(out) == ["UPS", "USPS"]
+
+    def test_does_not_merge_distinct_people(self):
+        out, merged = consolidate_entity_names([_person("Sam Altman"), _person("Tim Cook")])
+        assert len(out) == 2 and merged == 0
+
+    def test_kind_aware_no_cross_kind_merge(self):
+        # Same string, different kind -> two entities (a person and an org).
+        ents = [
+            {"name": "Jordan", "entity_kind": "person"},
+            {"name": "Jordan", "entity_kind": "org"},
+        ]
+        out, merged = consolidate_entity_names(ents)
+        assert len(out) == 2 and merged == 0
+
+    # --- behavior / hygiene -----------------------------------------------------
+
+    def test_canonical_preserves_fields(self):
+        ents = [
+            {"name": "Byrne Hobart", "entity_kind": "person", "description": "investor"},
+            {"name": "Burne Hobart", "entity_kind": "person"},
+        ]
+        out, merged = consolidate_entity_names(ents)
+        assert len(out) == 1 and merged == 1
+        # Canonical name is the lexical tie-break "Burne Hobart", but the
+        # description from the merged-away "Byrne Hobart" is backfilled (no data loss).
+        assert out[0]["entity_kind"] == "person"
+        assert out[0]["description"] == "investor"
+
+    def test_noop_when_all_distinct(self):
+        ents = [
+            _person("Sam Altman"),
+            _person("Satya Nadella"),
+            {"name": "OpenAI", "entity_kind": "org"},
+        ]
+        out, merged = consolidate_entity_names(ents)
+        assert merged == 0
+        assert _names(out) == _names(ents)
+
+    def test_passthrough_non_dict_and_empty_names(self):
+        ents = [_person("Sam Altman"), "not-a-dict", {"name": "  ", "entity_kind": "person"}]
+        out, merged = consolidate_entity_names(ents)
+        # Non-dict and empty-name entries are preserved, never crash.
+        assert merged == 0
+        assert any(isinstance(e, dict) and e.get("name") == "Sam Altman" for e in out)
+
+    def test_three_way_cluster_counts_merges(self):
+        # Three spellings of one entity collapse to one; merged == 2.
+        ents = [_person("Greg Brew"), _person("Gregory Brew"), _person("Greg Brews")]
+        out, merged = consolidate_entity_names(ents)
+        assert len(out) == 1 and merged == 2

--- a/tests/unit/search/test_corpus_graph.py
+++ b/tests/unit/search/test_corpus_graph.py
@@ -1,0 +1,181 @@
+"""Unit tests for the cross-layer corpus graph (search/corpus_graph.py, #849 Slice B)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from podcast_scraper.search.corpus_graph import (
+    clear_corpus_graph_cache,
+    CorpusGraph,
+    get_corpus_graph,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# A GI artifact and a KG artifact for the SAME episode, sharing person:alice,
+# topic:ai, and episode:e1 — the cross-layer join surface.
+_GI = {
+    "schema_version": "1.0",
+    "episode_id": "e1",
+    "nodes": [
+        {"id": "podcast:show1", "type": "Podcast", "properties": {"title": "Show One"}},
+        {"id": "episode:e1", "type": "Episode", "properties": {"title": "Ep 1"}},
+        {
+            "id": "person:alice",
+            "type": "Person",
+            "properties": {"name": "Alice", "aliases": ["Al"]},
+        },
+        {"id": "topic:ai", "type": "Topic", "properties": {"label": "AI"}},
+        {
+            "id": "insight:i1",
+            "type": "Insight",
+            "properties": {"text": "AI insight", "episode_id": "e1", "grounded": True},
+        },
+        {
+            "id": "quote:q1",
+            "type": "Quote",
+            "properties": {"text": "quote text", "episode_id": "e1"},
+        },
+    ],
+    "edges": [
+        {"type": "HAS_EPISODE", "from": "podcast:show1", "to": "episode:e1"},
+        {"type": "HAS_INSIGHT", "from": "episode:e1", "to": "insight:i1"},
+        {"type": "ABOUT", "from": "insight:i1", "to": "topic:ai"},
+        {"type": "SUPPORTED_BY", "from": "insight:i1", "to": "quote:q1"},
+        {"type": "SPOKEN_BY", "from": "quote:q1", "to": "person:alice"},
+    ],
+}
+
+_KG = {
+    "schema_version": "1.2",
+    "episode_id": "e1",
+    "nodes": [
+        {"id": "episode:e1", "type": "Episode", "properties": {"title": "Ep 1"}},
+        {
+            "id": "person:alice",
+            "type": "Entity",
+            "properties": {"name": "Alice", "kind": "person", "role": "guest"},
+        },
+        {"id": "org:acme", "type": "Entity", "properties": {"name": "Acme", "kind": "org"}},
+        {"id": "topic:ai", "type": "Topic", "properties": {"label": "AI", "slug": "ai"}},
+        # Layer-prefixed id must canonicalize to topic:ai (strip_layer_prefixes).
+        {"id": "kg:topic:ai", "type": "Topic", "properties": {"slug": "ai"}},
+    ],
+    "edges": [
+        {"type": "MENTIONS", "from": "person:alice", "to": "episode:e1"},
+        {"type": "MENTIONS", "from": "topic:ai", "to": "episode:e1"},
+        {"type": "MENTIONS", "from": "org:acme", "to": "episode:e1"},
+    ],
+}
+
+
+def _write_corpus(tmp_path: Path, gi=_GI, kg=_KG) -> Path:
+    (tmp_path / "ep1.gi.json").write_text(json.dumps(gi))
+    (tmp_path / "ep1.kg.json").write_text(json.dumps(kg))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_corpus_graph_cache()
+    yield
+    clear_corpus_graph_cache()
+
+
+# --- cross-layer join ----------------------------------------------------------
+
+
+def test_person_node_unified_across_layers(tmp_path):
+    g = CorpusGraph.build(_write_corpus(tmp_path))
+    node = g.get_node("person:alice")
+    assert node is not None
+    assert node.type == "person"
+    assert node.layers == {"gi", "kg"}
+    # Merged payload: GI name + aliases AND KG kind/role.
+    assert node.payload["name"] == "Alice"
+    assert node.payload["kind"] == "person"
+    assert node.payload["role"] == "guest"
+    assert node.payload["aliases"] == ["Al"]
+
+
+def test_neighbors_span_both_layers(tmp_path):
+    g = CorpusGraph.build(_write_corpus(tmp_path))
+    nbrs = set(g.neighbors("person:alice"))
+    assert "quote:q1" in nbrs  # GIL SPOKEN_BY
+    assert "episode:e1" in nbrs  # KG MENTIONS
+
+
+def test_layer_prefixed_id_canonicalizes(tmp_path):
+    g = CorpusGraph.build(_write_corpus(tmp_path))
+    assert g.get_node("topic:ai") is not None
+    assert g.get_node("kg:topic:ai") is None  # canonicalized into topic:ai
+
+
+# --- traversal -----------------------------------------------------------------
+
+
+def test_bfs_reaches_insight_from_person(tmp_path):
+    g = CorpusGraph.build(_write_corpus(tmp_path))
+    dist = g.bfs("person:alice", max_hops=3)
+    # person:alice -SPOKEN_BY- quote:q1 -SUPPORTED_BY- insight:i1  (2 hops)
+    # (also person -MENTIONS- episode -HAS_INSIGHT- insight = 2 hops)
+    assert dist.get("insight:i1") == 2
+    assert dist["person:alice"] == 0
+
+
+def test_bfs_respects_max_hops(tmp_path):
+    g = CorpusGraph.build(_write_corpus(tmp_path))
+    dist = g.bfs("person:alice", max_hops=1)
+    assert "insight:i1" not in dist  # 2 hops away
+    assert "episode:e1" in dist and dist["episode:e1"] == 1
+
+
+def test_bfs_unknown_start_returns_empty(tmp_path):
+    g = CorpusGraph.build(_write_corpus(tmp_path))
+    assert g.bfs("person:nobody") == {}
+
+
+# --- access helpers ------------------------------------------------------------
+
+
+def test_nodes_by_type_and_degree(tmp_path):
+    g = CorpusGraph.build(_write_corpus(tmp_path))
+    assert g.nodes_by_type("insight") == ["insight:i1"]
+    assert "podcast:show1" in g.nodes_by_type("podcast")
+    # episode:e1 connects to: podcast, insight, person, topic, org -> degree 5
+    assert g.degree("episode:e1") == 5
+    assert g.get_node("missing") is None
+    assert g.get_node(None) is None
+
+
+def test_show_connectivity_present(tmp_path):
+    # FROM_SHOW is satisfied natively: Podcast --HAS_EPISODE--> Episode.
+    g = CorpusGraph.build(_write_corpus(tmp_path))
+    assert "episode:e1" in g.neighbors("podcast:show1")
+
+
+def test_empty_corpus_builds_empty_graph(tmp_path):
+    g = CorpusGraph.build(tmp_path)
+    assert len(g) == 0
+    assert g.neighbors("anything") == []
+
+
+# --- cache ---------------------------------------------------------------------
+
+
+def test_get_corpus_graph_caches(tmp_path):
+    _write_corpus(tmp_path)
+    g1 = get_corpus_graph(tmp_path)
+    g2 = get_corpus_graph(tmp_path)
+    assert g1 is g2
+    clear_corpus_graph_cache()
+    assert get_corpus_graph(tmp_path) is not g1
+
+
+def test_build_from_real_fixture_corpus():
+    g = CorpusGraph.build(Path("tests/fixtures/viewer-validation-corpus"))
+    assert len(g) > 0

--- a/tests/unit/search/test_corpus_graph.py
+++ b/tests/unit/search/test_corpus_graph.py
@@ -216,7 +216,11 @@ def _write_variant_corpus(tmp_path):
                 {
                     "episode_id": ep,
                     "nodes": [
-                        {"id": f"episode:{ep}", "type": "Episode", "properties": {}},
+                        {
+                            "id": f"episode:{ep}",
+                            "type": "Episode",
+                            "properties": {"podcast_id": "show:lots"},
+                        },
                         {"id": org, "type": "Entity", "properties": {"name": org.split(":")[1]}},
                     ],
                     "edges": [{"type": "MENTIONS", "from": org, "to": f"episode:{ep}"}],
@@ -240,3 +244,14 @@ def test_no_identity_map_keeps_variants_separate(tmp_path):
     g = CorpusGraph.build(_write_variant_corpus(tmp_path))
     assert g.get_node("org:cargil") is not None
     assert g.get_node("org:cargill") is not None
+
+
+def test_get_corpus_graph_canonicalizes_entities_by_default(tmp_path):
+    # Prod path: get_corpus_graph builds + applies the entity canonical map (#852).
+    corpus = _write_variant_corpus(tmp_path)
+    g = get_corpus_graph(corpus)  # canonicalize_entities=True by default
+    assert g.get_node("org:cargil") is None  # auto-merged into the canonical
+    assert g.get_node("org:cargill") is not None
+    clear_corpus_graph_cache()
+    g_off = get_corpus_graph(corpus, canonicalize_entities=False)
+    assert g_off.get_node("org:cargil") is not None  # faithful union when off

--- a/tests/unit/search/test_corpus_graph.py
+++ b/tests/unit/search/test_corpus_graph.py
@@ -203,3 +203,40 @@ def test_get_corpus_graph_caches_per_derive_flag(tmp_path):
     assert plain is not derived
     assert "insight:i1" not in plain.neighbors("person:alice")
     assert "insight:i1" in derived.neighbors("person:alice")
+
+
+# --- #852: identity_map collapses cross-episode variant nodes -------------------
+
+
+def _write_variant_corpus(tmp_path):
+    # Two episodes, same show: org:cargill (ep1) and org:cargil (ep2, a spelling variant).
+    for ep, org in (("e1", "org:cargill"), ("e2", "org:cargil")):
+        (tmp_path / f"{ep}.kg.json").write_text(
+            json.dumps(
+                {
+                    "episode_id": ep,
+                    "nodes": [
+                        {"id": f"episode:{ep}", "type": "Episode", "properties": {}},
+                        {"id": org, "type": "Entity", "properties": {"name": org.split(":")[1]}},
+                    ],
+                    "edges": [{"type": "MENTIONS", "from": org, "to": f"episode:{ep}"}],
+                }
+            )
+        )
+    return tmp_path
+
+
+def test_identity_map_collapses_variant_nodes(tmp_path):
+    corpus = _write_variant_corpus(tmp_path)
+    g = CorpusGraph.build(corpus, identity_map={"org:cargil": "org:cargill"})
+    assert g.get_node("org:cargil") is None  # variant collapsed
+    assert g.get_node("org:cargill") is not None
+    # The remapped node reaches BOTH episodes (its own + the variant's).
+    nbrs = set(g.neighbors("org:cargill"))
+    assert {"episode:e1", "episode:e2"} <= nbrs
+
+
+def test_no_identity_map_keeps_variants_separate(tmp_path):
+    g = CorpusGraph.build(_write_variant_corpus(tmp_path))
+    assert g.get_node("org:cargil") is not None
+    assert g.get_node("org:cargill") is not None

--- a/tests/unit/search/test_corpus_graph.py
+++ b/tests/unit/search/test_corpus_graph.py
@@ -179,3 +179,27 @@ def test_get_corpus_graph_caches(tmp_path):
 def test_build_from_real_fixture_corpus():
     g = CorpusGraph.build(Path("tests/fixtures/viewer-validation-corpus"))
     assert len(g) > 0
+
+
+# --- Slice C: derived person -> insight shortcut -------------------------------
+
+
+def test_derive_speaker_links_adds_one_hop_person_to_insight(tmp_path):
+    g = CorpusGraph.build(_write_corpus(tmp_path), derive_speaker_links=True)
+    assert "insight:i1" in g.neighbors("person:alice")
+    assert g.bfs("person:alice", max_hops=1).get("insight:i1") == 1
+
+
+def test_derive_off_by_default_keeps_insight_two_hops(tmp_path):
+    g = CorpusGraph.build(_write_corpus(tmp_path))
+    assert "insight:i1" not in g.neighbors("person:alice")
+    assert g.bfs("person:alice").get("insight:i1") == 2
+
+
+def test_get_corpus_graph_caches_per_derive_flag(tmp_path):
+    _write_corpus(tmp_path)
+    plain = get_corpus_graph(tmp_path)
+    derived = get_corpus_graph(tmp_path, derive_speaker_links=True)
+    assert plain is not derived
+    assert "insight:i1" not in plain.neighbors("person:alice")
+    assert "insight:i1" in derived.neighbors("person:alice")


### PR DESCRIPTION
## Summary

Lands the **search retrieval prerequisites** and the **entity-quality** work that the Search
initiative (RFC-090–093 / PRD-031–033) depends on, plus the doc stabilization for that suite. All
local CI is green (`make ci-fast`: format/lint/mypy/bandit/docstrings + 3788 unit + viewer + build).

## What's in here

**#849 — Search retrieval prerequisites** (harvested from #466):
- **Entity resolver** (`identity/resolver.py`) — freeform text → canonical id, exact + fuzzy,
  conservative; process-cached.
- **Cross-layer corpus graph** (`search/corpus_graph.py`) — in-memory id-keyed union of GIL + KG
  with `neighbors()`/`get_node()`/`bfs()`; reaches GIL insight nodes for RFC-091 proximity.
- **Typed edges** resolved as native cross-layer connectivity (no KG schema churn) + an opt-in
  1-hop `person→insight` shortcut.

**#851 — Same-episode entity duplication** (the LLM emitting `Burne`+`Byrne Hobart` in one episode):
- **Slice 1** — deterministic within-episode consolidation (`kg/filters.py`), type-aware,
  acronym-safe (UPS≠USPS).
- **Slice 2** — KG extraction prompt **v4** (one canonical spelling per entity). Eval: 3/3, 4/4 dup
  episodes collapse at the source (`scripts/eval_entity_canonicalization.py`).

**#852 — Cross-episode / cross-podcast drift** (`Tracy`/`Tracey Alloway` across episodes):
- Corpus-wide entity canonical map (`kg/entity_clusters.py`) — frequency + same-show weighted,
  guards (acronym / version-token / distinct content word). Applied via the new
  `CorpusGraph` `identity_map` seam, default-on in the prod graph accessor.
- Real corpus: 35 variants → 33 clusters, 20 cross-episode pairs collapsed, guards held.

**Also:** doc stabilization of the search PRD/RFC suite (PRD-031/032/033, RFC-090/091/092/093,
renumbered + rebased to this repo); `AGENTS.md` rule 14 (read design intent before reasoning about
a subsystem — the bridge "seam, not a merge" lesson).

## Validation
- `make ci-fast` green end-to-end (3788 unit tests + 844/67/22 fast suites, vitest 824, viewer
  build, docs, package build).
- Entity-quality changes validated on the real `my-manual-run-10` corpus with live extraction
  (OpenAI) and the committed eval script.

## Closes
Closes #849 · Closes #851 · Closes #852

## Follow-ups (not in this PR)
- #853 — threshold precision tuning (autoresearch).
- RFC-090/091 implementation proper (this PR is the prerequisites).
- ASR-tier upgrade for severe garbles (a profile decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
