### PR TITLE
feat(search): RFC-090 hybrid-retrieval suite + corpus upgrade framework (#855–#862)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,12 @@ data/eval/runs/
 # Generated eval configs (scripts/eval/pipeline_validate.py auto-writes here)
 data/eval/configs/_pipeline_validate/
 
+# Generated search artifacts — regenerable, never commit the binaries.
+# Two-tier LanceDB index (search/migration.py, #858) + trained query-router model
+# (scripts/train_query_router.py, #860).
+data/lance_index/
+data/query_router.joblib
+
 # Environment variables
 .env
 .env.local

--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,7 @@ validate-kg-schema:
 	fi
 
 # GI/KG viewer v2 (#489): FastAPI + Vite. ``make init`` includes FastAPI via ``[dev]``; cd $(WEB_VIEWER_DIR) && npm install
-.PHONY: serve serve-api serve-ui serve-e2e-mock stack-build stack-build-llm stack-compose-validate stack-up stack-down stack-logs verify-stack-profiles stack-test-build stack-test-build-cloud stack-test-up stack-test-down stack-test-seed stack-test-playwright stack-test-export stack-test-ml stack-test-cloud-thin stack-test-ml-ci deploy-codespace restore-corpus restore-corpus-prod reprocess-corpus-from-transcripts corpus-compat-check smoke-prod corpus-snapshot-manifest-validate corpus-snapshot-select-tag corpus-snapshot-select-tag-prod corpus-snapshot-selftest corpus-snapshot-integration
+.PHONY: serve serve-api serve-ui serve-e2e-mock stack-build stack-build-llm stack-compose-validate stack-up stack-down stack-logs verify-stack-profiles stack-test-build stack-test-build-cloud stack-test-up stack-test-down stack-test-seed stack-test-playwright stack-test-export stack-test-ml stack-test-cloud-thin stack-test-ml-ci deploy-codespace restore-corpus restore-corpus-prod reprocess-corpus-from-transcripts corpus-compat-check upgrade-status upgrade-check upgrade-dry-run upgrade-corpus upgrade-verify smoke-prod corpus-snapshot-manifest-validate corpus-snapshot-select-tag corpus-snapshot-select-tag-prod corpus-snapshot-selftest corpus-snapshot-integration
 SERVE_OUTPUT_DIR ?= ./output
 # Optional corpus-editing + jobs routes (health shows green when on). Override with SERVE_ARGS= to disable.
 SERVE_ARGS ?= --enable-feeds-api --enable-operator-config-api --enable-jobs-api
@@ -1016,6 +1016,33 @@ reprocess-corpus-from-transcripts:
 corpus-compat-check:
 	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
 	$(PYTHON) -c "from pathlib import Path; from podcast_scraper.corpus_version import read_produced_by, assess_corpus_version_compat, MIN_SUPPORTED_CORPUS_CODE_VERSION; from podcast_scraper import __version__; root = Path('$${CORPUS_DIR}').expanduser().resolve(); pb = read_produced_by(root); ver, warn = assess_corpus_version_compat(pb); print(f'server={__version__} min_supported={MIN_SUPPORTED_CORPUS_CODE_VERSION}'); print(f'corpus_code_version={ver!r}'); print(f'produced_by={pb!r}'); import sys; (print(f'WARNING: {warn}') or sys.exit(1)) if warn else print('COMPAT OK')"
+
+# Corpus upgrade-path framework (#862). Managed, idempotent migrations for moving a
+# deployed corpus across releases (2.6 → 2.7 FAISS→LanceDB is step 0001). CORPUS_DIR
+# selects the corpus parent. `upgrade-check` exits 2 when migrations are pending —
+# wire it into boot/CI to detect a corpus that needs upgrading.
+upgrade-status:
+	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
+	$(PYTHON) -m podcast_scraper.cli upgrade status --corpus-dir "$${CORPUS_DIR}"
+
+upgrade-check:
+	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
+	$(PYTHON) -m podcast_scraper.cli upgrade status --corpus-dir "$${CORPUS_DIR}" --json
+
+# Preview the plan without writing anything.
+upgrade-dry-run:
+	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
+	$(PYTHON) -m podcast_scraper.cli upgrade run --corpus-dir "$${CORPUS_DIR}" --dry-run
+
+# Apply pending migrations. Non-interactive (--yes) for automated upgrades; drop
+# `--yes` and run the CLI directly for an interactive confirmation prompt.
+upgrade-corpus:
+	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
+	$(PYTHON) -m podcast_scraper.cli upgrade run --corpus-dir "$${CORPUS_DIR}" --yes
+
+upgrade-verify:
+	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
+	$(PYTHON) -m podcast_scraper.cli upgrade verify --corpus-dir "$${CORPUS_DIR}"
 
 # Post-deploy prod smoke over Tailscale HTTPS (#797). Requires PROD_TAILNET_FQDN.
 # Optional: SMOKE_CORPUS_PATH (in-container corpus root for API path=, e.g. /app/output on prod).

--- a/config/search.yaml
+++ b/config/search.yaml
@@ -8,6 +8,14 @@ backend: lancedb
 lancedb:
   path: ./data/lance_index
 
+# Query router (RFC-092 / #860): how a query's intent is classified, which drives
+# the per-intent signal/tier weights. `rules` is deterministic and dependency-free;
+# `ml` loads a trained classifier (scripts/train_query_router.py) and degrades to
+# rules if the model is absent. Stay on `rules` until the model is trained.
+router:
+  mode: rules  # rules | ml
+  model_path: ./data/query_router.joblib
+
 # Future backends (no implementation yet):
 # turbopuffer:
 #   api_key: ${TPUF_API_KEY}

--- a/config/search.yaml
+++ b/config/search.yaml
@@ -1,0 +1,15 @@
+# Two-tier hybrid search backend configuration (RFC-090 §3.10).
+# Selects the SearchBackend implementation for hybrid retrieval. LanceDB embedded
+# is the initial backend; cloud backends are supported by the abstraction but not
+# yet implemented (swapping backends costs zero changes outside this file).
+
+backend: lancedb
+
+lancedb:
+  path: ./data/lance_index
+
+# Future backends (no implementation yet):
+# turbopuffer:
+#   api_key: ${TPUF_API_KEY}
+#   namespace_segments: podcast_scraper_segments
+#   namespace_insights: podcast_scraper_insights

--- a/docs/guides/CORPUS_UPGRADE.md
+++ b/docs/guides/CORPUS_UPGRADE.md
@@ -1,0 +1,70 @@
+# Corpus upgrade framework (#862)
+
+Managed, idempotent migrations for moving a **deployed corpus** across releases. The
+first registered step is the 2.6 → 2.7 FAISS → two-tier LanceDB migration (RFC-090
+/ #858). Use this when upgrading an on-disk corpus to a newer code version — not for
+fresh corpora (those are produced at the current version by the pipeline).
+
+## TL;DR
+
+```bash
+export CORPUS_DIR=/path/to/corpus            # parent of feeds/
+make upgrade-status   CORPUS_DIR=$CORPUS_DIR  # what's pending? (exit 2 if pending)
+make upgrade-dry-run  CORPUS_DIR=$CORPUS_DIR  # preview the plan, write nothing
+make upgrade-corpus   CORPUS_DIR=$CORPUS_DIR  # apply (non-interactive, --yes)
+make upgrade-verify   CORPUS_DIR=$CORPUS_DIR  # verify applied migrations
+```
+
+Or drive the CLI directly (interactive confirmation, JSON, version ceiling):
+
+```bash
+podcast upgrade status  --corpus-dir $CORPUS_DIR [--json]
+podcast upgrade list    --corpus-dir $CORPUS_DIR
+podcast upgrade run     --corpus-dir $CORPUS_DIR [--dry-run] [--yes] [--to 2.7.0]
+podcast upgrade verify  --corpus-dir $CORPUS_DIR
+```
+
+## Manual vs automated
+
+- **Manual / on-demand:** `upgrade status` to see what's pending, `upgrade run`
+  (no `--yes`) prompts before applying, `--dry-run` previews.
+- **Automated:** `upgrade status --json` exits **2** when migrations are pending
+  (distinct from error=1), so a boot script or CI job can gate on it:
+
+  ```bash
+  podcast upgrade status --corpus-dir "$CORPUS_DIR" --json || \
+    podcast upgrade run --corpus-dir "$CORPUS_DIR" --yes
+  ```
+
+## How it works
+
+- **Version stamp** comes from the corpus's existing `corpus_manifest.json`
+  (`produced_by.code_version`, #796). After a migration runs, the new version is
+  recorded in `upgrade_ledger.json` at the corpus root, which then takes precedence.
+- **Ledger-driven** (like a DB migrations table): a migration runs unless its id is
+  already recorded. Re-runs are safe — steps are idempotent (the FAISS→LanceDB step
+  merge-inserts) and recorded steps are skipped.
+- **Stop on failure:** if a step fails, earlier steps stay recorded; fix and re-run
+  to resume from the failed step.
+
+## Forward-compatibility with a database
+
+The framework is deliberately storage-agnostic so it survives a future move from
+files-on-disk to a database:
+
+- *Where* version + ledger live is behind the `StateStore` protocol
+  (`upgrade/state.py`). Today: JSON on disk. With a DB: add one `DbStateStore` over a
+  `schema_migrations` table — the runner and CLI don't change.
+- A `Migration` (`upgrade/migration.py`) is opaque about storage. A step may rewrite
+  files today and target a DB tomorrow; the runner only sequences and records it.
+
+## Adding a migration
+
+1. Add `upgrade/migrations/mNNNN_<name>.py` subclassing `Migration` (set `id`,
+   `to_version`, `description`; implement `apply`, optionally `verify`). Make `apply`
+   idempotent.
+2. Register it in `upgrade/registry.py`.
+3. Add unit coverage in `tests/unit/upgrade/`.
+
+Known 2.6 → 2.7 migrations still to inventory/register: vector index rebuilds and the
+cross-episode entity canonical-map rebuild (#852).

--- a/docs/rfc/RFC-090-hybrid-retrieval.md
+++ b/docs/rfc/RFC-090-hybrid-retrieval.md
@@ -301,10 +301,31 @@ def link_insights_to_segments(chunks, insights, tolerance_seconds=2.0):
 
 ### 9. Migration & Configuration
 
-A migration script (`scripts/migrate_to_lancedb_two_tier.py`) chunks each episode, links insights,
-and writes the `segments` and `insights` LanceDB tables with FTS + vector indices. Backend selected
-via `config/search.yaml` (`backend: lancedb`), with commented cloud-backend stanzas for the future
-abstraction.
+`search/migration.py::migrate_faiss_to_lance` re-projects the existing FAISS store into the
+`segments` (Tier 1, from `transcript` chunks) and `insights` (Tier 2) LanceDB tables with FTS +
+vector indices. It **reuses the FAISS embeddings verbatim** rather than re-embedding — deliberately,
+so the Stage-4 eval holds the dense signal constant and isolates the BM25 + RRF contribution. The
+migration is idempotent (merge-insert on `id`). Backend selected via `config/search.yaml`
+(`backend: lancedb`); the router mode (`rules` | `ml`) is configured in the same file.
+
+This migration is the first step of the 2.6 → 2.7 corpus upgrade; the managed upgrade-path runner
+(ordering, version stamp, dry-run, rollback) that registers it is **#862**. A from-corpus indexer
+(chunk via #857 + embed via `indexer` + link insights) is future work.
+
+#### Stage-4 eval result (#858)
+
+`scripts/eval_two_tier_retrieval.py` on the real corpus (149 known-item queries, k=10):
+
+| system | recall@10 | MRR@10 | nDCG@10 |
+| ------ | --------- | ------ | ------- |
+| FAISS  | 1.000     | 0.993  | 0.995   |
+| hybrid | 1.000     | 0.997  | 0.998   |
+
+**Verdict:** hybrid does not regress and marginally improves ranking (MRR +0.003). The known-item
+proxy **saturates** (recall 1.0 on both), so it confirms parity but cannot justify FAISS removal on
+its own. **Decision: deprecate FAISS by notice, do not remove** (Phase 3 below is re-gated). Actual
+removal waits on a discriminating, human-judged query set — which is also the labeled-query source
+RFC-092 (#860) needs, so the two unblock together.
 
 ## Key Decisions
 
@@ -371,8 +392,10 @@ index (not per-PR).
   script, unit tests.
 - **Phase 2 — Query router + tier weights**: rules-based `classify_query()`, per-type weights,
   wire into `RetrievalLayer`, integration tests.
-- **Phase 3 — Eval + FAISS deprecation**: baseline vs hybrid eval; deprecate FAISS on confirmed
-  improvement.
+- **Phase 3 — Eval + FAISS deprecation**: baseline vs hybrid eval (done — see §9 Stage-4 result).
+  FAISS is **deprecated by notice** (`faiss_store.py` docstring); **removal is re-gated** on a
+  discriminating human-judged eval, because the known-item proxy saturated. Cutover orchestration:
+  #862.
 
 **Monitoring:** `make search-health` (segment/insight counts); eval metrics tracked over time;
 log unlinked insights post-migration to inspect linking miss rate.
@@ -414,7 +437,8 @@ Other relationships:
 1. **Phase 1**: Add `lancedb`; build two-tier index via the migration script alongside the existing
    FAISS index (no removal yet).
 2. **Phase 2**: Route viewer/MCP search through `RetrievalLayer`; keep FAISS as fallback.
-3. **Phase 3**: Deprecate FAISS once eval confirms improvement; remove `faiss-cpu` in a later PR.
+3. **Phase 3**: FAISS deprecated by notice (eval confirmed parity, not a clear win — §9). `faiss-cpu`
+   removal deferred to a later PR, gated on a human-judged eval and the #862 upgrade runner.
 
 ## Open Questions
 

--- a/docs/rfc/RFC-092-ml-query-router.md
+++ b/docs/rfc/RFC-092-ml-query-router.md
@@ -114,8 +114,32 @@ class MLQueryRouter(QueryRouter):
 # config/search.yaml
 router:
   mode: rules                                   # "rules" | "ml"
-  ml_model_path: ./models/query_router.onnx     # only used if mode: ml
+  model_path: ./data/query_router.joblib        # only used if mode: ml
 ```
+
+### 4. Implementation status (#860)
+
+Built in `search/query_router.py` (`QueryRouter` protocol, `RulesQueryRouter`, `MLQueryRouter`),
+wired into `RetrievalLayer` via an optional `router=` arg, switched in `config/search.yaml`.
+`scripts/train_query_router.py` bootstraps the labeled set and trains the model. Two deliberate
+deviations from this RFC's sketch:
+
+- **sklearn/joblib, not ONNX.** A `LogisticRegression` over MiniLM embeddings, persisted with
+  joblib. `onnxruntime`/`skl2onnx` are not in the stack and adding them needs approval; sklearn +
+  joblib already are, and still satisfy the local-first / no-cloud constraint. ONNX export can be
+  revisited if a redeploy-as-file-swap workflow demands it.
+- **Template-defined labels, not rules-silver labels.** Goal §4's "silver labels from the rules
+  router" is **circular** — it can only teach the model to copy the rules. Instead each query is
+  generated from an intent *template* (the label is ground truth by construction) with slots filled
+  from **real corpus entities/topics** (FAISS `kg_entity`/`kg_topic` surface text), so the lexical
+  distribution is realistic while the labels are genuine.
+
+**Bootstrap result** (750 queries, 1083 people × 1106 topics, 80/20 split): holdout accuracy 1.000;
+on the same held-out queries the rules router scores 0.867 ground-truth — so **ML adds +13.3 points**,
+recovering intents the bigram-name / keyword rules miss. The 1.0 is inflated by template
+separability, so this is a *bootstrap*, not the final story: **default stays `mode: rules`** until
+the model is validated on real (messy, human-judged) queries — the same query set that re-gates FAISS
+removal in RFC-090 #858. The two unblock together.
 
 ## Key Decisions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - Prod Runbook (always-on VPS): guides/PROD_RUNBOOK.md
       - DGX Spark runbook (RFC-089): guides/DGX_RUNBOOK.md
       - Prod compat validation (#796/#797): guides/PROD_COMPAT_VALIDATION.md
+      - Corpus upgrade framework (#862): guides/CORPUS_UPGRADE.md
       - Stack contract (cross-surface audit): guides/STACK_CONTRACT.md
       - Corpus snapshot manifest and restore: guides/CORPUS_SNAPSHOT_MANIFEST_AND_RESTORE.md
       - Prod Operator Cheat Sheet: guides/PROD_OPERATOR_CHEAT_SHEET.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,8 @@ search = [
   "sentencepiece>=0.1.99,<1.0.0",
   "sentence-transformers>=5.4.1,<6.0.0",
   "faiss-cpu>=1.13.2,<2.0.0",
+  # RFC-090 two-tier hybrid backend: embedded vector + native FTS (BM25) in one store.
+  "lancedb>=0.33.0,<1.0.0",
   "protobuf>=3.20.0,!=6.33.4,<8.0.0",  # Exclude 6.33.4 due to CVE-2026-0994 (fixed in 6.33.5+)
 ]
 # Live pipeline monitor profiling: py-spy + memray (RFC-065; core `--monitor` uses stdlib + psutil + rich)

--- a/scripts/eval_two_tier_retrieval.py
+++ b/scripts/eval_two_tier_retrieval.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Eval two-tier hybrid retrieval vs the FAISS baseline (RFC-090 Stage 4 / #858).
+
+The Stage-4 gate: does hybrid (BM25 + dense + RRF over the two-tier LanceDB index,
+#855/#856) beat the current vector-only FAISS store on a real corpus? Because the
+migration (``search/migration.py``) reuses the FAISS embeddings verbatim, the dense
+signal is held constant across both systems — so the measured delta isolates the
+value of adding BM25 + RRF fusion, which is precisely the RFC-090 hypothesis.
+
+Eval design — known-item retrieval, no human judgments:
+  For each sampled insight, build a *term-subset* query from its salient content
+  words (stopwords dropped, capped at --query-terms). This is neither a verbatim
+  slice (so BM25 gets no free exact-phrase hit) nor the full text (so the dense
+  vector gets no free self-similarity ~1.0). Gold = that insight. Both systems are
+  scored on the insight tier only, apples-to-apples.
+
+  Limitation: a term-subset known-item proxy correlates with, but is not, a
+  human-judged relevance eval. Treat the numbers as a *relative* A/B, not absolute
+  retrieval quality. A labeled query set (also feeds #860's ML router) supersedes
+  this when it exists.
+
+Metrics (k=10): recall@k, MRR@k, nDCG@k (single relevant doc).
+
+Decision rule (RFC-090 Phase 3): FAISS removal is gated on hybrid ≥ FAISS on MRR
+*and* recall here. This script reports the verdict; it does not remove anything.
+
+Usage:
+  python scripts/eval_two_tier_retrieval.py \
+      --faiss-dir .test_outputs/manual/my-manual-run-10/search \
+      --lance-path /tmp/lance_eval --sample 200 --k 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# Repo src on path when run as a script.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from podcast_scraper.providers.ml.embedding_loader import encode  # noqa: E402
+from podcast_scraper.search.backends.lancedb_backend import LanceDBBackend  # noqa: E402
+from podcast_scraper.search.faiss_store import FaissVectorStore  # noqa: E402
+from podcast_scraper.search.migration import migrate_faiss_to_lance  # noqa: E402
+from podcast_scraper.search.retrieval import RetrievalLayer  # noqa: E402
+
+_STOPWORDS = {
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "but",
+    "if",
+    "of",
+    "to",
+    "in",
+    "on",
+    "for",
+    "with",
+    "as",
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "being",
+    "it",
+    "its",
+    "this",
+    "that",
+    "these",
+    "those",
+    "we",
+    "you",
+    "they",
+    "he",
+    "she",
+    "i",
+    "our",
+    "their",
+    "his",
+    "her",
+    "so",
+    "like",
+    "just",
+    "about",
+    "which",
+    "what",
+    "when",
+    "where",
+    "how",
+    "why",
+    "who",
+    "from",
+    "by",
+    "at",
+    "into",
+    "than",
+    "then",
+    "there",
+    "here",
+    "have",
+    "has",
+    "had",
+    "do",
+    "does",
+    "did",
+    "not",
+    "no",
+    "yes",
+    "can",
+    "will",
+    "would",
+    "could",
+    "should",
+    "more",
+    "most",
+    "very",
+    "really",
+}
+
+
+def _term_subset_query(text: str, *, max_terms: int) -> str:
+    """Salient content terms from *text* (stopwords dropped, order preserved)."""
+    seen: set[str] = set()
+    terms: List[str] = []
+    for tok in re.findall(r"[A-Za-z][A-Za-z'\-]+", text):
+        low = tok.lower()
+        if low in _STOPWORDS or len(low) < 3 or low in seen:
+            continue
+        seen.add(low)
+        terms.append(tok)
+        if len(terms) >= max_terms:
+            break
+    return " ".join(terms)
+
+
+def _ndcg_at(rank: Optional[int]) -> float:
+    return 1.0 / math.log2(rank + 1) if rank else 0.0
+
+
+def _rank_of(doc_ids: List[str], gold: str) -> Optional[int]:
+    for i, did in enumerate(doc_ids):
+        if did == gold:
+            return i + 1
+    return None
+
+
+def _faiss_insight_ranks(store: FaissVectorStore, embedding: List[float], k: int) -> List[str]:
+    # Overfetch then filter to insights (FAISS holds 6 doc types).
+    hits = store.search(embedding, top_k=k * 6)
+    out = [h.doc_id for h in hits if h.metadata.get("doc_type") == "insight"]
+    return out[:k]
+
+
+def _hybrid_insight_ranks(
+    layer: RetrievalLayer, query: str, embedding: List[float], k: int
+) -> List[str]:
+    results = layer.retrieve(query, embedding, k=k * 2, tier="insight", signals="hybrid")
+    return [r.doc_id for r in results][:k]
+
+
+def _evaluate(
+    queries: List[Tuple[str, str]],  # (query_text, gold_insight_id)
+    store: FaissVectorStore,
+    layer: RetrievalLayer,
+    k: int,
+) -> Dict[str, Dict[str, float]]:
+    agg = {sys: {"recall": 0.0, "mrr": 0.0, "ndcg": 0.0} for sys in ("faiss", "hybrid")}
+    n = len(queries)
+    for query, gold in queries:
+        emb = encode(query, "minilm-l6", allow_download=True)
+        emb_list = emb.tolist() if hasattr(emb, "tolist") else list(emb)
+        for name, ranks in (
+            ("faiss", _faiss_insight_ranks(store, emb_list, k)),
+            ("hybrid", _hybrid_insight_ranks(layer, query, emb_list, k)),
+        ):
+            rank = _rank_of(ranks, gold)
+            agg[name]["recall"] += 1.0 if rank else 0.0
+            agg[name]["mrr"] += 1.0 / rank if rank else 0.0
+            agg[name]["ndcg"] += _ndcg_at(rank)
+    for name in agg:
+        for metric in agg[name]:
+            agg[name][metric] /= max(n, 1)
+    return agg
+
+
+def main() -> int:
+    """Run the two-tier-vs-FAISS eval and print the verdict."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--faiss-dir", required=True, help="dir with vectors.faiss")
+    ap.add_argument("--lance-path", default=None, help="LanceDB dir (default: temp)")
+    ap.add_argument("--sample", type=int, default=200, help="insight queries to eval")
+    ap.add_argument("--k", type=int, default=10)
+    ap.add_argument("--query-terms", type=int, default=8)
+    args = ap.parse_args()
+
+    lance_path = args.lance_path or tempfile.mkdtemp(prefix="lance_eval_")
+    print(f"Migrating FAISS → LanceDB at {lance_path} ...")
+    stats = migrate_faiss_to_lance(args.faiss_dir, lance_path)
+    print(f"  segments={stats.segments} insights={stats.insights} skipped={stats.skipped}")
+
+    store = FaissVectorStore.load(Path(args.faiss_dir))
+    backend = LanceDBBackend(lance_path, embed_dim=store.embedding_dim)
+    layer = RetrievalLayer(backend)
+
+    # Build the known-item query set: deterministic sample of insights with usable text.
+    md = store.metadata_by_doc_id
+    insights = sorted(
+        (did, m) for did, m in md.items() if m.get("doc_type") == "insight" and m.get("text")
+    )
+    insights = insights[:: max(1, len(insights) // max(args.sample, 1))][: args.sample]
+    queries: List[Tuple[str, str]] = []
+    for did, m in insights:
+        q = _term_subset_query(m["text"], max_terms=args.query_terms)
+        if len(q.split()) >= 3:  # need a non-degenerate query
+            queries.append((q, did))
+    print(f"Evaluating {len(queries)} known-item queries (k={args.k}) ...")
+
+    agg = _evaluate(queries, store, layer, args.k)
+    print("\n  system   recall@{k}   MRR@{k}   nDCG@{k}".format(k=args.k))
+    for name in ("faiss", "hybrid"):
+        a = agg[name]
+        print(f"  {name:7s}  {a['recall']:8.3f}  {a['mrr']:7.3f}  {a['ndcg']:7.3f}")
+
+    f, h = agg["faiss"], agg["hybrid"]
+    wins = h["mrr"] >= f["mrr"] and h["recall"] >= f["recall"]
+    verdict = (
+        "PASS — hybrid ≥ FAISS (FAISS removal unblocked)"
+        if wins
+        else ("HOLD — hybrid did not beat FAISS; keep FAISS, investigate")
+    )
+    print(f"\n  Δ MRR={h['mrr'] - f['mrr']:+.3f}  Δ recall={h['recall'] - f['recall']:+.3f}")
+    print(f"  VERDICT: {verdict}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/train_query_router.py
+++ b/scripts/train_query_router.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Train the ML query router (RFC-092 / #860).
+
+Bootstraps the ≥500 labeled queries the learned router needs, then trains a
+LogisticRegression over MiniLM query embeddings and persists it for
+``search.query_router.MLQueryRouter``.
+
+Where the labels come from — and why they are real, not circular:
+  Each query is generated from an intent *template* (e.g. "exact quote from
+  {person} about {topic}" → ``raw_evidence``). The template defines the ground
+  truth by construction, so the label is genuine — we are NOT silver-labeling with
+  the rules router (which would only teach the model to copy the rules). The slots
+  ({person}, {topic}) are filled from REAL corpus entities/topics (FAISS
+  ``kg_entity`` / ``kg_topic`` surface text), so the lexical distribution matches
+  production queries. A small built-in entity list is used when no corpus is given.
+
+Validation:
+  - Stratified holdout: accuracy + per-class report on unseen queries.
+  - Divergence vs the rules router on the holdout: shows the model learned signal
+    beyond the rules (and where it disagrees) rather than memorising them.
+
+Output: a joblib LogisticRegression whose ``predict`` takes a 384-dim MiniLM
+embedding — exactly what ``MLQueryRouter`` feeds it. No ONNX runtime needed.
+
+Usage:
+  python scripts/train_query_router.py \
+      --faiss-dir .test_outputs/manual/my-manual-run-10/search \
+      --out ./data/query_router.joblib --per-template 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from podcast_scraper.providers.ml.embedding_loader import encode  # noqa: E402
+from podcast_scraper.search.router import classify_query, QUERY_TYPES  # noqa: E402
+
+# Intent templates. `{p}` = person/entity slot, `{t}` = topic slot. The label is
+# the template's intent by construction.
+_TEMPLATES: Dict[str, List[str]] = {
+    "entity_lookup": [
+        "{p}",
+        "who is {p}",
+        "tell me about {p}",
+        "{p} background",
+        "profile of {p}",
+    ],
+    "raw_evidence": [
+        "exact quote from {p} about {t}",
+        "what did {p} say verbatim about {t}",
+        "transcript where {p} mentions {t}",
+        "the phrase {p} used for {t}",
+        "{p} said exactly what about {t}",
+    ],
+    "temporal_tracking": [
+        "how has {t} evolved",
+        "{t} over time",
+        "the history of {t}",
+        "how {p} changed their view on {t}",
+        "trend in {t} discussions",
+    ],
+    "cross_show_synthesis": [
+        "compare {p} and {t}",
+        "{p} versus {t}",
+        "contrast views on {t} across shows",
+        "{t} across shows",
+        "compare how shows cover {t}",
+    ],
+    "semantic": [
+        "{t} explained",
+        "why does {t} matter",
+        "the idea behind {t}",
+        "what drives {t}",
+        "understanding {t}",
+    ],
+}
+
+_FALLBACK_PEOPLE = [
+    "Sam Altman",
+    "Tim Cook",
+    "Byrne Hobart",
+    "Scott Bessent",
+    "Rory Johnston",
+    "Elon Musk",
+    "Jensen Huang",
+    "Janet Yellen",
+    "Patrick Collison",
+    "Marc Andreessen",
+]
+_FALLBACK_TOPICS = [
+    "artificial intelligence",
+    "interest rates",
+    "oil markets",
+    "inflation",
+    "semiconductors",
+    "venture capital",
+    "energy policy",
+    "the dollar",
+    "machine learning",
+    "supply chains",
+]
+
+
+def _corpus_entities(faiss_dir: Path) -> Tuple[List[str], List[str]]:
+    """(people, topics) surface strings from a FAISS index, else built-in fallbacks."""
+    from podcast_scraper.search.faiss_store import FaissVectorStore
+
+    try:
+        store = FaissVectorStore.load(faiss_dir)
+    except Exception:  # noqa: BLE001 - no/unreadable index → fallbacks
+        return _FALLBACK_PEOPLE, _FALLBACK_TOPICS
+    people, topics = [], []
+    for meta in store.metadata_by_doc_id.values():
+        txt = (meta.get("text") or "").strip()
+        if not txt or len(txt) > 40:
+            continue
+        if meta.get("doc_type") == "kg_entity":
+            people.append(txt)
+        elif meta.get("doc_type") == "kg_topic":
+            topics.append(txt)
+    # De-dupe, keep deterministic order.
+    people = list(dict.fromkeys(people)) or _FALLBACK_PEOPLE
+    topics = list(dict.fromkeys(topics)) or _FALLBACK_TOPICS
+    return people, topics
+
+
+def _build_dataset(
+    people: List[str], topics: List[str], per_template: int
+) -> List[Tuple[str, str]]:
+    """Generate (query, intent) pairs — `per_template` per template, slots cycled."""
+    data: List[Tuple[str, str]] = []
+    for intent, templates in _TEMPLATES.items():
+        for tmpl in templates:
+            for i in range(per_template):
+                q = tmpl.format(p=people[i % len(people)], t=topics[i % len(topics)])
+                data.append((q, intent))
+    return data
+
+
+def main() -> int:
+    """Bootstrap labeled queries, train the router, validate, and persist it."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--faiss-dir", default=None, help="corpus FAISS index for real slots")
+    ap.add_argument("--out", default="./data/query_router.joblib")
+    ap.add_argument("--per-template", type=int, default=30)
+    ap.add_argument("--test-frac", type=float, default=0.2)
+    args = ap.parse_args()
+
+    import joblib
+    import numpy as np
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.metrics import classification_report
+    from sklearn.model_selection import train_test_split
+
+    people, topics = (
+        _corpus_entities(Path(args.faiss_dir))
+        if args.faiss_dir
+        else (_FALLBACK_PEOPLE, _FALLBACK_TOPICS)
+    )
+    print(f"Slots: {len(people)} people, {len(topics)} topics")
+
+    dataset = _build_dataset(people, topics, args.per_template)
+    print(f"Generated {len(dataset)} labeled queries across {len(QUERY_TYPES)} intents")
+    if len(dataset) < 500:
+        print(f"WARNING: only {len(dataset)} queries (< 500 target); raise --per-template")
+
+    texts = [q for q, _ in dataset]
+    labels = [y for _, y in dataset]
+    print("Embedding queries (MiniLM) ...")
+    X = np.array([encode(t, "minilm-l6", allow_download=True) for t in texts])
+    y = np.array(labels)
+
+    X_tr, X_te, y_tr, y_te, txt_tr, txt_te = train_test_split(
+        X, y, texts, test_size=args.test_frac, random_state=42, stratify=y
+    )
+    clf = LogisticRegression(max_iter=1000, C=4.0)
+    clf.fit(X_tr, y_tr)
+
+    acc = clf.score(X_te, y_te)
+    print(f"\nHoldout accuracy: {acc:.3f}  (n_test={len(y_te)})")
+    print(classification_report(y_te, clf.predict(X_te), zero_division=0))
+
+    # Divergence vs rules — proves the model isn't just the rules in disguise.
+    preds = clf.predict(X_te)
+    rules = np.array([classify_query(t) for t in txt_te])
+    agree_rules = float((preds == rules).mean())
+    rules_acc = float((rules == y_te).mean())
+    gain = acc - rules_acc
+    print(f"ML vs rules agreement on holdout: {agree_rules:.3f}")
+    print(f"Rules vs ground-truth accuracy:   {rules_acc:.3f}  (ML adds {gain:+.3f})")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(clf, out)
+    print(f"\nSaved router model → {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/podcast_scraper/cli.py
+++ b/src/podcast_scraper/cli.py
@@ -3502,6 +3502,12 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         serve_argv = list(argv[1:]) if len(argv) > 1 else []
         return parse_serve_argv(serve_argv)
 
+    if argv and len(argv) > 0 and argv[0] == "upgrade":
+        from .upgrade.cli_handlers import parse_upgrade_argv
+
+        upgrade_argv = list(argv[1:]) if len(argv) > 1 else []
+        return parse_upgrade_argv(upgrade_argv)
+
     # Check if first argument is "cache" subcommand
     if argv and len(argv) > 0 and argv[0] == "cache":
         # Handle cache subcommand
@@ -4546,6 +4552,11 @@ def main(  # noqa: C901 - main function handles multiple command paths
         from .server.cli_handlers import run_serve
 
         return run_serve(args, log)
+
+    if hasattr(args, "command") and args.command == "upgrade":
+        from .upgrade.cli_handlers import run_upgrade_cli
+
+        return run_upgrade_cli(args, log)
 
     # Handle cache subcommand
     if hasattr(args, "command") and args.command == "cache":

--- a/src/podcast_scraper/search/backend.py
+++ b/src/podcast_scraper/search/backend.py
@@ -1,0 +1,125 @@
+"""Two-tier hybrid search backend contracts (RFC-090 §3.1–3.2).
+
+Coexists with the single-signal ``VectorStore`` (``protocol.py`` / ``FaissVectorStore``)
+until FAISS is deprecated (RFC-090 Stage 4, #858). The two-tier ``SearchBackend``
+exposes BM25 and dense-vector retrieval **separately** so the retrieval layer can
+fuse them — plus a KG-proximity signal (RFC-091) — via RRF (#856).
+
+Tier 1 = transcript segments (raw evidence); Tier 2 = GIL insight nodes
+(synthesized intelligence). Results are mixed by score, not grouped by tier.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Literal, Optional, Protocol, runtime_checkable
+
+Tier = Literal["segment", "insight", "all"]
+
+
+@dataclass
+class SegmentDocument:
+    """Tier 1 — a transcript chunk (raw evidence)."""
+
+    id: str  # "{episode_id}_chunk_{n}"
+    text: str  # 200-300 word chunk, 50-word overlap
+    show_id: str
+    episode_id: str
+    start_time: float  # seconds from episode start
+    end_time: float
+    embedding: List[float] = field(default_factory=list)  # filled by embedding step
+    speaker_id: Optional[str] = None  # if diarized
+    linked_insight_ids: List[str] = field(default_factory=list)  # GIL insights by timestamp overlap
+    source_tier: str = "segment"
+
+
+@dataclass
+class InsightDocument:
+    """Tier 2 — a GIL insight node (synthesized claim / grounded quote)."""
+
+    id: str  # GIL insight node id
+    text: str
+    show_id: str
+    episode_id: str
+    entity_type: str
+    confidence: float
+    derived: bool
+    embedding: List[float] = field(default_factory=list)
+    speaker_id: Optional[str] = None
+    source_segment_id: Optional[str] = None  # back-ref to grounding-quote segment
+    source_tier: str = "insight"
+
+
+@dataclass
+class SearchQuery:
+    """A retrieval request over one or both tiers."""
+
+    text: str
+    embedding: List[float]
+    filters: Dict = field(default_factory=dict)
+    k: int = 20
+    tier: Tier = "all"
+
+
+@dataclass
+class ScoredResult:
+    """One ranked hit from a single signal (or the fused RRF list)."""
+
+    doc_id: str
+    score: float
+    rank: int
+    payload: Dict  # includes source_tier, linked_insight_ids / source_segment_id
+    signal: str  # "bm25" | "vector" | "kg" | "rrf"
+    source_tier: str  # "segment" | "insight" | "compound"
+
+
+@dataclass
+class CompoundResult:
+    """A merged result when a segment and an insight refer to the same content."""
+
+    doc_id: str  # segment id (primary key)
+    score: float  # max(segment_score, insight_score)
+    rank: int
+    segment: ScoredResult
+    insight: ScoredResult
+    signal: str = "rrf"
+    source_tier: str = "compound"
+
+
+@runtime_checkable
+class SearchBackend(Protocol):
+    """Backend that exposes BM25 + vector retrieval separately, over two tiers.
+
+    Decouples signal generation from fusion (RFC-090 KD-1): the retrieval layer
+    runs RRF over the separate ranked lists, so a third (KG) signal plugs in
+    without touching the backend. LanceDB is the initial implementation; cloud
+    backends require no retrieval-layer change.
+    """
+
+    def search_bm25(self, query: SearchQuery) -> List[ScoredResult]:
+        """BM25 (full-text) ranked results for *query* over its tier(s)."""
+        ...
+
+    def search_vector(self, query: SearchQuery) -> List[ScoredResult]:
+        """Dense-vector ranked results for *query* over its tier(s)."""
+        ...
+
+    def upsert_segment(self, doc: SegmentDocument) -> None:
+        """Insert or update a Tier-1 segment document."""
+        ...
+
+    def upsert_insight(self, doc: InsightDocument) -> None:
+        """Insert or update a Tier-2 insight document."""
+        ...
+
+    def delete(self, doc_id: str, tier: Tier) -> None:
+        """Delete a document by id from the given tier."""
+        ...
+
+    def create_indices(self) -> None:
+        """Create the FTS + vector indices required for retrieval."""
+        ...
+
+    def health(self) -> Dict:
+        """Return backend status and per-tier document counts."""
+        ...

--- a/src/podcast_scraper/search/backends/__init__.py
+++ b/src/podcast_scraper/search/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Search backend implementations (RFC-090)."""

--- a/src/podcast_scraper/search/backends/lancedb_backend.py
+++ b/src/podcast_scraper/search/backends/lancedb_backend.py
@@ -1,0 +1,201 @@
+"""LanceDB two-tier ``SearchBackend`` implementation (RFC-090 §3.7).
+
+Two tables — ``segments`` (Tier 1) and ``insights`` (Tier 2) — each with a
+full-text (BM25) index on ``text`` and a vector index on ``embedding``. BM25 and
+vector retrieval are exposed separately so the retrieval layer (#856) fuses them
+via RRF. ``lancedb`` is imported lazily so importing this module is cheap and only
+instantiating the backend requires the dependency.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Dict, List, TYPE_CHECKING
+
+from ..backend import InsightDocument, ScoredResult, SearchQuery, SegmentDocument, Tier
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import pyarrow as pa
+
+# all-MiniLM-L6-v2 dimensionality (matches the existing FAISS index).
+DEFAULT_EMBED_DIM = 384
+
+_SEGMENT_TABLE = "segments"
+_INSIGHT_TABLE = "insights"
+
+
+def _segment_schema(dim: int) -> "pa.Schema":
+    import pyarrow as pa
+
+    return pa.schema(
+        [
+            ("id", pa.string()),
+            ("text", pa.string()),
+            ("embedding", pa.list_(pa.float32(), dim)),
+            ("show_id", pa.string()),
+            ("episode_id", pa.string()),
+            ("speaker_id", pa.string()),
+            ("start_time", pa.float64()),
+            ("end_time", pa.float64()),
+            ("linked_insight_ids", pa.list_(pa.string())),
+            ("source_tier", pa.string()),
+        ]
+    )
+
+
+def _insight_schema(dim: int) -> "pa.Schema":
+    import pyarrow as pa
+
+    return pa.schema(
+        [
+            ("id", pa.string()),
+            ("text", pa.string()),
+            ("embedding", pa.list_(pa.float32(), dim)),
+            ("show_id", pa.string()),
+            ("episode_id", pa.string()),
+            ("speaker_id", pa.string()),
+            ("entity_type", pa.string()),
+            ("confidence", pa.float64()),
+            ("derived", pa.bool_()),
+            ("source_segment_id", pa.string()),
+            ("source_tier", pa.string()),
+        ]
+    )
+
+
+class LanceDBBackend:
+    """Embedded LanceDB backend (segments + insights), BM25 + vector per tier."""
+
+    TABLES = {"segment": _SEGMENT_TABLE, "insight": _INSIGHT_TABLE}
+
+    def __init__(self, path: str, *, embed_dim: int = DEFAULT_EMBED_DIM) -> None:
+        import lancedb
+
+        self.db = lancedb.connect(path)
+        self.embed_dim = embed_dim
+        self._tables: Dict[str, Any] = {}  # tier -> open table (list_tables() is cached)
+
+    # --- table lifecycle -------------------------------------------------------
+
+    def _open_if_exists(self, tier: str):
+        cached = self._tables.get(tier)
+        if cached is not None:
+            return cached
+        try:
+            table = self.db.open_table(self.TABLES[tier])
+        except Exception:  # noqa: BLE001 - table does not exist yet
+            return None
+        self._tables[tier] = table
+        return table
+
+    def _ensure_table(self, tier: str):
+        table = self._open_if_exists(tier)
+        if table is not None:
+            return table
+        schema = (
+            _segment_schema(self.embed_dim)
+            if tier == "segment"
+            else _insight_schema(self.embed_dim)
+        )
+        table = self.db.create_table(self.TABLES[tier], schema=schema)
+        self._tables[tier] = table
+        return table
+
+    def create_indices(self) -> None:
+        """Create FTS (required for BM25) + vector indices on both tables."""
+        for tier in ("segment", "insight"):
+            table = self._ensure_table(tier)
+            table.create_fts_index("text", replace=True)
+            try:
+                table.create_index(vector_column_name="embedding", replace=True)
+            except Exception:  # noqa: BLE001 - small tables use brute force; index optional
+                pass
+
+    def _tables_for_tier(self, tier: Tier) -> List[str]:
+        if tier == "all":
+            return ["segment", "insight"]
+        return [tier]
+
+    # --- retrieval -------------------------------------------------------------
+
+    def _to_sql(self, filters: Dict) -> str | None:
+        # OQ-3 (RFC-090): naive interpolation — parameterise before any user-facing
+        # free-text filter reaches it. Filters today are internal canonical ids.
+        if not filters:
+            return None
+        return " AND ".join(f"{k} = '{v}'" for k, v in filters.items())
+
+    def _run(self, query: SearchQuery, *, query_type: str, score_key: str) -> List[ScoredResult]:
+        where = self._to_sql(query.filters)
+        hits: List[tuple[float, Dict[str, Any], str]] = []
+        for tier in self._tables_for_tier(query.tier):
+            table = self._ensure_table(tier)
+            search_target = query.text if query_type == "fts" else query.embedding
+            req = table.search(search_target, query_type=query_type)
+            if where:
+                req = req.where(where)
+            for row in req.limit(query.k).to_list():
+                raw = float(row.get(score_key, 0.0) or 0.0)
+                # BM25 _score: higher is better; vector _distance: lower is better.
+                score = raw if query_type == "fts" else 1.0 / (1.0 + raw)
+                row.pop("embedding", None)  # keep payload lean
+                hits.append((score, row, tier))
+        hits.sort(key=lambda h: h[0], reverse=True)
+        signal = "bm25" if query_type == "fts" else "vector"
+        return [
+            ScoredResult(
+                doc_id=str(row.get("id")),
+                score=score,
+                rank=i + 1,
+                payload=row,
+                signal=signal,
+                source_tier=tier,
+            )
+            for i, (score, row, tier) in enumerate(hits)
+        ]
+
+    def search_bm25(self, query: SearchQuery) -> List[ScoredResult]:
+        """BM25 (FTS) results over the query's tier(s) (signal ``bm25``)."""
+        return self._run(query, query_type="fts", score_key="_score")
+
+    def search_vector(self, query: SearchQuery) -> List[ScoredResult]:
+        """Dense-vector results over the query's tier(s) (signal ``vector``)."""
+        return self._run(query, query_type="vector", score_key="_distance")
+
+    # --- writes ----------------------------------------------------------------
+
+    def _upsert(self, tier: str, data: Dict[str, Any]) -> None:
+        table = self._ensure_table(tier)
+        (
+            table.merge_insert("id")
+            .when_matched_update_all()
+            .when_not_matched_insert_all()
+            .execute([data])
+        )
+
+    def upsert_segment(self, doc: SegmentDocument) -> None:
+        """Insert or update a Tier-1 segment document."""
+        self._upsert("segment", dataclasses.asdict(doc))
+
+    def upsert_insight(self, doc: InsightDocument) -> None:
+        """Insert or update a Tier-2 insight document."""
+        self._upsert("insight", dataclasses.asdict(doc))
+
+    def delete(self, doc_id: str, tier: Tier) -> None:
+        """Delete a document by id from the given tier's table."""
+        table = self._open_if_exists(tier if tier != "all" else "segment")
+        if table is not None:
+            table.delete(f"id = '{doc_id}'")
+
+    def health(self) -> Dict:
+        """Return backend status + per-table row counts."""
+        try:
+            seg = self._open_if_exists("segment")
+            ins = self._open_if_exists("insight")
+            return {
+                "status": "ok",
+                "segments": seg.count_rows() if seg is not None else 0,
+                "insights": ins.count_rows() if ins is not None else 0,
+            }
+        except Exception as exc:  # noqa: BLE001
+            return {"status": "error", "error": str(exc)}

--- a/src/podcast_scraper/search/context_pack.py
+++ b/src/podcast_scraper/search/context_pack.py
@@ -1,0 +1,135 @@
+"""LITM-aware corpus briefing packs (RFC-093 / #861).
+
+Reshapes ``RetrievalLayer`` output into a structured, token-budgeted document
+positioned for attention: critical grounding at the start, supporting evidence in
+the middle, caveats at the end (LITM — models attend poorly to the middle of long
+contexts). The builder is plain Python — the autoresearch loop can consume it
+directly; the ``corpus_briefing_pack`` MCP tool wrapper is gated on an MCP layer
+that does not exist in this repo yet (separate issue).
+
+``top_contradiction`` / ``coverage_gaps`` remain empty until typed contradiction
+KG edges and a corpus-impact surface exist; the fields are kept so the consumer
+schema is stable when those land.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence
+
+from .backend import CompoundResult, ScoredResult
+from .dedup import Result
+
+
+@dataclass
+class CorpusBriefingPack:
+    """A LITM-positioned, token-budgeted briefing over retrieval results."""
+
+    query: str
+    query_type: str
+    canonical_entity: Optional[Dict] = None
+    top_insight: Optional[ScoredResult] = None
+    top_contradiction: Optional[Dict] = None  # populated when typed KG edges exist
+    supporting_segments: List[ScoredResult] = field(default_factory=list)
+    coverage_summary: Dict = field(default_factory=dict)
+    coverage_gaps: List[str] = field(default_factory=list)  # from corpus-impact surface (future)
+    confidence_p50: float = 0.0
+    token_count: int = 0
+
+    def render(self) -> str:
+        """Serialize to LITM-positioned text (critical → supporting → caveats)."""
+        lines: List[str] = ["[CRITICAL GROUNDING]"]
+        if self.canonical_entity:
+            name = self.canonical_entity.get("name") or self.canonical_entity.get("id")
+            lines.append(f"Entity: {name}")
+        if self.top_insight is not None:
+            lines.append(f"Top insight: {self.top_insight.payload.get('text', '')}")
+        lines.append(f"Contradiction: {self.top_contradiction or 'none detected'}")
+
+        lines.append("")
+        lines.append("[SUPPORTING EVIDENCE]")
+        cov = self.coverage_summary
+        lines.append(
+            f"Coverage: {len(cov.get('show_ids', []))} shows, "
+            f"{cov.get('episode_count', 0)} episodes"
+        )
+        for seg in self.supporting_segments:
+            lines.append(f"- {seg.payload.get('text', '')}")
+
+        lines.append("")
+        lines.append("[CAVEATS]")
+        lines.append(f"Coverage gaps: {', '.join(self.coverage_gaps) or 'none'}")
+        lines.append(f"Confidence (p50): {self.confidence_p50:.2f}")
+        lines.append(f"Date range: {cov.get('date_range') or 'n/a'}")
+        return "\n".join(lines)
+
+
+def _result_payload(result: Result) -> Dict:
+    if isinstance(result, CompoundResult):
+        return result.segment.payload or result.insight.payload
+    return result.payload
+
+
+def _date_range(results: Sequence[Result]) -> Optional[str]:
+    dates = sorted(
+        d
+        for r in results
+        for d in [_result_payload(r).get("publish_date") or _result_payload(r).get("date")]
+        if d
+    )
+    return f"{dates[0]} – {dates[-1]}" if dates else None
+
+
+def _count_tokens(text: str) -> int:
+    # Word-count approximation; a canonical tokenizer is RFC-093 OQ-3.
+    return len(text.split())
+
+
+def build_briefing_pack(
+    query: str,
+    query_type: str,
+    results: Sequence[Result],
+    *,
+    canonical_entity: Optional[Dict] = None,
+    max_tokens: int = 2000,
+) -> CorpusBriefingPack:
+    """Build a LITM-positioned, token-budgeted briefing pack from *results*.
+
+    Compounds contribute their insight (top-grounding candidate) and segment
+    (supporting evidence). Supporting segments are trimmed to fit ``max_tokens``.
+    """
+    insights: List[ScoredResult] = []
+    segments: List[ScoredResult] = []
+    for result in results:
+        if isinstance(result, CompoundResult):
+            insights.append(result.insight)
+            segments.append(result.segment)
+        elif result.source_tier == "insight":
+            insights.append(result)
+        elif result.source_tier == "segment":
+            segments.append(result)
+
+    show_ids = sorted({s for r in results if (s := _result_payload(r).get("show_id"))})
+    episode_count = len({e for r in results if (e := _result_payload(r).get("episode_id"))})
+    confidences = sorted(c for r in insights if (c := r.payload.get("confidence")) is not None)
+    p50 = confidences[len(confidences) // 2] if confidences else 0.0
+
+    pack = CorpusBriefingPack(
+        query=query,
+        query_type=query_type,
+        canonical_entity=canonical_entity,
+        top_insight=insights[0] if insights else None,
+        supporting_segments=segments[:5],
+        coverage_summary={
+            "show_ids": show_ids,
+            "episode_count": episode_count,
+            "date_range": _date_range(results),
+        },
+        confidence_p50=float(p50),
+    )
+
+    pack.token_count = _count_tokens(pack.render())
+    while pack.token_count > max_tokens and pack.supporting_segments:
+        pack.supporting_segments.pop()
+        pack.token_count = _count_tokens(pack.render())
+    return pack

--- a/src/podcast_scraper/search/dedup.py
+++ b/src/podcast_scraper/search/dedup.py
@@ -1,0 +1,62 @@
+"""Compound-result deduplication (RFC-090 §3.4).
+
+When a segment result and an insight result refer to the same content (the
+segment contains the insight's grounding quote), merge them into one
+``CompoundResult`` so consumers (viewer, MCP, autoresearch) receive one object
+with both the raw segment and the synthesized insight. Done once here, not in
+every consumer (RFC-090 KD-3).
+"""
+
+from __future__ import annotations
+
+from typing import List, Set, Union
+
+from .backend import CompoundResult, ScoredResult
+
+Result = Union[ScoredResult, CompoundResult]
+
+
+def deduplicate(results: List[ScoredResult]) -> List[Result]:
+    """Merge segment+insight pairs referring to the same content into compounds.
+
+    A pair merges when the insight's ``source_segment_id`` (or the segment's
+    ``linked_insight_ids``) links them. The compound takes ``max`` score and
+    ``min`` rank; output is re-sorted by score.
+    """
+    segment_map = {r.doc_id: r for r in results if r.source_tier == "segment"}
+    insight_map = {r.doc_id: r for r in results if r.source_tier == "insight"}
+
+    output: List[Result] = []
+    consumed: Set[str] = set()
+
+    for insight_id, insight in insight_map.items():
+        seg_id = insight.payload.get("source_segment_id")
+        if not seg_id or seg_id not in segment_map:
+            # Fall back to the segment->insight link direction.
+            seg_id = next(
+                (
+                    s_id
+                    for s_id, seg in segment_map.items()
+                    if insight_id in (seg.payload.get("linked_insight_ids") or [])
+                ),
+                None,
+            )
+        if seg_id and seg_id in segment_map and seg_id not in consumed:
+            seg = segment_map[seg_id]
+            output.append(
+                CompoundResult(
+                    doc_id=seg_id,
+                    score=max(insight.score, seg.score),
+                    rank=min(insight.rank, seg.rank),
+                    segment=seg,
+                    insight=insight,
+                )
+            )
+            consumed.add(seg_id)
+            consumed.add(insight_id)
+
+    for result in results:
+        if result.doc_id not in consumed:
+            output.append(result)
+
+    return sorted(output, key=lambda r: r.score, reverse=True)

--- a/src/podcast_scraper/search/faiss_store.py
+++ b/src/podcast_scraper/search/faiss_store.py
@@ -1,4 +1,14 @@
-"""FAISS-backed local vector store for semantic corpus search (Phase 1 / #484)."""
+"""FAISS-backed local vector store for semantic corpus search (Phase 1 / #484).
+
+DEPRECATION (RFC-090 / #858): superseded by the two-tier LanceDB backend
+(``search/backends/lancedb_backend.py``), which adds native BM25 + per-tier
+hybrid fusion. Removal is **gated**, not scheduled: the Stage-4 eval
+(``scripts/eval_two_tier_retrieval.py``) confirmed hybrid >= FAISS but on a
+known-item proxy that *saturates* (recall 1.0 both sides), so it cannot justify
+deleting FAISS on its own. A discriminating, human-judged query set must show a
+real hybrid win first. Until then both backends coexist; do not delete this
+module. Upgrade orchestration for the eventual cutover is tracked in #862.
+"""
 
 from __future__ import annotations
 

--- a/src/podcast_scraper/search/fusion.py
+++ b/src/podcast_scraper/search/fusion.py
@@ -1,0 +1,60 @@
+"""Reciprocal Rank Fusion for hybrid retrieval (RFC-090 §3.3).
+
+Fuses independent ranked lists (BM25, dense vector, and — via RFC-091/#859 — KG
+proximity) into one list. RRF uses rank, not raw score, so signals with
+incomparable score scales combine cleanly. Tier weights gently boost insights
+(grounded signal) over raw segments; the query router (#856 router.py) overrides
+these per intent.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence
+
+from .backend import ScoredResult
+
+# Default tier weights: insights are grounded signal, slight boost is appropriate.
+TIER_WEIGHTS: Dict[str, float] = {"insight": 1.2, "segment": 1.0}
+
+
+def rrf_fuse(
+    ranked_lists: Sequence[List[ScoredResult]],
+    *,
+    k: int = 60,
+    signal_weights: Optional[Dict[str, float]] = None,
+    tier_weights: Optional[Dict[str, float]] = None,
+) -> List[ScoredResult]:
+    """Fuse ranked lists via RRF: ``score(d) = Σ (signal_w · tier_w) / (k + rank_i(d))``.
+
+    Each input list must be from a single signal (``result_list[0].signal`` names
+    it). Returns one ``rrf``-signal list ordered by fused score.
+    """
+    signal_weights = signal_weights or {}
+    tier_weights = tier_weights or TIER_WEIGHTS
+    scores: Dict[str, float] = {}
+    payloads: Dict[str, Dict] = {}
+    tiers: Dict[str, str] = {}
+
+    for result_list in ranked_lists:
+        if not result_list:
+            continue
+        signal = result_list[0].signal
+        sw = signal_weights.get(signal, 1.0)
+        for result in result_list:
+            tw = tier_weights.get(result.source_tier, 1.0)
+            scores[result.doc_id] = scores.get(result.doc_id, 0.0) + (sw * tw) / (k + result.rank)
+            payloads.setdefault(result.doc_id, result.payload)
+            tiers.setdefault(result.doc_id, result.source_tier)
+
+    ordered = sorted(scores, key=lambda d: scores[d], reverse=True)
+    return [
+        ScoredResult(
+            doc_id=doc_id,
+            score=scores[doc_id],
+            rank=i + 1,
+            payload=payloads[doc_id],
+            signal="rrf",
+            source_tier=tiers[doc_id],
+        )
+        for i, doc_id in enumerate(ordered)
+    ]

--- a/src/podcast_scraper/search/kg_proximity.py
+++ b/src/podcast_scraper/search/kg_proximity.py
@@ -1,0 +1,75 @@
+"""KG-proximity retrieval signal (RFC-091 / #859).
+
+The third RRF signal: traverse the cross-layer ``CorpusGraph`` (#849) from a
+query's resolved entity and return reachable insight/segment nodes scored by
+inverse hop distance (``1/(hop+1)``). This encodes relational context — that two
+insights connect because they're about the same person's position on the same
+topic across shows — which embedding similarity cannot capture. It plugs into the
+reserved slot in ``RetrievalLayer`` without any backend/fusion change.
+
+Prerequisites (merged, #849): ``CorpusGraph`` (``bfs``/``get_node``) and
+``EntityResolver`` (seeds the traversal from query text).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+from .backend import ScoredResult
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .corpus_graph import CorpusGraph, Node
+
+# Nodes worth returning as retrieval hits (insights are ranked; segments arrive
+# with two-tier indexing). Other node types (person/topic/episode) are traversal
+# waypoints, not results.
+_RESULT_TYPES = ("insight", "segment")
+
+
+def _passes_filters(node: "Node", filters: Optional[Dict]) -> bool:
+    if not filters:
+        return True
+    return all(node.payload.get(key) == value for key, value in filters.items())
+
+
+class KGProximitySearch:
+    """Scores insight/segment nodes by graph hop-distance from a seed entity."""
+
+    def __init__(self, graph: "CorpusGraph", *, max_hops: int = 3):
+        self.graph = graph
+        self.max_hops = max_hops
+
+    def search(
+        self,
+        entity_id: str,
+        *,
+        k: int = 20,
+        filters: Optional[Dict] = None,
+    ) -> List[ScoredResult]:
+        """BFS from *entity_id*; return top-*k* insight/segment hits (signal ``kg``).
+
+        Score decays as ``1/(hop+1)`` (1.0 at the seed, 0.5 one hop out, …). Nodes
+        that are pure traversal waypoints (person/topic/episode) are skipped.
+        """
+        distances = self.graph.bfs(entity_id, max_hops=self.max_hops)
+        results: List[ScoredResult] = []
+        for node_id, hops in distances.items():
+            node = self.graph.get_node(node_id)
+            if node is None or node.type not in _RESULT_TYPES:
+                continue
+            if not _passes_filters(node, filters):
+                continue
+            results.append(
+                ScoredResult(
+                    doc_id=node_id,
+                    score=1.0 / (hops + 1),
+                    rank=0,
+                    payload=node.payload,
+                    signal="kg",
+                    source_tier=node.type,
+                )
+            )
+        results.sort(key=lambda r: r.score, reverse=True)
+        for i, result in enumerate(results):
+            result.rank = i + 1
+        return results[:k]

--- a/src/podcast_scraper/search/migration.py
+++ b/src/podcast_scraper/search/migration.py
@@ -1,0 +1,115 @@
+"""FAISS → two-tier LanceDB migration (RFC-090 Stage 4 / #858).
+
+Re-projects an existing single-index FAISS store into the two-tier LanceDB layout
+(#855): ``insight`` rows become Tier-2 ``InsightDocument``s, ``transcript`` chunks
+become Tier-1 ``SegmentDocument``s. **Embeddings are reused verbatim** — the FAISS
+vectors are the same MiniLM projections the new index would compute, so the
+migration neither re-embeds nor changes the vector space. That is deliberate: it
+makes the Stage-4 A/B (``scripts/eval_two_tier_retrieval.py``) a controlled
+experiment — vector signal held constant, the only new variable is BM25 + RRF
+fusion, which is exactly the RFC-090 hybrid hypothesis.
+
+Other FAISS doc types (``quote``/``summary``/``kg_entity``/``kg_topic``) are not
+part of the two-tier retrieval surface and are skipped; they remain reachable via
+the KG-proximity signal (#859), which reads the corpus graph, not this index.
+
+A from-corpus build path (chunk via #857 ``build_segment_documents`` + embed via
+``indexer`` + link insights) is the eventual production indexer; it is out of
+scope for the migration, whose job is to stand up a LanceDB index comparable to
+the live FAISS one for the gating eval.
+
+This is the first step an operator runs when upgrading a deployed 2.6 corpus to
+2.7. Ordering, version-stamping, dry-run and rollback around it — the managed
+upgrade-path runner that will register this step — are tracked in #862. The
+migration itself is idempotent (merge-insert on ``id``), so re-runs are safe.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+from .backend import InsightDocument, SegmentDocument
+from .backends.lancedb_backend import LanceDBBackend
+from .faiss_store import FaissVectorStore
+
+
+@dataclass
+class MigrationStats:
+    """Counts from a FAISS → LanceDB migration run."""
+
+    segments: int = 0
+    insights: int = 0
+    skipped: int = 0
+    embed_dim: int = 0
+
+
+def _segment_from_faiss(doc_id: str, meta: Dict, embedding: list) -> SegmentDocument:
+    return SegmentDocument(
+        id=doc_id,
+        text=meta.get("text") or "",
+        show_id=meta.get("feed_id") or "",
+        episode_id=meta.get("episode_id") or "",
+        start_time=float(meta.get("timestamp_start_ms") or 0.0) / 1000.0,
+        end_time=float(meta.get("timestamp_end_ms") or 0.0) / 1000.0,
+        embedding=embedding,
+        speaker_id=meta.get("speaker_id"),
+    )
+
+
+def _insight_from_faiss(doc_id: str, meta: Dict, embedding: list) -> InsightDocument:
+    return InsightDocument(
+        id=doc_id,
+        text=meta.get("text") or "",
+        show_id=meta.get("feed_id") or "",
+        episode_id=meta.get("episode_id") or "",
+        entity_type="insight",
+        confidence=float(meta.get("confidence") or 0.0),
+        # FAISS marks quote-grounded insights with ``grounded``; reuse it as the
+        # derived flag so the two-tier payload keeps the provenance bit.
+        derived=bool(meta.get("grounded")),
+        embedding=embedding,
+    )
+
+
+def migrate_faiss_to_lance(
+    faiss_dir: str | Path,
+    lance_path: str | Path,
+    *,
+    limit_per_tier: Optional[int] = None,
+) -> MigrationStats:
+    """Re-project the FAISS store at *faiss_dir* into a two-tier LanceDB index.
+
+    Reuses the stored embeddings; only ``insight`` and ``transcript`` doc types
+    cross over (Tier 2 and Tier 1 respectively). ``limit_per_tier`` caps each tier
+    for smoke runs. Returns per-tier counts. Idempotent (merge-insert on ``id``).
+    """
+    store = FaissVectorStore.load(Path(faiss_dir))
+    vectors = store.export_vectors_by_doc_id()
+    metadata = store.metadata_by_doc_id
+    backend = LanceDBBackend(str(lance_path), embed_dim=store.embedding_dim)
+
+    stats = MigrationStats(embed_dim=store.embedding_dim)
+    for doc_id, meta in metadata.items():
+        doc_type = meta.get("doc_type")
+        vec = vectors.get(doc_id)
+        if vec is None:
+            stats.skipped += 1
+            continue
+        emb = vec.tolist()
+        if doc_type == "transcript":
+            if limit_per_tier is not None and stats.segments >= limit_per_tier:
+                continue
+            backend.upsert_segment(_segment_from_faiss(doc_id, meta, emb))
+            stats.segments += 1
+        elif doc_type == "insight":
+            if limit_per_tier is not None and stats.insights >= limit_per_tier:
+                continue
+            backend.upsert_insight(_insight_from_faiss(doc_id, meta, emb))
+            stats.insights += 1
+        else:
+            stats.skipped += 1
+
+    backend.create_indices()
+    return stats

--- a/src/podcast_scraper/search/query_router.py
+++ b/src/podcast_scraper/search/query_router.py
@@ -1,0 +1,110 @@
+"""Pluggable query router (RFC-092 / #860).
+
+A thin classification seam over the rules table in ``router.py``. The
+``RetrievalLayer`` calls ``QueryRouter.classify`` to pick an intent, which drives
+``signal_weights_for`` / ``tier_weights_for``; *how* the intent is decided —
+hand-written rules or a learned classifier — is swapped here without touching
+fusion, the backend, or the weight tables.
+
+- ``RulesQueryRouter`` wraps the deterministic ``classify_query`` (today's default,
+  zero dependencies, zero training data).
+- ``MLQueryRouter`` loads a joblib-persisted scikit-learn classifier over MiniLM
+  query embeddings (trained by ``scripts/train_query_router.py``). It degrades to
+  the rules router when the model file is absent or fails to load, so enabling
+  ``router.mode: ml`` can never harden into a failure — worst case is rules
+  behaviour. Misclassification only perturbs RRF weights, never drops results
+  (RFC-090 §3.6).
+
+The trained model is a LogisticRegression over the same 384-dim all-MiniLM-L6-v2
+space the index uses (no ONNX runtime dependency — sklearn + joblib are already
+in the stack). Bootstrapping the ≥500 labeled queries it needs is the train
+script's job; until that model exists, ``get_query_router`` returns rules.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional, Protocol
+
+from .router import classify_query, QUERY_TYPES
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_PATH = "./data/query_router.joblib"
+
+
+class QueryRouter(Protocol):
+    """Maps query text → one of ``router.QUERY_TYPES``."""
+
+    def classify(self, text: str) -> str:
+        """Return the detected intent for *text*."""
+        ...
+
+
+class RulesQueryRouter:
+    """Deterministic router — wraps the hand-written ``classify_query`` rules."""
+
+    mode = "rules"
+
+    def classify(self, text: str) -> str:
+        """Return the rules-based intent for *text*."""
+        return classify_query(text)
+
+
+class MLQueryRouter:
+    """Learned router — sklearn classifier over MiniLM query embeddings.
+
+    Loads lazily and falls back to ``RulesQueryRouter`` if the model is missing or
+    unloadable, so the ML mode is always safe to enable.
+    """
+
+    mode = "ml"
+
+    def __init__(self, model_path: str | Path = DEFAULT_MODEL_PATH) -> None:
+        self.model_path = Path(model_path)
+        self._model = None
+        self._fallback = RulesQueryRouter()
+        self._loaded = False
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        self._loaded = True
+        if not self.model_path.is_file():
+            logger.warning("query-router model %s absent; using rules", self.model_path)
+            return
+        try:
+            import joblib
+
+            self._model = joblib.load(self.model_path)
+        except Exception as exc:  # noqa: BLE001 - any load failure degrades to rules
+            logger.warning("query-router model load failed (%s); using rules", exc)
+            self._model = None
+
+    def _embed(self, text: str) -> List[float]:
+        import numpy as np
+
+        from ..providers.ml.embedding_loader import encode
+
+        arr = np.asarray(encode(text, "minilm-l6", allow_download=True), dtype=float).ravel()
+        return [float(x) for x in arr.tolist()]
+
+    def classify(self, text: str) -> str:
+        """Predict the intent for *text* (rules fallback if no model)."""
+        self._ensure_loaded()
+        if self._model is None:
+            return self._fallback.classify(text)
+        try:
+            label = str(self._model.predict([self._embed(text)])[0])
+        except Exception as exc:  # noqa: BLE001 - inference failure degrades to rules
+            logger.warning("query-router inference failed (%s); using rules", exc)
+            return self._fallback.classify(text)
+        return label if label in QUERY_TYPES else self._fallback.classify(text)
+
+
+def get_query_router(mode: str = "rules", *, model_path: Optional[str] = None) -> QueryRouter:
+    """Build the router for *mode* (``rules`` | ``ml``); unknown modes → rules."""
+    if mode == "ml":
+        return MLQueryRouter(model_path or DEFAULT_MODEL_PATH)
+    return RulesQueryRouter()

--- a/src/podcast_scraper/search/retrieval.py
+++ b/src/podcast_scraper/search/retrieval.py
@@ -17,6 +17,7 @@ from .router import classify_query, signal_weights_for, tier_weights_for
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from ..identity.resolver import EntityResolver
     from .kg_proximity import KGProximitySearch
+    from .query_router import QueryRouter
 
 
 class RetrievalLayer:
@@ -28,10 +29,16 @@ class RetrievalLayer:
         *,
         kg_proximity: "Optional[KGProximitySearch]" = None,
         entity_resolver: "Optional[EntityResolver]" = None,
+        router: "Optional[QueryRouter]" = None,
     ):
         self.backend = backend
         self.kg_proximity = kg_proximity
         self.entity_resolver = entity_resolver
+        self.router = router
+
+    def _classify(self, text: str) -> str:
+        """Intent for *text* via the injected router, else the rules default."""
+        return self.router.classify(text) if self.router is not None else classify_query(text)
 
     @staticmethod
     def classify(text: str) -> str:
@@ -56,7 +63,7 @@ class RetrievalLayer:
         ``vector``). Returns a score-ordered list of ``ScoredResult`` /
         ``CompoundResult``.
         """
-        intent = intent or classify_query(text)
+        intent = intent or self._classify(text)
         query = SearchQuery(text=text, embedding=embedding, filters=filters or {}, k=k, tier=tier)
 
         ranked_lists = []

--- a/src/podcast_scraper/search/retrieval.py
+++ b/src/podcast_scraper/search/retrieval.py
@@ -1,0 +1,66 @@
+"""Hybrid retrieval layer: signals → RRF → compound dedup (RFC-090 §3.5).
+
+Ties the backend (#855), fusion (RRF), router (intent → weights), and compound
+dedup together. The KG-proximity signal (RFC-091 / #859) plugs into the reserved
+slot below without touching this layer's contract (RFC-090 KD-1).
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .backend import SearchBackend, SearchQuery, Tier
+from .dedup import deduplicate, Result
+from .fusion import rrf_fuse
+from .router import classify_query, signal_weights_for, tier_weights_for
+
+
+class RetrievalLayer:
+    """Runs the configured signals over a ``SearchBackend`` and fuses them."""
+
+    def __init__(self, backend: SearchBackend):
+        self.backend = backend
+
+    @staticmethod
+    def classify(text: str) -> str:
+        """Detected query intent for *text* (delegates to the rules router)."""
+        return classify_query(text)
+
+    def retrieve(
+        self,
+        text: str,
+        embedding: List[float],
+        *,
+        filters: Optional[dict] = None,
+        k: int = 20,
+        intent: Optional[str] = None,
+        signals: str = "hybrid",
+        tier: Tier = "all",
+    ) -> List[Result]:
+        """Retrieve fused, deduplicated results.
+
+        ``intent`` selects per-query signal/tier weights (auto-classified when
+        None). ``signals`` chooses which signals to run (``hybrid`` | ``bm25`` |
+        ``vector``). Returns a score-ordered list of ``ScoredResult`` /
+        ``CompoundResult``.
+        """
+        intent = intent or classify_query(text)
+        query = SearchQuery(text=text, embedding=embedding, filters=filters or {}, k=k, tier=tier)
+
+        ranked_lists = []
+        if signals in ("hybrid", "bm25"):
+            ranked_lists.append(self.backend.search_bm25(query))
+        if signals in ("hybrid", "vector"):
+            ranked_lists.append(self.backend.search_vector(query))
+
+        # KG-proximity slot — RFC-091 / #859 resolves an entity from the query and
+        # appends a third ranked list here. No fusion/backend change needed.
+
+        if len(ranked_lists) == 1:
+            return deduplicate(ranked_lists[0])
+        fused = rrf_fuse(
+            ranked_lists,
+            signal_weights=signal_weights_for(intent),
+            tier_weights=tier_weights_for(intent),
+        )
+        return deduplicate(fused)

--- a/src/podcast_scraper/search/retrieval.py
+++ b/src/podcast_scraper/search/retrieval.py
@@ -7,19 +7,31 @@ slot below without touching this layer's contract (RFC-090 KD-1).
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 from .backend import SearchBackend, SearchQuery, Tier
 from .dedup import deduplicate, Result
 from .fusion import rrf_fuse
 from .router import classify_query, signal_weights_for, tier_weights_for
 
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..identity.resolver import EntityResolver
+    from .kg_proximity import KGProximitySearch
+
 
 class RetrievalLayer:
     """Runs the configured signals over a ``SearchBackend`` and fuses them."""
 
-    def __init__(self, backend: SearchBackend):
+    def __init__(
+        self,
+        backend: SearchBackend,
+        *,
+        kg_proximity: "Optional[KGProximitySearch]" = None,
+        entity_resolver: "Optional[EntityResolver]" = None,
+    ):
         self.backend = backend
+        self.kg_proximity = kg_proximity
+        self.entity_resolver = entity_resolver
 
     @staticmethod
     def classify(text: str) -> str:
@@ -53,8 +65,15 @@ class RetrievalLayer:
         if signals in ("hybrid", "vector"):
             ranked_lists.append(self.backend.search_vector(query))
 
-        # KG-proximity slot — RFC-091 / #859 resolves an entity from the query and
-        # appends a third ranked list here. No fusion/backend change needed.
+        # KG-proximity signal (RFC-091): resolve an entity from the query, traverse
+        # the cross-layer graph, append a third ranked list. Graceful skip when the
+        # KG components are absent or no entity resolves.
+        if self.kg_proximity is not None and self.entity_resolver is not None:
+            entity_id = self.entity_resolver.resolve(text)
+            if entity_id:
+                kg_results = self.kg_proximity.search(entity_id, k=k, filters=filters or {})
+                if kg_results:
+                    ranked_lists.append(kg_results)
 
         if len(ranked_lists) == 1:
             return deduplicate(ranked_lists[0])

--- a/src/podcast_scraper/search/router.py
+++ b/src/podcast_scraper/search/router.py
@@ -40,13 +40,13 @@ def classify_query(text: str) -> str:
     return "semantic"
 
 
-# Signal weights per query type (BM25 vs dense vector).
+# Signal weights per query type (BM25 vs dense vector vs KG proximity, RFC-091).
 SIGNAL_WEIGHTS: Dict[str, Dict[str, float]] = {
-    "entity_lookup": {"bm25": 1.4, "vector": 0.6},
-    "raw_evidence": {"bm25": 1.5, "vector": 0.5},
-    "temporal_tracking": {"bm25": 0.8, "vector": 1.2},
-    "cross_show_synthesis": {"bm25": 0.7, "vector": 1.3},
-    "semantic": {"bm25": 1.0, "vector": 1.0},
+    "entity_lookup": {"bm25": 1.4, "vector": 0.6, "kg": 1.2},
+    "raw_evidence": {"bm25": 1.5, "vector": 0.5, "kg": 0.5},
+    "temporal_tracking": {"bm25": 0.8, "vector": 1.2, "kg": 1.0},
+    "cross_show_synthesis": {"bm25": 0.7, "vector": 1.3, "kg": 1.1},
+    "semantic": {"bm25": 1.0, "vector": 1.0, "kg": 1.0},
 }
 
 # Tier weights per query type (override the RRF defaults).

--- a/src/podcast_scraper/search/router.py
+++ b/src/podcast_scraper/search/router.py
@@ -1,0 +1,69 @@
+"""Rules-based query router (RFC-090 §3.6).
+
+Classifies a query into one intent and selects per-intent signal + tier weights.
+Deterministic and dependency-free; the ML router (RFC-092 / #860) replaces
+``classify_query`` behind the same weights without changing this interface.
+Misclassification degrades to sub-optimal weights, not wrong results — RRF is
+robust to weight perturbation.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict
+
+TEMPORAL_WORDS = ["evolve", "changed", "over time", "history", "trend", "shift"]
+SYNTH_WORDS = ["compare", "contrast", " vs ", "versus", "across shows"]
+EVIDENCE_WORDS = ["quote", "said", "exactly", "transcript", "verbatim", "phrase"]
+_NAME_RE = re.compile(r"\b[A-Z][a-z]+ [A-Z][a-z]+\b")
+
+QUERY_TYPES = (
+    "entity_lookup",
+    "raw_evidence",
+    "temporal_tracking",
+    "cross_show_synthesis",
+    "semantic",
+)
+
+
+def classify_query(text: str) -> str:
+    """Return the detected intent for *text* (one of ``QUERY_TYPES``)."""
+    t = f" {text.lower()} "
+    if any(w in t for w in EVIDENCE_WORDS):
+        return "raw_evidence"
+    if any(w in t for w in TEMPORAL_WORDS):
+        return "temporal_tracking"
+    if any(w in t for w in SYNTH_WORDS):
+        return "cross_show_synthesis"
+    if _NAME_RE.search(text):
+        return "entity_lookup"
+    return "semantic"
+
+
+# Signal weights per query type (BM25 vs dense vector).
+SIGNAL_WEIGHTS: Dict[str, Dict[str, float]] = {
+    "entity_lookup": {"bm25": 1.4, "vector": 0.6},
+    "raw_evidence": {"bm25": 1.5, "vector": 0.5},
+    "temporal_tracking": {"bm25": 0.8, "vector": 1.2},
+    "cross_show_synthesis": {"bm25": 0.7, "vector": 1.3},
+    "semantic": {"bm25": 1.0, "vector": 1.0},
+}
+
+# Tier weights per query type (override the RRF defaults).
+TIER_WEIGHTS_BY_QUERY: Dict[str, Dict[str, float]] = {
+    "entity_lookup": {"insight": 1.3, "segment": 0.9},
+    "raw_evidence": {"insight": 0.9, "segment": 1.3},
+    "temporal_tracking": {"insight": 1.2, "segment": 1.0},
+    "cross_show_synthesis": {"insight": 1.2, "segment": 1.0},
+    "semantic": {"insight": 1.2, "segment": 1.0},
+}
+
+
+def signal_weights_for(query_type: str) -> Dict[str, float]:
+    """Signal weights for *query_type* (falls back to ``semantic``)."""
+    return SIGNAL_WEIGHTS.get(query_type, SIGNAL_WEIGHTS["semantic"])
+
+
+def tier_weights_for(query_type: str) -> Dict[str, float]:
+    """Tier weights for *query_type* (falls back to ``semantic``)."""
+    return TIER_WEIGHTS_BY_QUERY.get(query_type, TIER_WEIGHTS_BY_QUERY["semantic"])

--- a/src/podcast_scraper/search/segments.py
+++ b/src/podcast_scraper/search/segments.py
@@ -1,0 +1,82 @@
+"""Segment-document construction + insight linking (RFC-090 §3.8, #857).
+
+Adapts the existing sentence-based ``chunk_transcript`` (chunker.py) into Tier-1
+``SegmentDocument`` objects, and links GIL insights to the segment that contains
+their grounding quote (by timestamp overlap). The segment↔insight link is what
+lets the retrieval layer merge a raw segment and its synthesized insight into a
+``CompoundResult`` (#856 dedup).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from .backend import SegmentDocument
+from .chunker import chunk_transcript
+
+# RFC-090 KD-5: 200–300 words, 50-word overlap.
+DEFAULT_TARGET_TOKENS = 250
+DEFAULT_OVERLAP_TOKENS = 50
+
+
+def build_segment_documents(
+    transcript: str,
+    *,
+    episode_id: str,
+    show_id: str,
+    timestamps: Optional[List[Dict]] = None,
+    speaker_id: Optional[str] = None,
+    target_tokens: int = DEFAULT_TARGET_TOKENS,
+    overlap_tokens: int = DEFAULT_OVERLAP_TOKENS,
+) -> List[SegmentDocument]:
+    """Chunk *transcript* into Tier-1 ``SegmentDocument`` objects.
+
+    ``timestamps`` (Whisper segment dicts with ``char_start``/``char_end`` +
+    ``start_ms``/``end_ms``) drive the per-chunk time span; absent timestamps yield
+    ``0.0`` start/end. ``embedding`` is left empty for the embedding step.
+    """
+    overlap_tokens = min(overlap_tokens, max(0, target_tokens - 1))  # overlap < target
+    chunks = chunk_transcript(
+        transcript,
+        target_tokens=target_tokens,
+        overlap_tokens=overlap_tokens,
+        timestamps=timestamps,
+    )
+    return [
+        SegmentDocument(
+            id=f"{episode_id}_chunk_{ch.chunk_index}",
+            text=ch.text,
+            show_id=show_id,
+            episode_id=episode_id,
+            start_time=(ch.timestamp_start_ms or 0) / 1000.0,
+            end_time=(ch.timestamp_end_ms or 0) / 1000.0,
+            speaker_id=speaker_id,
+        )
+        for ch in chunks
+    ]
+
+
+def link_insights_to_segments(
+    segments: Sequence[SegmentDocument],
+    insight_quotes: Sequence[Tuple[str, Optional[float], Optional[float]]],
+    *,
+    tolerance_seconds: float = 2.0,
+) -> Dict[str, str]:
+    """Link insights to the segment containing their grounding quote (by time).
+
+    ``insight_quotes`` are ``(insight_id, quote_start_s, quote_end_s)`` (convert
+    GIL ms → seconds at the call site). Mutates ``segment.linked_insight_ids`` in
+    place and returns ``{insight_id: segment_id}`` so the caller can set
+    ``InsightDocument.source_segment_id``. One segment per insight (first match).
+    """
+    mapping: Dict[str, str] = {}
+    for insight_id, quote_start, quote_end in insight_quotes:
+        if quote_start is None:
+            continue
+        for seg in segments:
+            end_ok = quote_end is None or quote_end <= seg.end_time + tolerance_seconds
+            if seg.start_time - tolerance_seconds <= quote_start and end_ok:
+                seg.linked_insight_ids.append(insight_id)
+                mapping[insight_id] = seg.id
+                break
+    return mapping

--- a/src/podcast_scraper/upgrade/__init__.py
+++ b/src/podcast_scraper/upgrade/__init__.py
@@ -1,0 +1,39 @@
+"""Managed corpus upgrade-path framework (#862).
+
+A small, ordered, idempotent migration runner for moving a deployed corpus across
+releases (the first concrete step being the 2.6 → 2.7 FAISS → LanceDB migration,
+#858). Two design rules make it forward-compatible with a future database backend
+replacing files-on-disk:
+
+1. **Storage-agnostic state.** *Where* the current version and the applied-migration
+   ledger live is behind the ``StateStore`` protocol (``state.py``). Today that is
+   JSON on disk (``FilesystemStateStore``); introducing a DB means adding one
+   ``DbStateStore`` that reads/writes a ``schema_migrations`` table — the runner and
+   CLI never change.
+2. **Opaque migration steps.** A ``Migration`` (``migration.py``) exposes
+   ``apply`` / ``verify`` / ``plan`` and nothing about storage. A step may rewrite
+   files today and target a DB tomorrow; the runner only sequences them and records
+   the ledger.
+
+The runner is ledger-driven (Rails/Django-style): a migration runs unless its id is
+already recorded, so it is safe to re-run and maps directly onto a DB migrations
+table when that day comes.
+"""
+
+from __future__ import annotations
+
+from .migration import Migration, MigrationContext, MigrationResult
+from .registry import get_migrations
+from .runner import UpgradeRunner, UpgradeStatus
+from .state import FilesystemStateStore, StateStore
+
+__all__ = [
+    "Migration",
+    "MigrationContext",
+    "MigrationResult",
+    "StateStore",
+    "FilesystemStateStore",
+    "UpgradeRunner",
+    "UpgradeStatus",
+    "get_migrations",
+]

--- a/src/podcast_scraper/upgrade/cli_handlers.py
+++ b/src/podcast_scraper/upgrade/cli_handlers.py
@@ -1,0 +1,200 @@
+"""CLI for the corpus upgrade framework (#862): ``podcast upgrade ...``.
+
+Subcommands give both on-demand and automated operation:
+
+- ``status``  — current vs target version + pending migrations. Exit **2** when
+  upgrades are pending (distinct from error=1), so boot scripts / CI can gate on it.
+- ``list``    — every registered migration with applied|pending state.
+- ``run``     — apply pending migrations. Interactive confirmation by default;
+  ``--yes`` for automation, ``--dry-run`` to preview the plan, ``--to`` to stop at a
+  version. Exit 1 if any step fails.
+- ``verify``  — run each applied migration's verification. Exit 1 on any failure.
+
+``--json`` on any subcommand emits a machine-readable object for pipelines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from .migration import MigrationContext
+from .runner import UpgradeRunner, UpgradeStatus
+from .state import FilesystemStateStore
+
+
+def _add_common(sub: argparse.ArgumentParser) -> None:
+    sub.add_argument(
+        "--corpus-dir",
+        default=os.getenv("CORPUS_DIR") or os.getenv("OUTPUT_DIR"),
+        help="Corpus root (parent of feeds/). Defaults to $CORPUS_DIR / $OUTPUT_DIR.",
+    )
+    sub.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+
+
+def parse_upgrade_argv(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse ``upgrade`` subcommand args into a namespace with ``command='upgrade'``."""
+    parser = argparse.ArgumentParser(prog="podcast_scraper upgrade")
+    subparsers = parser.add_subparsers(dest="upgrade_subcommand", required=True, help="Command")
+
+    _add_common(subparsers.add_parser("status", help="Show version + pending migrations"))
+    _add_common(subparsers.add_parser("list", help="List all migrations + their state"))
+    _add_common(subparsers.add_parser("verify", help="Verify applied migrations"))
+
+    run_p = subparsers.add_parser("run", help="Apply pending migrations")
+    _add_common(run_p)
+    run_p.add_argument("--to", dest="to_version", default=None, help="Stop at this version.")
+    run_p.add_argument("--dry-run", action="store_true", help="Preview the plan; write nothing.")
+    run_p.add_argument("--yes", "-y", action="store_true", help="Skip confirmation (automation).")
+
+    args = parser.parse_args(list(argv))
+    args.command = "upgrade"
+    return args
+
+
+def _resolve_corpus_root(args: argparse.Namespace, log: logging.Logger) -> Optional[Path]:
+    if not args.corpus_dir:
+        log.error("--corpus-dir is required (or set $CORPUS_DIR / $OUTPUT_DIR).")
+        return None
+    return Path(args.corpus_dir).expanduser().resolve()
+
+
+def _runner_for(corpus_root: Path) -> UpgradeRunner:
+    return UpgradeRunner(FilesystemStateStore(corpus_root))
+
+
+def _status_payload(status: UpgradeStatus) -> dict:
+    return {
+        "current_version": status.current_version,
+        "target_version": status.target_version,
+        "applied": status.applied,
+        "pending": [m.id for m in status.pending],
+        "up_to_date": status.up_to_date,
+    }
+
+
+def _cmd_status(runner: UpgradeRunner, as_json: bool, log: logging.Logger) -> int:
+    status = runner.status()
+    if as_json:
+        print(json.dumps(_status_payload(status), indent=2))
+    else:
+        print(f"Current version: {status.current_version or 'unstamped'}")
+        print(f"Target version:  {status.target_version or 'n/a'}")
+        print(f"Applied:         {', '.join(status.applied) or 'none'}")
+        if status.pending:
+            print(f"Pending ({len(status.pending)}):")
+            for m in status.pending:
+                print(f"  - {m.id} → {m.to_version}: {m.description}")
+        else:
+            print("Up to date — no pending migrations.")
+    return 0 if status.up_to_date else 2  # 2 = action needed (distinct from error)
+
+
+def _cmd_list(runner: UpgradeRunner, as_json: bool) -> int:
+    applied = set(runner.state.applied_migration_ids())
+    rows = [
+        {
+            "id": m.id,
+            "to_version": m.to_version,
+            "description": m.description,
+            "state": "applied" if m.id in applied else "pending",
+        }
+        for m in runner.migrations
+    ]
+    if as_json:
+        print(json.dumps(rows, indent=2))
+    else:
+        for r in rows:
+            print(f"  [{r['state']:7s}] {r['id']} → {r['to_version']}: {r['description']}")
+    return 0
+
+
+def _cmd_verify(runner: UpgradeRunner, ctx: MigrationContext, as_json: bool) -> int:
+    results = runner.verify(ctx)
+    ok_all = all(ok for _, ok, _ in results)
+    if as_json:
+        print(json.dumps([{"id": i, "ok": ok, "message": m} for i, ok, m in results], indent=2))
+    else:
+        if not results:
+            print("No applied migrations to verify.")
+        for mid, ok, msg in results:
+            print(f"  [{'OK ' if ok else 'FAIL'}] {mid}: {msg}")
+    return 0 if ok_all else 1
+
+
+def _confirm(status: UpgradeStatus, log: logging.Logger) -> bool:
+    if not sys.stdin.isatty():
+        log.error("Refusing to apply without confirmation; pass --yes for automation.")
+        return False
+    names = ", ".join(m.id for m in status.pending)
+    reply = input(f"Apply {len(status.pending)} migration(s) [{names}]? [y/N] ").strip().lower()
+    return reply in ("y", "yes")
+
+
+def _cmd_run(
+    runner: UpgradeRunner, ctx: MigrationContext, args: argparse.Namespace, log: logging.Logger
+) -> int:
+    status = runner.status()
+    if not status.pending:
+        print("Up to date — nothing to run.")
+        return 0
+    if not args.dry_run and not args.yes and not _confirm(status, log):
+        print("Aborted.")
+        return 1
+
+    now = datetime.now(timezone.utc).isoformat()
+    results = runner.run(ctx, to_version=args.to_version, now=now)
+    payload: List[dict] = [
+        {
+            "id": r.migration_id,
+            "applied": r.applied,
+            "dry_run": r.dry_run,
+            "message": r.message,
+            "details": r.details,
+        }
+        for r in results
+    ]
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        for r in results:
+            tag = "DRY-RUN" if r.dry_run else ("applied" if r.applied else "skipped")
+            print(f"  [{tag}] {r.migration_id}: {r.message}")
+        remaining = runner.pending()
+        if not args.dry_run:
+            print(
+                f"\nNow at version {runner.state.current_version() or 'unstamped'}; "
+                f"{len(remaining)} pending."
+            )
+    return 0
+
+
+def run_upgrade_cli(args: argparse.Namespace, log: logging.Logger) -> int:
+    """Dispatch a parsed ``upgrade`` namespace to its subcommand handler."""
+    corpus_root = _resolve_corpus_root(args, log)
+    if corpus_root is None:
+        return 1
+    runner = _runner_for(corpus_root)
+    ctx = MigrationContext(
+        corpus_root=corpus_root,
+        dry_run=getattr(args, "dry_run", False),
+        logger=log,
+    )
+
+    sub = args.upgrade_subcommand
+    if sub == "status":
+        return _cmd_status(runner, args.json, log)
+    if sub == "list":
+        return _cmd_list(runner, args.json)
+    if sub == "verify":
+        return _cmd_verify(runner, ctx, args.json)
+    if sub == "run":
+        return _cmd_run(runner, ctx, args, log)
+    log.error("Unknown upgrade subcommand: %s", sub)
+    return 1

--- a/src/podcast_scraper/upgrade/migration.py
+++ b/src/podcast_scraper/upgrade/migration.py
@@ -1,0 +1,78 @@
+"""Migration step abstractions (#862).
+
+A ``Migration`` is an opaque, ordered, idempotent unit of corpus-upgrade work. It
+knows nothing about *where* state is stored — the runner records the ledger via a
+``StateStore`` — so the same step interface works whether the corpus is files on
+disk today or a database later. A step that rewrites files now and one that targets
+a DB later are indistinguishable to the runner.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+
+@dataclass
+class MigrationContext:
+    """Inputs a migration needs to run, decoupled from storage specifics.
+
+    ``options`` is the per-migration override bag (e.g. an explicit index path) and
+    the natural extension point for a future DB handle — adding one means adding a
+    field here, not changing every migration signature.
+    """
+
+    corpus_root: Path
+    dry_run: bool = False
+    options: Dict[str, Any] = field(default_factory=dict)
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("upgrade"))
+
+    def log(self, message: str) -> None:
+        """Emit an info-level progress line (prefixed in dry-run)."""
+        self.logger.info("%s%s", "[dry-run] " if self.dry_run else "", message)
+
+
+@dataclass
+class MigrationResult:
+    """Outcome of a single migration's ``apply``."""
+
+    migration_id: str
+    applied: bool
+    dry_run: bool = False
+    message: str = ""
+    details: Dict[str, Any] = field(default_factory=dict)
+
+
+class Migration(ABC):
+    """One ordered, idempotent corpus-upgrade step.
+
+    Subclasses set ``id`` (stable, lexicographically ordered, e.g.
+    ``"0001_faiss_to_lance"``), ``to_version`` (the corpus version this step brings
+    the corpus to), and ``description``; and implement ``apply``. ``apply`` must be
+    safe to run more than once — the ledger prevents re-runs, but defence in depth
+    (e.g. merge-insert writes) keeps a manual re-run harmless.
+    """
+
+    id: str = ""
+    to_version: str = ""
+    description: str = ""
+
+    @abstractmethod
+    def apply(self, ctx: MigrationContext) -> MigrationResult:
+        """Perform the migration (or, when ``ctx.dry_run``, only report the plan)."""
+        raise NotImplementedError
+
+    def verify(self, ctx: MigrationContext) -> Tuple[bool, str]:
+        """Check the migration's effect is present; ``(ok, message)``.
+
+        Default: no verification (always ``True``). Steps with a checkable outcome
+        (row counts, file existence) should override.
+        """
+        return True, "no verification defined"
+
+    def plan(self, ctx: MigrationContext) -> str:
+        """One-line human description of what ``apply`` would do for this corpus."""
+        return self.description

--- a/src/podcast_scraper/upgrade/migrations/__init__.py
+++ b/src/podcast_scraper/upgrade/migrations/__init__.py
@@ -1,0 +1,4 @@
+"""Concrete corpus-upgrade migrations (#862).
+
+One module per step, named ``mNNNN_*`` to keep filesystem and registry order aligned.
+"""

--- a/src/podcast_scraper/upgrade/migrations/m0001_faiss_to_lance.py
+++ b/src/podcast_scraper/upgrade/migrations/m0001_faiss_to_lance.py
@@ -1,0 +1,92 @@
+"""0001 — FAISS → two-tier LanceDB index (2.6 → 2.7, #858 under #862).
+
+The first registered upgrade step. Wraps ``search.migration.migrate_faiss_to_lance``
+behind the ``Migration`` interface so the runner sequences, records, and verifies it
+like any other step. Idempotent: the underlying migration merge-inserts on id, and a
+missing FAISS index is a clean no-op (a brand-new corpus has nothing to migrate).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+from ...search.faiss_store import VECTORS_FILE
+from ..migration import Migration, MigrationContext, MigrationResult
+
+
+class FaissToLanceMigration(Migration):
+    """Re-project the corpus FAISS index into the two-tier LanceDB layout."""
+
+    id = "0001_faiss_to_lance"
+    to_version = "2.7.0"
+    description = "Build the two-tier LanceDB index from the existing FAISS index (RFC-090, #858)"
+
+    def _faiss_dir(self, ctx: MigrationContext) -> Path:
+        return Path(ctx.options.get("faiss_dir") or ctx.corpus_root / "search")
+
+    def _lance_path(self, ctx: MigrationContext) -> Path:
+        # Default: co-located with the corpus so the index travels with it.
+        return Path(ctx.options.get("lance_path") or ctx.corpus_root / "search" / "lance_index")
+
+    def plan(self, ctx: MigrationContext) -> str:
+        """Describe the source FAISS index and the target LanceDB path."""
+        faiss_dir = self._faiss_dir(ctx)
+        if not (faiss_dir / VECTORS_FILE).is_file():
+            return f"No FAISS index at {faiss_dir} — nothing to migrate (no-op)."
+        return f"Migrate {faiss_dir}/{VECTORS_FILE} → two-tier LanceDB at {self._lance_path(ctx)}"
+
+    def apply(self, ctx: MigrationContext) -> MigrationResult:
+        """Run the FAISS→LanceDB migration (or report the plan when dry-run)."""
+        faiss_dir = self._faiss_dir(ctx)
+        lance_path = self._lance_path(ctx)
+
+        if not (faiss_dir / VECTORS_FILE).is_file():
+            ctx.log(f"no FAISS index at {faiss_dir}; nothing to migrate")
+            return MigrationResult(
+                self.id, applied=True, dry_run=ctx.dry_run, message="no FAISS index — no-op"
+            )
+
+        if ctx.dry_run:
+            ctx.log(self.plan(ctx))
+            return MigrationResult(self.id, applied=False, dry_run=True, message=self.plan(ctx))
+
+        from ...search.migration import migrate_faiss_to_lance
+
+        ctx.log(f"migrating {faiss_dir} → {lance_path}")
+        stats = migrate_faiss_to_lance(faiss_dir, lance_path)
+        details = {
+            "segments": stats.segments,
+            "insights": stats.insights,
+            "skipped": stats.skipped,
+            "lance_path": str(lance_path),
+        }
+        return MigrationResult(
+            self.id,
+            applied=True,
+            dry_run=False,
+            message=f"migrated segments={stats.segments} insights={stats.insights}",
+            details=details,
+        )
+
+    def verify(self, ctx: MigrationContext) -> Tuple[bool, str]:
+        """Confirm the LanceDB index exists with non-empty tiers (skip pure no-op)."""
+        faiss_dir = self._faiss_dir(ctx)
+        if not (faiss_dir / VECTORS_FILE).is_file():
+            return True, "no source FAISS index (no-op migration)"
+        lance_path = self._lance_path(ctx)
+        if not lance_path.exists():
+            return False, f"LanceDB index missing at {lance_path}"
+        try:
+            from ...search.backends.lancedb_backend import LanceDBBackend
+
+            health = LanceDBBackend(str(lance_path)).health()
+        except Exception as exc:  # noqa: BLE001 - surface as a verify failure
+            return False, f"LanceDB health check failed: {exc}"
+        total = int(health.get("segments", 0)) + int(health.get("insights", 0))
+        if total <= 0:
+            return False, "LanceDB index has no rows"
+        return (
+            True,
+            f"LanceDB ok: segments={health.get('segments')} insights={health.get('insights')}",
+        )

--- a/src/podcast_scraper/upgrade/registry.py
+++ b/src/podcast_scraper/upgrade/registry.py
@@ -1,0 +1,23 @@
+"""Ordered registry of corpus-upgrade migrations (#862).
+
+Future migrations (index rebuilds, the entity canonical-map rebuild #852, schema
+deltas, or a files → DB move) append here with the next ``mNNNN_`` id. The runner
+applies any registered migration whose id is not yet in the corpus ledger.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from .migration import Migration
+from .migrations.m0001_faiss_to_lance import FaissToLanceMigration
+
+# Source of truth, declared in intended apply order.
+_MIGRATIONS: List[Migration] = [
+    FaissToLanceMigration(),
+]
+
+
+def get_migrations() -> List[Migration]:
+    """All registered migrations, sorted by id (lexicographic == apply order)."""
+    return sorted(_MIGRATIONS, key=lambda m: m.id)

--- a/src/podcast_scraper/upgrade/runner.py
+++ b/src/podcast_scraper/upgrade/runner.py
@@ -1,0 +1,109 @@
+"""Upgrade runner: sequence pending migrations, record the ledger (#862).
+
+Ledger-driven: a migration is pending iff its id is not in the ``StateStore``'s
+applied set. Migrations run in id order; each successful apply is recorded and the
+corpus version advanced. A migration that raises stops the run — earlier steps stay
+recorded (forward progress is preserved and the ledger reflects reality), so a fixed
+re-run resumes from the failed step. This is exactly how a DB migrations table
+behaves, so the contract survives a future move off the filesystem.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+from packaging.version import InvalidVersion, Version
+
+from .migration import Migration, MigrationContext, MigrationResult
+from .registry import get_migrations
+from .state import StateStore
+
+
+@dataclass
+class UpgradeStatus:
+    """Snapshot of where a corpus sits relative to the registered migrations."""
+
+    current_version: Optional[str]
+    target_version: Optional[str]
+    applied: List[str]
+    pending: List[Migration]
+    up_to_date: bool = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Derive ``up_to_date`` from whether anything is pending."""
+        self.up_to_date = not self.pending
+
+
+class UpgradeRunner:
+    """Plans and applies pending migrations against a ``StateStore``."""
+
+    def __init__(
+        self, state_store: StateStore, migrations: Optional[List[Migration]] = None
+    ) -> None:
+        self.state = state_store
+        source = migrations if migrations is not None else get_migrations()
+        # Id order is a runner invariant — migrations must apply deterministically in
+        # sequence regardless of how the list was supplied.
+        self.migrations = sorted(source, key=lambda m: m.id)
+
+    @staticmethod
+    def _as_version(raw: str) -> Version:
+        try:
+            return Version(raw)
+        except InvalidVersion:
+            return Version("0")
+
+    def _target_version(self) -> Optional[str]:
+        versions = [m.to_version for m in self.migrations if m.to_version]
+        return max(versions, key=self._as_version) if versions else None
+
+    def pending(self) -> List[Migration]:
+        """Registered migrations whose id is not yet recorded as applied."""
+        applied = self.state.applied_migration_ids()
+        return [m for m in self.migrations if m.id not in applied]
+
+    def status(self) -> UpgradeStatus:
+        """Current vs target version, applied ids, and the pending migration list."""
+        applied = self.state.applied_migration_ids()
+        return UpgradeStatus(
+            current_version=self.state.current_version(),
+            target_version=self._target_version(),
+            applied=sorted(applied),
+            pending=self.pending(),
+        )
+
+    def run(
+        self,
+        ctx: MigrationContext,
+        *,
+        to_version: Optional[str] = None,
+        now: str = "",
+    ) -> List[MigrationResult]:
+        """Apply pending migrations in order (optionally only up to *to_version*).
+
+        Records each applied migration in the ledger unless ``ctx.dry_run``. Stops at
+        the first migration that raises, after collecting results for the steps that
+        did run. ``now`` is the timestamp stamped into ledger records (passed in so
+        the runner stays deterministic / clock-free).
+        """
+        results: List[MigrationResult] = []
+        ceiling = self._as_version(to_version) if to_version is not None else None
+        for migration in self.pending():
+            if ceiling is not None and self._as_version(migration.to_version) > ceiling:
+                continue
+            result = migration.apply(ctx)
+            results.append(result)
+            if result.applied and not ctx.dry_run:
+                self.state.record_applied(migration.id, to_version=migration.to_version, at=now)
+        return results
+
+    def verify(self, ctx: MigrationContext) -> List[Tuple[str, bool, str]]:
+        """Run ``verify`` for every applied migration; ``[(id, ok, message)]``."""
+        applied = self.state.applied_migration_ids()
+        out: List[Tuple[str, bool, str]] = []
+        for migration in self.migrations:
+            if migration.id in applied:
+                ok, msg = migration.verify(ctx)
+                out.append((migration.id, ok, msg))
+        return out

--- a/src/podcast_scraper/upgrade/state.py
+++ b/src/podcast_scraper/upgrade/state.py
@@ -1,0 +1,96 @@
+"""Upgrade state: current version + applied-migration ledger (#862).
+
+``StateStore`` is the single seam that makes the framework storage-agnostic. The
+filesystem implementation keeps the ledger in ``upgrade_ledger.json`` at the corpus
+root and reads the corpus's produced-by code version from the existing
+``corpus_manifest.json`` (``corpus_version.py``, #796) — it does **not** invent a
+second version concept. A future database backend implements the same four methods
+against a ``schema_migrations`` table; nothing above this file changes.
+
+Version reporting precedence: the ledger's recorded version (set as migrations
+advance the corpus) wins; absent that, the manifest's produced-by code version; else
+``None`` (unstamped corpus).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Optional, Protocol, Set
+
+from ..corpus_version import corpus_code_version, read_produced_by
+
+LEDGER_FILE = "upgrade_ledger.json"
+
+
+class StateStore(Protocol):
+    """Persists the upgrade ledger + current version, independent of storage medium."""
+
+    def current_version(self) -> Optional[str]:
+        """Return the corpus's current version, or ``None`` if unstamped."""
+        ...
+
+    def applied_migration_ids(self) -> Set[str]:
+        """Return the set of migration ids already applied."""
+        ...
+
+    def record_applied(self, migration_id: str, *, to_version: str, at: str) -> None:
+        """Record *migration_id* as applied and advance the version to *to_version*."""
+        ...
+
+
+class FilesystemStateStore:
+    """``StateStore`` backed by a JSON ledger at the corpus root."""
+
+    def __init__(self, corpus_root: Path) -> None:
+        self.corpus_root = Path(corpus_root)
+        self.ledger_path = self.corpus_root / LEDGER_FILE
+
+    def _read_ledger(self) -> dict:
+        if not self.ledger_path.is_file():
+            return {}
+        try:
+            data = json.loads(self.ledger_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _write_ledger(self, data: dict) -> None:
+        self.corpus_root.mkdir(parents=True, exist_ok=True)
+        self.ledger_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+
+    def current_version(self) -> Optional[str]:
+        """Ledger version if set, else the manifest produced-by code version."""
+        ledger = self._read_ledger()
+        ver = ledger.get("version")
+        if isinstance(ver, str) and ver.strip():
+            return ver.strip()
+        return corpus_code_version(read_produced_by(self.corpus_root))
+
+    def applied_migration_ids(self) -> Set[str]:
+        """Migration ids recorded in the ledger's ``applied`` list."""
+        ledger = self._read_ledger()
+        applied = ledger.get("applied")
+        if not isinstance(applied, list):
+            return set()
+        return {
+            str(entry["id"]) for entry in applied if isinstance(entry, dict) and entry.get("id")
+        }
+
+    def applied_records(self) -> List[dict]:
+        """Full applied-migration records (id, to_version, at) in recorded order."""
+        ledger = self._read_ledger()
+        applied = ledger.get("applied")
+        return [e for e in applied if isinstance(e, dict)] if isinstance(applied, list) else []
+
+    def record_applied(self, migration_id: str, *, to_version: str, at: str) -> None:
+        """Append *migration_id* to the ledger and advance the recorded version."""
+        ledger = self._read_ledger()
+        applied = ledger.get("applied")
+        if not isinstance(applied, list):
+            applied = []
+        applied = [e for e in applied if not (isinstance(e, dict) and e.get("id") == migration_id)]
+        applied.append({"id": migration_id, "to_version": to_version, "at": at})
+        ledger["applied"] = applied
+        ledger["version"] = to_version
+        self._write_ledger(ledger)

--- a/tests/integration/search/test_lancedb_backend.py
+++ b/tests/integration/search/test_lancedb_backend.py
@@ -14,7 +14,7 @@ from podcast_scraper.search.backend import (
     SegmentDocument,
 )
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.integration
 
 lancedb = pytest.importorskip("lancedb")
 

--- a/tests/integration/search/test_migration.py
+++ b/tests/integration/search/test_migration.py
@@ -10,7 +10,7 @@ import pytest
 
 from podcast_scraper.search.backend import SearchQuery
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.integration
 
 pytest.importorskip("lancedb")
 pytest.importorskip("faiss")

--- a/tests/integration/upgrade/test_end_to_end.py
+++ b/tests/integration/upgrade/test_end_to_end.py
@@ -10,7 +10,7 @@ import logging
 
 import pytest
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.integration
 
 pytest.importorskip("lancedb")
 pytest.importorskip("faiss")

--- a/tests/unit/search/test_backend.py
+++ b/tests/unit/search/test_backend.py
@@ -1,0 +1,90 @@
+"""Unit tests for the two-tier SearchBackend contracts (RFC-090 §3.1–3.2, #855)."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pytest
+
+from podcast_scraper.search.backend import (
+    CompoundResult,
+    InsightDocument,
+    ScoredResult,
+    SearchBackend,
+    SearchQuery,
+    SegmentDocument,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_segment_document_defaults():
+    seg = SegmentDocument(
+        id="ep1_chunk_0", text="hello", show_id="s", episode_id="ep1", start_time=0.0, end_time=1.0
+    )
+    assert seg.source_tier == "segment"
+    assert seg.embedding == [] and seg.linked_insight_ids == [] and seg.speaker_id is None
+
+
+def test_insight_document_defaults():
+    ins = InsightDocument(
+        id="insight:1",
+        text="claim",
+        show_id="s",
+        episode_id="ep1",
+        entity_type="opinion",
+        confidence=0.9,
+        derived=False,
+    )
+    assert ins.source_tier == "insight"
+    assert ins.embedding == [] and ins.source_segment_id is None
+
+
+def test_search_query_defaults():
+    q = SearchQuery(text="sam altman", embedding=[0.1, 0.2])
+    assert q.k == 20 and q.tier == "all" and q.filters == {}
+
+
+def test_compound_result_wraps_both_tiers():
+    seg = ScoredResult("ep1_chunk_0", 0.8, 1, {}, "vector", "segment")
+    ins = ScoredResult("insight:1", 0.9, 1, {}, "vector", "insight")
+    comp = CompoundResult(doc_id="ep1_chunk_0", score=0.9, rank=1, segment=seg, insight=ins)
+    assert comp.source_tier == "compound" and comp.signal == "rrf"
+    assert comp.segment is seg and comp.insight is ins
+
+
+class _FakeBackend:
+    """Minimal in-memory backend used to verify protocol conformance (no deps)."""
+
+    def __init__(self) -> None:
+        self.segments: Dict[str, SegmentDocument] = {}
+        self.insights: Dict[str, InsightDocument] = {}
+
+    def search_bm25(self, query: SearchQuery) -> List[ScoredResult]:
+        return []
+
+    def search_vector(self, query: SearchQuery) -> List[ScoredResult]:
+        return []
+
+    def upsert_segment(self, doc: SegmentDocument) -> None:
+        self.segments[doc.id] = doc
+
+    def upsert_insight(self, doc: InsightDocument) -> None:
+        self.insights[doc.id] = doc
+
+    def delete(self, doc_id: str, tier) -> None:
+        self.segments.pop(doc_id, None)
+        self.insights.pop(doc_id, None)
+
+    def create_indices(self) -> None:
+        pass
+
+    def health(self) -> Dict:
+        return {"status": "ok", "segments": len(self.segments), "insights": len(self.insights)}
+
+
+def test_fake_backend_satisfies_protocol():
+    backend = _FakeBackend()
+    assert isinstance(backend, SearchBackend)  # runtime_checkable structural check
+    backend.upsert_segment(SegmentDocument("ep1_chunk_0", "t", "s", "ep1", 0.0, 1.0))
+    assert backend.health()["segments"] == 1

--- a/tests/unit/search/test_context_pack.py
+++ b/tests/unit/search/test_context_pack.py
@@ -1,0 +1,80 @@
+"""Unit tests for LITM briefing packs (RFC-093, #861)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.backend import CompoundResult, ScoredResult
+from podcast_scraper.search.context_pack import build_briefing_pack
+
+pytestmark = pytest.mark.unit
+
+
+def _ins(doc_id, text="", show="A", ep="e1", conf=None):
+    payload = {"text": text, "show_id": show, "episode_id": ep}
+    if conf is not None:
+        payload["confidence"] = conf
+    return ScoredResult(doc_id, 0.9, 1, payload, "vector", "insight")
+
+
+def _seg(doc_id, text="", show="A", ep="e1"):
+    return ScoredResult(
+        doc_id, 0.8, 1, {"text": text, "show_id": show, "episode_id": ep}, "bm25", "segment"
+    )
+
+
+def test_top_insight_and_supporting_segments():
+    results = [
+        _ins("i1", "grounded claim", conf=0.9),
+        _seg("s1", "raw quote one"),
+        _seg("s2", "raw quote two"),
+    ]
+    pack = build_briefing_pack("q", "entity_lookup", results)
+    assert pack.top_insight.doc_id == "i1"
+    assert [s.doc_id for s in pack.supporting_segments] == ["s1", "s2"]
+    assert pack.coverage_summary["episode_count"] == 1
+    assert pack.coverage_summary["show_ids"] == ["A"]
+
+
+def test_compound_contributes_both_tiers():
+    seg = _seg("s1", "quote")
+    ins = _ins("i1", "claim", conf=0.7)
+    comp = CompoundResult(doc_id="s1", score=0.9, rank=1, segment=seg, insight=ins)
+    pack = build_briefing_pack("q", "semantic", [comp])
+    assert pack.top_insight.doc_id == "i1"  # insight extracted from the compound
+    assert pack.supporting_segments[0].doc_id == "s1"  # segment too
+
+
+def test_confidence_p50():
+    results = [_ins("i1", conf=0.5), _ins("i2", conf=0.7), _ins("i3", conf=0.9)]
+    pack = build_briefing_pack("q", "semantic", results)
+    assert pack.confidence_p50 == 0.7
+
+
+def test_empty_results_pack():
+    pack = build_briefing_pack("q", "semantic", [])
+    assert pack.top_insight is None and pack.supporting_segments == []
+    assert pack.coverage_summary["episode_count"] == 0
+
+
+def test_render_litm_order_and_stable_null_fields():
+    pack = build_briefing_pack(
+        "q", "semantic", [_ins("i1", "claim")], canonical_entity={"name": "Alice"}
+    )
+    text = pack.render()
+    # critical before supporting before caveats.
+    assert (
+        text.index("[CRITICAL GROUNDING]")
+        < text.index("[SUPPORTING EVIDENCE]")
+        < text.index("[CAVEATS]")
+    )
+    assert "Entity: Alice" in text
+    assert pack.top_contradiction is None and pack.coverage_gaps == []  # stable until inputs exist
+
+
+def test_token_budget_trims_segments():
+    long = "word " * 200
+    results = [_ins("i1", "claim")] + [_seg(f"s{i}", long) for i in range(5)]
+    pack = build_briefing_pack("q", "semantic", results, max_tokens=50)
+    assert pack.token_count <= 50
+    assert len(pack.supporting_segments) < 5  # trimmed to fit

--- a/tests/unit/search/test_kg_proximity.py
+++ b/tests/unit/search/test_kg_proximity.py
@@ -1,0 +1,136 @@
+"""Unit tests for the KG-proximity signal + RetrievalLayer wiring (RFC-091, #859)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from podcast_scraper.search.backend import ScoredResult
+from podcast_scraper.search.corpus_graph import CorpusGraph
+from podcast_scraper.search.kg_proximity import KGProximitySearch
+from podcast_scraper.search.retrieval import RetrievalLayer
+
+pytestmark = pytest.mark.unit
+
+
+def _write_chain_corpus(tmp_path):
+    # person:alice -SPOKEN_BY- quote:q1 -SUPPORTED_BY- insight:i1 -HAS_INSIGHT- episode:e1
+    gi = {
+        "episode_id": "e1",
+        "nodes": [
+            {"id": "podcast:show1", "type": "Podcast", "properties": {}},
+            {"id": "episode:e1", "type": "Episode", "properties": {}},
+            {"id": "person:alice", "type": "Person", "properties": {"name": "Alice"}},
+            {"id": "topic:ai", "type": "Topic", "properties": {"label": "AI"}},
+            {
+                "id": "insight:i1",
+                "type": "Insight",
+                "properties": {"text": "AI insight", "episode_id": "e1"},
+            },
+            {"id": "quote:q1", "type": "Quote", "properties": {"episode_id": "e1"}},
+        ],
+        "edges": [
+            {"type": "HAS_EPISODE", "from": "podcast:show1", "to": "episode:e1"},
+            {"type": "HAS_INSIGHT", "from": "episode:e1", "to": "insight:i1"},
+            {"type": "ABOUT", "from": "insight:i1", "to": "topic:ai"},
+            {"type": "SUPPORTED_BY", "from": "insight:i1", "to": "quote:q1"},
+            {"type": "SPOKEN_BY", "from": "quote:q1", "to": "person:alice"},
+        ],
+    }
+    (tmp_path / "e1.gi.json").write_text(json.dumps(gi))
+    return tmp_path
+
+
+# --- KGProximitySearch ----------------------------------------------------------
+
+
+def test_proximity_returns_insight_with_hop_score(tmp_path):
+    graph = CorpusGraph.build(_write_chain_corpus(tmp_path))
+    res = KGProximitySearch(graph).search("person:alice")
+    # alice→quote(1)→insight(2): the insight is the only result-typed node within 3 hops.
+    assert len(res) == 1
+    r = res[0]
+    assert r.doc_id == "insight:i1" and r.signal == "kg" and r.source_tier == "insight"
+    assert r.score == pytest.approx(1.0 / 3.0)  # 1/(hop+1), hop=2
+    assert r.rank == 1
+
+
+def test_proximity_skips_non_result_node_types(tmp_path):
+    graph = CorpusGraph.build(_write_chain_corpus(tmp_path))
+    res = KGProximitySearch(graph).search("person:alice")
+    returned = {r.doc_id for r in res}
+    assert "quote:q1" not in returned and "topic:ai" not in returned
+    assert "episode:e1" not in returned and "person:alice" not in returned
+
+
+def test_proximity_filters(tmp_path):
+    graph = CorpusGraph.build(_write_chain_corpus(tmp_path))
+    kg = KGProximitySearch(graph)
+    assert kg.search("person:alice", filters={"episode_id": "e1"})  # matches
+    assert kg.search("person:alice", filters={"episode_id": "e2"}) == []  # filtered out
+
+
+def test_proximity_unknown_entity_returns_empty(tmp_path):
+    graph = CorpusGraph.build(_write_chain_corpus(tmp_path))
+    assert KGProximitySearch(graph).search("person:nobody") == []
+
+
+def test_proximity_max_hops_bounds_reach(tmp_path):
+    graph = CorpusGraph.build(_write_chain_corpus(tmp_path))
+    # insight is 2 hops away; max_hops=1 cannot reach it.
+    assert KGProximitySearch(graph, max_hops=1).search("person:alice") == []
+
+
+# --- RetrievalLayer wiring ------------------------------------------------------
+
+
+class _FakeBackend:
+    def search_bm25(self, query):
+        return [ScoredResult("seg1", 1.0, 1, {}, "bm25", "segment")]
+
+    def search_vector(self, query):
+        return [ScoredResult("ins0", 1.0, 1, {}, "vector", "insight")]
+
+
+class _FakeKG:
+    def __init__(self, results):
+        self._results = results
+
+    def search(self, entity_id, *, k=20, filters=None):
+        return list(self._results)
+
+
+class _FakeResolver:
+    def __init__(self, entity_id):
+        self._entity_id = entity_id
+
+    def resolve(self, text):
+        return self._entity_id
+
+
+def test_retrieval_includes_kg_signal_when_entity_resolves():
+    kg_hit = ScoredResult("ins_kg", 0.5, 1, {}, "kg", "insight")
+    layer = RetrievalLayer(
+        _FakeBackend(),
+        kg_proximity=_FakeKG([kg_hit]),
+        entity_resolver=_FakeResolver("person:alice"),
+    )
+    out = layer.retrieve("Sam Altman", [0.1, 0.2])
+    assert "ins_kg" in {r.doc_id for r in out}  # KG hit entered the fused results
+
+
+def test_retrieval_skips_kg_when_entity_unresolved():
+    layer = RetrievalLayer(
+        _FakeBackend(),
+        kg_proximity=_FakeKG([ScoredResult("ins_kg", 0.5, 1, {}, "kg", "insight")]),
+        entity_resolver=_FakeResolver(None),  # no entity
+    )
+    out = layer.retrieve("nothing here", [0.1])
+    assert "ins_kg" not in {r.doc_id for r in out}
+
+
+def test_retrieval_without_kg_components_unchanged():
+    layer = RetrievalLayer(_FakeBackend())
+    out = layer.retrieve("Sam Altman", [0.1])
+    assert {r.doc_id for r in out} == {"seg1", "ins0"}

--- a/tests/unit/search/test_lancedb_backend.py
+++ b/tests/unit/search/test_lancedb_backend.py
@@ -1,0 +1,96 @@
+"""Tests for the LanceDB two-tier backend (RFC-090 §3.7, #855).
+
+Uses a real embedded LanceDB in a temp dir with tiny 4-dim vectors (fast).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.backend import (
+    InsightDocument,
+    SearchBackend,
+    SearchQuery,
+    SegmentDocument,
+)
+
+pytestmark = pytest.mark.unit
+
+lancedb = pytest.importorskip("lancedb")
+
+from podcast_scraper.search.backends.lancedb_backend import LanceDBBackend  # noqa: E402
+
+
+def _seg(i, text, show, emb):
+    return SegmentDocument(
+        id=i, text=text, show_id=show, episode_id="ep1", start_time=0.0, end_time=1.0, embedding=emb
+    )
+
+
+@pytest.fixture
+def backend(tmp_path):
+    b = LanceDBBackend(str(tmp_path / "lance"), embed_dim=4)
+    b.upsert_segment(_seg("s1", "Sam Altman talks about OpenAI", "A", [0.1, 0.2, 0.3, 0.4]))
+    b.upsert_segment(_seg("s2", "Tim Cook and Apple earnings", "B", [0.9, 0.1, 0.0, 0.1]))
+    b.upsert_insight(
+        InsightDocument(
+            id="insight:1",
+            text="Altman argues AI scaling continues",
+            show_id="A",
+            episode_id="ep1",
+            entity_type="claim",
+            confidence=0.9,
+            derived=False,
+            embedding=[0.1, 0.2, 0.3, 0.45],
+        )
+    )
+    b.create_indices()
+    return b
+
+
+def test_satisfies_protocol(backend):
+    assert isinstance(backend, SearchBackend)
+
+
+def test_bm25_named_entity(backend):
+    # BM25 retrieves the proper noun across both tiers.
+    res = backend.search_bm25(SearchQuery(text="Altman", embedding=[0, 0, 0, 0], tier="all"))
+    ids = {r.doc_id for r in res}
+    assert "s1" in ids and "insight:1" in ids
+    assert all(r.signal == "bm25" for r in res)
+    assert res[0].rank == 1
+
+
+def test_vector_search_orders_by_similarity(backend):
+    res = backend.search_vector(
+        SearchQuery(text="", embedding=[0.1, 0.2, 0.3, 0.4], tier="segment")
+    )
+    assert res and res[0].doc_id == "s1"  # closest segment
+    assert all(r.signal == "vector" and r.source_tier == "segment" for r in res)
+    # similarity score is higher-is-better.
+    assert res[0].score >= res[-1].score
+
+
+def test_tier_filter_segment_only(backend):
+    res = backend.search_bm25(SearchQuery(text="Altman", embedding=[0, 0, 0, 0], tier="segment"))
+    assert {r.source_tier for r in res} == {"segment"}
+
+
+def test_payload_excludes_embedding(backend):
+    res = backend.search_bm25(SearchQuery(text="Altman", embedding=[0, 0, 0, 0], tier="all"))
+    assert "embedding" not in res[0].payload
+    assert res[0].payload.get("show_id") == "A"
+
+
+def test_filters_where_show(backend):
+    res = backend.search_bm25(
+        SearchQuery(text="Altman", embedding=[0, 0, 0, 0], tier="segment", filters={"show_id": "B"})
+    )
+    assert res == []  # s1 is show A; filtered out
+
+
+def test_health_and_delete(backend):
+    h = backend.health()
+    assert h["status"] == "ok" and h["segments"] == 2 and h["insights"] == 1
+    backend.delete("s1", "segment")
+    assert backend.health()["segments"] == 1

--- a/tests/unit/search/test_migration.py
+++ b/tests/unit/search/test_migration.py
@@ -1,0 +1,90 @@
+"""Tests for the FAISS → two-tier LanceDB migration (RFC-090 Stage 4, #858).
+
+Builds a tiny real FAISS store (4-dim), migrates it, and asserts the two tiers
+land with reused embeddings and reusable indices.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.backend import SearchQuery
+
+pytestmark = pytest.mark.unit
+
+pytest.importorskip("lancedb")
+pytest.importorskip("faiss")
+
+from podcast_scraper.search.backends.lancedb_backend import LanceDBBackend  # noqa: E402
+from podcast_scraper.search.faiss_store import FaissVectorStore  # noqa: E402
+from podcast_scraper.search.migration import migrate_faiss_to_lance  # noqa: E402
+
+
+def _build_faiss(tmp_path):
+    store = FaissVectorStore(4, index_dir=tmp_path / "faiss")
+    store.upsert(
+        "insight:1",
+        [0.1, 0.2, 0.3, 0.4],
+        {
+            "doc_type": "insight",
+            "text": "Altman on AI scaling",
+            "episode_id": "ep1",
+            "feed_id": "showA",
+            "grounded": True,
+        },
+    )
+    store.upsert(
+        "chunk:1",
+        [0.9, 0.1, 0.0, 0.1],
+        {
+            "doc_type": "transcript",
+            "text": "raw transcript chunk",
+            "episode_id": "ep1",
+            "feed_id": "showA",
+            "timestamp_start_ms": 2000,
+            "timestamp_end_ms": 5000,
+        },
+    )
+    # A non-two-tier doc type that must be skipped.
+    store.upsert(
+        "kg_entity:1",
+        [0.5, 0.5, 0.0, 0.0],
+        {"doc_type": "kg_entity", "text": "Sam Altman", "episode_id": "ep1"},
+    )
+    store.persist()
+    return tmp_path / "faiss"
+
+
+def test_migration_maps_tiers_and_skips_others(tmp_path):
+    faiss_dir = _build_faiss(tmp_path)
+    stats = migrate_faiss_to_lance(faiss_dir, tmp_path / "lance")
+    assert stats.insights == 1
+    assert stats.segments == 1
+    assert stats.skipped == 1  # kg_entity skipped
+    assert stats.embed_dim == 4
+
+    backend = LanceDBBackend(str(tmp_path / "lance"), embed_dim=4)
+    health = backend.health()
+    assert health["insights"] == 1 and health["segments"] == 1
+
+
+def test_migration_preserves_searchable_payload(tmp_path):
+    faiss_dir = _build_faiss(tmp_path)
+    migrate_faiss_to_lance(faiss_dir, tmp_path / "lance")
+    backend = LanceDBBackend(str(tmp_path / "lance"), embed_dim=4)
+
+    # BM25 over the migrated insight tier finds the reused text + timestamp mapping.
+    hits = backend.search_bm25(SearchQuery(text="Altman scaling", embedding=[], tier="insight"))
+    assert any(h.doc_id == "insight:1" for h in hits)
+
+    seg_hits = backend.search_bm25(
+        SearchQuery(text="transcript chunk", embedding=[], tier="segment")
+    )
+    seg = next(h for h in seg_hits if h.doc_id == "chunk:1")
+    assert seg.payload["start_time"] == 2.0 and seg.payload["end_time"] == 5.0  # ms→s
+
+
+def test_migration_limit_per_tier(tmp_path):
+    faiss_dir = _build_faiss(tmp_path)
+    stats = migrate_faiss_to_lance(faiss_dir, tmp_path / "lance", limit_per_tier=0)
+    assert stats.segments == 0 and stats.insights == 0

--- a/tests/unit/search/test_query_router.py
+++ b/tests/unit/search/test_query_router.py
@@ -1,0 +1,89 @@
+"""Unit tests for the pluggable query router (RFC-092, #860)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.backend import ScoredResult
+from podcast_scraper.search.query_router import (
+    get_query_router,
+    MLQueryRouter,
+    RulesQueryRouter,
+)
+from podcast_scraper.search.retrieval import RetrievalLayer
+
+pytestmark = pytest.mark.unit
+
+
+def test_rules_router_matches_classify_query():
+    r = RulesQueryRouter()
+    assert r.classify("exact quote from the transcript") == "raw_evidence"
+    assert r.classify("Sam Altman") == "entity_lookup"
+    assert r.classify("how has AI evolved over time") == "temporal_tracking"
+
+
+def test_factory_returns_rules_by_default():
+    assert isinstance(get_query_router("rules"), RulesQueryRouter)
+    assert isinstance(get_query_router("bogus"), RulesQueryRouter)
+    assert isinstance(get_query_router("ml"), MLQueryRouter)
+
+
+def test_ml_router_falls_back_to_rules_when_model_absent(tmp_path):
+    # No model file → must degrade to rules, not raise.
+    router = MLQueryRouter(tmp_path / "missing.joblib")
+    assert router.classify("Sam Altman") == "entity_lookup"
+    assert router.classify("exact verbatim quote") == "raw_evidence"
+
+
+def test_ml_router_uses_model_when_present():
+    class _StubModel:
+        def predict(self, X):
+            return ["cross_show_synthesis"]
+
+    router = MLQueryRouter()
+    router._model = _StubModel()
+    router._loaded = True
+    # Patch the embed step so we don't load MiniLM in a unit test.
+    router._embed = lambda text: [0.0, 0.0, 0.0]  # type: ignore[method-assign]
+    assert router.classify("anything") == "cross_show_synthesis"
+
+
+def test_ml_router_rejects_out_of_vocab_label_falls_back():
+    class _BadModel:
+        def predict(self, X):
+            return ["not_a_real_intent"]
+
+    router = MLQueryRouter()
+    router._model = _BadModel()
+    router._loaded = True
+    router._embed = lambda text: [0.0]  # type: ignore[method-assign]
+    # Out-of-vocab prediction → rules fallback ("Sam Altman" → entity_lookup).
+    assert router.classify("Sam Altman") == "entity_lookup"
+
+
+class _FakeBackend:
+    def search_bm25(self, query):
+        return [ScoredResult("seg1", 1.0, 1, {}, "bm25", "segment")]
+
+    def search_vector(self, query):
+        return [ScoredResult("ins0", 1.0, 1, {}, "vector", "insight")]
+
+
+def test_retrieval_layer_uses_injected_router():
+    class _StubRouter:
+        seen = []
+
+        def classify(self, text):
+            _StubRouter.seen.append(text)
+            return "semantic"
+
+    layer = RetrievalLayer(_FakeBackend(), router=_StubRouter())
+    layer.retrieve("some query", [0.1, 0.2])
+    assert _StubRouter.seen == ["some query"]  # router drove classification
+
+
+def test_retrieval_layer_default_router_is_rules():
+    # No router → falls back to rules classify_query; behaviour unchanged.
+    layer = RetrievalLayer(_FakeBackend())
+    out = layer.retrieve("Sam Altman", [0.1])
+    assert {r.doc_id for r in out} == {"seg1", "ins0"}

--- a/tests/unit/search/test_retrieval.py
+++ b/tests/unit/search/test_retrieval.py
@@ -1,0 +1,138 @@
+"""Unit tests for RRF fusion + dedup + router + RetrievalLayer (RFC-090 §3.3–3.6, #856)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.backend import ScoredResult
+from podcast_scraper.search.dedup import deduplicate
+from podcast_scraper.search.fusion import rrf_fuse
+from podcast_scraper.search.retrieval import RetrievalLayer
+from podcast_scraper.search.router import (
+    classify_query,
+    signal_weights_for,
+    tier_weights_for,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _sr(doc_id, rank, signal, tier, score=1.0, payload=None):
+    return ScoredResult(doc_id, score, rank, payload or {}, signal, tier)
+
+
+# --- RRF fusion -----------------------------------------------------------------
+
+
+def test_rrf_doc_in_both_lists_ranks_highest():
+    bm25 = [_sr("a", 1, "bm25", "insight"), _sr("b", 2, "bm25", "segment")]
+    vector = [_sr("b", 1, "vector", "segment"), _sr("c", 2, "vector", "insight")]
+    fused = rrf_fuse([bm25, vector])
+    assert fused[0].doc_id == "b"  # appears in both → highest fused score
+    assert all(r.signal == "rrf" for r in fused)
+    assert [r.rank for r in fused] == [1, 2, 3]
+
+
+def test_rrf_signal_weights_boost():
+    bm25 = [_sr("a", 1, "bm25", "segment")]
+    vector = [_sr("z", 1, "vector", "segment")]
+    fused = rrf_fuse([bm25, vector], signal_weights={"bm25": 2.0, "vector": 0.1})
+    assert fused[0].doc_id == "a"  # bm25 weighted far higher
+
+
+def test_rrf_skips_empty_lists():
+    assert rrf_fuse([[], [_sr("a", 1, "vector", "segment")], []])[0].doc_id == "a"
+
+
+# --- compound dedup -------------------------------------------------------------
+
+
+def test_dedup_compound_via_source_segment_id():
+    res = [
+        _sr("seg1", 1, "vector", "segment", score=0.7),
+        _sr("ins1", 2, "vector", "insight", score=0.9, payload={"source_segment_id": "seg1"}),
+    ]
+    out = deduplicate(res)
+    assert len(out) == 1
+    comp = out[0]
+    assert comp.source_tier == "compound" and comp.doc_id == "seg1"
+    assert comp.score == 0.9 and comp.rank == 1  # max score, min rank
+    assert comp.segment.doc_id == "seg1" and comp.insight.doc_id == "ins1"
+
+
+def test_dedup_compound_via_linked_insight_ids():
+    res = [
+        _sr("seg1", 1, "bm25", "segment", payload={"linked_insight_ids": ["ins1"]}),
+        _sr("ins1", 2, "bm25", "insight"),
+    ]
+    out = deduplicate(res)
+    assert len(out) == 1 and out[0].source_tier == "compound"
+
+
+def test_dedup_passthrough_when_unlinked():
+    res = [
+        _sr("seg1", 1, "vector", "segment", score=0.5),
+        _sr("ins9", 2, "vector", "insight", score=0.8, payload={"source_segment_id": "other"}),
+    ]
+    out = deduplicate(res)
+    assert {r.doc_id for r in out} == {"seg1", "ins9"}
+    assert out[0].doc_id == "ins9"  # sorted by score desc
+
+
+# --- router ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Sam Altman", "entity_lookup"),
+        ("what was the exact quote about scaling", "raw_evidence"),
+        ("how has AI reasoning changed over time", "temporal_tracking"),
+        ("Acquired vs The Journal on AI", "cross_show_synthesis"),
+        ("tell me about scaling laws", "semantic"),
+    ],
+)
+def test_classify_query(text, expected):
+    assert classify_query(text) == expected
+
+
+def test_weights_lookup_and_fallback():
+    assert signal_weights_for("raw_evidence")["bm25"] == 1.5
+    assert signal_weights_for("entity_lookup")["bm25"] == 1.4
+    assert tier_weights_for("raw_evidence")["segment"] == 1.3
+    assert signal_weights_for("unknown") == signal_weights_for("semantic")
+
+
+# --- RetrievalLayer -------------------------------------------------------------
+
+
+class _FakeBackend:
+    def __init__(self, bm25, vector):
+        self._bm25, self._vector = bm25, vector
+
+    def search_bm25(self, query):
+        return list(self._bm25)
+
+    def search_vector(self, query):
+        return list(self._vector)
+
+
+def test_retrieval_hybrid_fuses_and_dedups():
+    bm25 = [_sr("seg1", 1, "bm25", "segment", payload={"linked_insight_ids": ["ins1"]})]
+    vector = [_sr("ins1", 1, "vector", "insight")]
+    layer = RetrievalLayer(_FakeBackend(bm25, vector))
+    out = layer.retrieve("Sam Altman", [0.1, 0.2])
+    # seg1 + ins1 are linked → one compound result.
+    assert len(out) == 1 and out[0].source_tier == "compound"
+
+
+def test_retrieval_single_signal_skips_fusion():
+    bm25 = [_sr("seg1", 1, "bm25", "segment"), _sr("seg2", 2, "bm25", "segment")]
+    layer = RetrievalLayer(_FakeBackend(bm25, []))
+    out = layer.retrieve("x", [0.0], signals="bm25")
+    assert [r.doc_id for r in out] == ["seg1", "seg2"]  # deduped passthrough, order kept
+
+
+def test_retrieval_classify_helper():
+    layer = RetrievalLayer(_FakeBackend([], []))
+    assert layer.classify("Sam Altman") == "entity_lookup"

--- a/tests/unit/search/test_segments.py
+++ b/tests/unit/search/test_segments.py
@@ -1,0 +1,71 @@
+"""Unit tests for segment-document build + insight linking (RFC-090 §3.8, #857)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.backend import SegmentDocument
+from podcast_scraper.search.segments import build_segment_documents, link_insights_to_segments
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_segment_documents_ids_and_text():
+    text = "Sam Altman discussed AI. Tim Cook talked earnings. The market reacted."
+    segs = build_segment_documents(text, episode_id="ep1", show_id="showA", target_tokens=5)
+    assert len(segs) >= 1
+    assert all(isinstance(s, SegmentDocument) for s in segs)
+    assert segs[0].id == "ep1_chunk_0"
+    assert segs[0].show_id == "showA" and segs[0].episode_id == "ep1"
+    assert segs[0].source_tier == "segment" and segs[0].embedding == []
+
+
+def test_build_segment_documents_timestamps_to_seconds():
+    text = "Hello world this is a sentence. And another one here please."
+    ts = [
+        {"char_start": 0, "char_end": 31, "start_ms": 1000, "end_ms": 4000},
+        {"char_start": 31, "char_end": 60, "start_ms": 4000, "end_ms": 7000},
+    ]
+    segs = build_segment_documents(
+        text, episode_id="ep1", show_id="s", timestamps=ts, target_tokens=50
+    )
+    # ms -> seconds.
+    assert segs[0].start_time == 1.0 and segs[0].end_time == 7.0
+
+
+def test_build_segment_documents_no_timestamps_defaults_zero():
+    segs = build_segment_documents("one two three.", episode_id="ep1", show_id="s")
+    assert segs[0].start_time == 0.0 and segs[0].end_time == 0.0
+
+
+def _seg(sid, start, end):
+    return SegmentDocument(
+        id=sid, text="t", show_id="s", episode_id="ep1", start_time=start, end_time=end
+    )
+
+
+def test_link_insight_within_segment_time():
+    segs = [_seg("ep1_chunk_0", 0.0, 10.0), _seg("ep1_chunk_1", 10.0, 20.0)]
+    mapping = link_insights_to_segments(segs, [("insight:1", 12.0, 15.0)])
+    assert mapping == {"insight:1": "ep1_chunk_1"}
+    assert segs[1].linked_insight_ids == ["insight:1"]
+    assert segs[0].linked_insight_ids == []
+
+
+def test_link_respects_tolerance():
+    segs = [_seg("ep1_chunk_0", 0.0, 10.0)]
+    # quote at 10.5s is just past the segment but within the 2s tolerance.
+    mapping = link_insights_to_segments(segs, [("insight:1", 9.5, 10.5)], tolerance_seconds=2.0)
+    assert mapping == {"insight:1": "ep1_chunk_0"}
+
+
+def test_link_no_match_when_far_outside():
+    segs = [_seg("ep1_chunk_0", 0.0, 10.0)]
+    mapping = link_insights_to_segments(segs, [("insight:1", 50.0, 55.0)])
+    assert mapping == {}
+    assert segs[0].linked_insight_ids == []
+
+
+def test_link_skips_insight_without_timestamp():
+    segs = [_seg("ep1_chunk_0", 0.0, 10.0)]
+    assert link_insights_to_segments(segs, [("insight:1", None, None)]) == {}

--- a/tests/unit/upgrade/test_end_to_end.py
+++ b/tests/unit/upgrade/test_end_to_end.py
@@ -1,0 +1,101 @@
+"""End-to-end test of the real 0001 migration + CLI dispatch (#862).
+
+Builds a tiny FAISS corpus, drives the actual ``podcast upgrade`` CLI path
+(parse → run → status → verify), and asserts the ledger + LanceDB index land.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+pytest.importorskip("lancedb")
+pytest.importorskip("faiss")
+
+from podcast_scraper.search.faiss_store import FaissVectorStore  # noqa: E402
+from podcast_scraper.upgrade.cli_handlers import parse_upgrade_argv, run_upgrade_cli  # noqa: E402
+from podcast_scraper.upgrade.state import FilesystemStateStore  # noqa: E402
+
+log = logging.getLogger("test")
+
+
+def _tiny_corpus(root):
+    search = root / "search"
+    store = FaissVectorStore(4, index_dir=search)
+    store.upsert(
+        "insight:1",
+        [0.1, 0.2, 0.3, 0.4],
+        {"doc_type": "insight", "text": "Altman on AI", "episode_id": "ep1", "feed_id": "A"},
+    )
+    store.upsert(
+        "chunk:1",
+        [0.9, 0.1, 0.0, 0.1],
+        {
+            "doc_type": "transcript",
+            "text": "a chunk",
+            "episode_id": "ep1",
+            "feed_id": "A",
+            "timestamp_start_ms": 0,
+            "timestamp_end_ms": 1000,
+        },
+    )
+    store.persist()
+    (root / "corpus_manifest.json").write_text(
+        '{"produced_by": {"code_version": "2.6.0"}}', encoding="utf-8"
+    )
+
+
+def _run(corpus, *argv):
+    args = parse_upgrade_argv([argv[0], "--corpus-dir", str(corpus), *argv[1:]])
+    return run_upgrade_cli(args, log)
+
+
+def test_status_then_run_then_verify(tmp_path):
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    _tiny_corpus(corpus)
+
+    # status before: pending → exit 2.
+    assert _run(corpus, "status") == 2
+
+    # run --yes applies it.
+    assert _run(corpus, "run", "--yes") == 0
+    store = FilesystemStateStore(corpus)
+    assert store.applied_migration_ids() == {"0001_faiss_to_lance"}
+    assert store.current_version() == "2.7.0"
+    assert (corpus / "search" / "lance_index").exists()
+
+    # status after: up to date → exit 0.
+    assert _run(corpus, "status") == 0
+
+    # verify passes.
+    assert _run(corpus, "verify") == 0
+
+    # idempotent: a second run is a no-op (still exit 0, still one ledger entry).
+    assert _run(corpus, "run", "--yes") == 0
+    assert len(store.applied_records()) == 1
+
+
+def test_run_dry_run_writes_nothing(tmp_path):
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    _tiny_corpus(corpus)
+    assert _run(corpus, "run", "--dry-run") == 0
+    assert FilesystemStateStore(corpus).applied_migration_ids() == set()
+    assert not (corpus / "search" / "lance_index").exists()
+    assert not (corpus / "upgrade_ledger.json").exists()
+
+
+def test_no_faiss_index_is_clean_noop(tmp_path):
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "corpus_manifest.json").write_text(
+        '{"produced_by": {"code_version": "2.6.0"}}', encoding="utf-8"
+    )
+    # No FAISS index → migration applies as a no-op, version still advances.
+    assert _run(corpus, "run", "--yes") == 0
+    assert FilesystemStateStore(corpus).current_version() == "2.7.0"
+    assert _run(corpus, "verify") == 0  # no-op verifies ok

--- a/tests/unit/upgrade/test_runner.py
+++ b/tests/unit/upgrade/test_runner.py
@@ -1,0 +1,125 @@
+"""Tests for the upgrade runner orchestration (#862).
+
+Uses in-memory fakes for the state store + migrations so the runner contract
+(ordering, idempotency, stop-on-failure, version gating, verify) is exercised
+without touching FAISS/LanceDB.
+"""
+
+from __future__ import annotations
+
+from typing import List, Set
+
+import pytest
+
+from podcast_scraper.upgrade.migration import Migration, MigrationContext, MigrationResult
+from podcast_scraper.upgrade.runner import UpgradeRunner
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeStore:
+    def __init__(self, version=None):
+        self._version = version
+        self._applied: List[dict] = []
+
+    def current_version(self):
+        return self._version
+
+    def applied_migration_ids(self) -> Set[str]:
+        return {e["id"] for e in self._applied}
+
+    def record_applied(self, migration_id, *, to_version, at):
+        self._applied.append({"id": migration_id, "to_version": to_version, "at": at})
+        self._version = to_version
+
+
+class _FakeMigration(Migration):
+    def __init__(self, mid, to_version, *, raises=False, verify_ok=True):
+        self.id = mid
+        self.to_version = to_version
+        self.description = f"fake {mid}"
+        self._raises = raises
+        self._verify_ok = verify_ok
+        self.apply_calls = 0
+
+    def apply(self, ctx: MigrationContext) -> MigrationResult:
+        self.apply_calls += 1
+        if self._raises:
+            raise RuntimeError(f"{self.id} boom")
+        return MigrationResult(self.id, applied=True, dry_run=ctx.dry_run, message="ok")
+
+    def verify(self, ctx):
+        return self._verify_ok, "verified" if self._verify_ok else "broken"
+
+
+def _ctx(tmp_path, dry_run=False):
+    return MigrationContext(corpus_root=tmp_path, dry_run=dry_run)
+
+
+def test_status_lists_pending_in_order(tmp_path):
+    store = _FakeStore("2.6.0")
+    runner = UpgradeRunner(
+        store, [_FakeMigration("0002_b", "2.7.0"), _FakeMigration("0001_a", "2.7.0")]
+    )
+    status = runner.status()
+    assert [m.id for m in status.pending] == ["0001_a", "0002_b"]  # sorted by id
+    assert status.target_version == "2.7.0"
+    assert status.up_to_date is False
+
+
+def test_run_applies_and_records(tmp_path):
+    store = _FakeStore("2.6.0")
+    m = _FakeMigration("0001_a", "2.7.0")
+    runner = UpgradeRunner(store, [m])
+    results = runner.run(_ctx(tmp_path), now="t")
+    assert results[0].applied and m.apply_calls == 1
+    assert store.applied_migration_ids() == {"0001_a"}
+    assert store.current_version() == "2.7.0"
+    assert runner.status().up_to_date is True
+
+
+def test_idempotent_second_run_is_noop(tmp_path):
+    store = _FakeStore("2.6.0")
+    m = _FakeMigration("0001_a", "2.7.0")
+    runner = UpgradeRunner(store, [m])
+    runner.run(_ctx(tmp_path), now="t")
+    results = runner.run(_ctx(tmp_path), now="t")  # nothing pending
+    assert results == [] and m.apply_calls == 1
+
+
+def test_dry_run_does_not_record(tmp_path):
+    store = _FakeStore("2.6.0")
+    runner = UpgradeRunner(store, [_FakeMigration("0001_a", "2.7.0")])
+    runner.run(_ctx(tmp_path, dry_run=True), now="t")
+    assert store.applied_migration_ids() == set()  # dry-run writes nothing
+
+
+def test_stop_on_failure_preserves_prior(tmp_path):
+    store = _FakeStore("2.6.0")
+    good = _FakeMigration("0001_a", "2.7.0")
+    bad = _FakeMigration("0002_b", "2.7.0", raises=True)
+    never = _FakeMigration("0003_c", "2.7.0")
+    runner = UpgradeRunner(store, [good, bad, never])
+    with pytest.raises(RuntimeError):
+        runner.run(_ctx(tmp_path), now="t")
+    assert store.applied_migration_ids() == {"0001_a"}  # good recorded, bad/never not
+    assert never.apply_calls == 0  # never reached
+
+
+def test_to_version_gates_later_migrations(tmp_path):
+    store = _FakeStore("2.6.0")
+    runner = UpgradeRunner(
+        store, [_FakeMigration("0001_a", "2.7.0"), _FakeMigration("0002_b", "2.8.0")]
+    )
+    runner.run(_ctx(tmp_path), to_version="2.7.0", now="t")
+    assert store.applied_migration_ids() == {"0001_a"}  # 2.8.0 step skipped
+
+
+def test_verify_only_applied(tmp_path):
+    store = _FakeStore("2.6.0")
+    m1 = _FakeMigration("0001_a", "2.7.0", verify_ok=True)
+    m2 = _FakeMigration("0002_b", "2.8.0", verify_ok=False)
+    runner = UpgradeRunner(store, [m1, m2])
+    runner.run(_ctx(tmp_path), to_version="2.7.0", now="t")  # only m1 applied
+    verify = runner.verify(_ctx(tmp_path))
+    assert verify == [("0001_a", True, "verified")]  # m2 not applied → not verified

--- a/tests/unit/upgrade/test_state.py
+++ b/tests/unit/upgrade/test_state.py
@@ -1,0 +1,55 @@
+"""Tests for the filesystem upgrade state store (#862)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from podcast_scraper.upgrade.state import FilesystemStateStore
+
+pytestmark = pytest.mark.unit
+
+
+def _write_manifest(root, code_version):
+    (root / "corpus_manifest.json").write_text(
+        json.dumps({"produced_by": {"code_version": code_version}}), encoding="utf-8"
+    )
+
+
+def test_current_version_from_manifest_when_no_ledger(tmp_path):
+    _write_manifest(tmp_path, "2.6.0")
+    store = FilesystemStateStore(tmp_path)
+    assert store.current_version() == "2.6.0"
+    assert store.applied_migration_ids() == set()
+
+
+def test_record_advances_version_and_ledger(tmp_path):
+    _write_manifest(tmp_path, "2.6.0")
+    store = FilesystemStateStore(tmp_path)
+    store.record_applied("0001_x", to_version="2.7.0", at="2026-06-01T00:00:00Z")
+
+    # New store instance reads the persisted ledger.
+    store2 = FilesystemStateStore(tmp_path)
+    assert store2.applied_migration_ids() == {"0001_x"}
+    assert store2.current_version() == "2.7.0"  # ledger version wins over manifest
+    rec = store2.applied_records()[0]
+    assert rec["id"] == "0001_x" and rec["to_version"] == "2.7.0"
+
+
+def test_record_is_idempotent_on_id(tmp_path):
+    store = FilesystemStateStore(tmp_path)
+    store.record_applied("0001_x", to_version="2.7.0", at="t1")
+    store.record_applied("0001_x", to_version="2.7.0", at="t2")  # re-record same id
+    assert len(store.applied_records()) == 1  # not duplicated
+
+
+def test_unstamped_corpus_returns_none(tmp_path):
+    assert FilesystemStateStore(tmp_path).current_version() is None
+
+
+def test_corrupt_ledger_degrades_gracefully(tmp_path):
+    (tmp_path / "upgrade_ledger.json").write_text("{ not json", encoding="utf-8")
+    store = FilesystemStateStore(tmp_path)
+    assert store.applied_migration_ids() == set()
+    assert store.current_version() is None


### PR DESCRIPTION
## Summary

Implements the full **RFC-090 hybrid-retrieval suite** (#855–#861) plus the **managed corpus upgrade-path framework** (#862). Builds on the #854 squash already in `main`.

End-to-end the search stack now is: **two-tier LanceDB backend → BM25 + dense + KG-proximity → RRF fusion → compound dedup → LITM briefing packs**, with pluggable intent routing — and a CLI-driven, idempotent way to migrate a deployed corpus onto it.

## Commits

| # | Stage | Issue |
|---|---|---|
| Two-tier LanceDB backend | RFC-090 S1 | #855 |
| RRF fusion + dedup + RetrievalLayer + rules router | RFC-090 S2 | #856 |
| Segment documents + insight linking | RFC-090 S3 | #857 |
| KG-proximity signal wired into retrieval | RFC-091 | #859 |
| LITM corpus briefing-pack builder | RFC-093 | #861 |
| FAISS→LanceDB migration + Stage-4 eval | RFC-090 S4 | #858 |
| Pluggable ML query router | RFC-092 | #860 |
| Managed corpus upgrade-path framework | — | #862 |

## Notable results & decisions

- **#858 Stage-4 eval (real corpus, 149 known-item queries):** hybrid MRR 0.997 vs FAISS 0.993, recall 1.0 both. Hybrid doesn't regress and edges ranking, but the proxy **saturates** — so FAISS is **deprecated by notice, not removed**; removal is re-gated on a human-judged eval. The migration reuses FAISS embeddings verbatim to make the A/B a controlled experiment.
- **#860 ML router:** `QueryRouter` protocol (rules ⟷ ML), config switch, graceful fallback. Bootstrap training (750 corpus-grounded queries) shows **+13.3 pts over the rules regex** on held-out queries. The 1.0 holdout is template-inflated → **default stays `rules`** until validated on real queries. No new deps (sklearn/joblib).
- **#862 upgrade framework:** storage-agnostic by design — `StateStore` isolates *where* version + ledger live (filesystem today, a `DbStateStore` over a `schema_migrations` table drops in later with no runner/CLI change). Ledger-driven, idempotent, stop-on-failure. CLI `podcast upgrade status|list|run|verify` (+ Make targets); `status` exits **2** when pending so boot/CI can gate on it. Verified on the real corpus.

**#858 and #860 share one real blocker** — a discriminating, human-judged query set: it both re-gates FAISS removal and gives the ML router real training data, so they graduate together.

## Tests & gates

- New unit tests: backend, fusion, retrieval, segments, kg-proximity, context-pack, query-router, upgrade runner/state.
- Integration tests (real lancedb/faiss): lancedb backend, FAISS→LanceDB migration, upgrade CLI end-to-end.
- `make ci-fast` green (format, lint, markdown, mypy/798 files, security, complexity, deadcode, docstrings 100%, test-fast, docs, wheel).

## Follow-ups

- #862 registry/guide flag the remaining 2.6→2.7 migrations to inventory: vector-index rebuilds and the cross-episode entity canonical-map rebuild (#852).
- Human-judged eval set → unblocks FAISS removal (#858) + ML-router promotion (#860).

Closes #855, #856, #857, #858, #859, #860, #861, #862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
