### PR TITLE
feat(search): RFC-090 Phase 2 — wire hybrid retrieval live + indexer, migration, judged eval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,7 @@ validate-kg-schema:
 	fi
 
 # GI/KG viewer v2 (#489): FastAPI + Vite. ``make init`` includes FastAPI via ``[dev]``; cd $(WEB_VIEWER_DIR) && npm install
-.PHONY: serve serve-api serve-ui serve-e2e-mock stack-build stack-build-llm stack-compose-validate stack-up stack-down stack-logs verify-stack-profiles stack-test-build stack-test-build-cloud stack-test-up stack-test-down stack-test-seed stack-test-playwright stack-test-export stack-test-ml stack-test-cloud-thin stack-test-ml-ci deploy-codespace restore-corpus restore-corpus-prod reprocess-corpus-from-transcripts corpus-compat-check upgrade-status upgrade-check upgrade-dry-run upgrade-corpus upgrade-verify smoke-prod corpus-snapshot-manifest-validate corpus-snapshot-select-tag corpus-snapshot-select-tag-prod corpus-snapshot-selftest corpus-snapshot-integration
+.PHONY: serve serve-api serve-ui serve-e2e-mock stack-build stack-build-llm stack-compose-validate stack-up stack-down stack-logs verify-stack-profiles stack-test-build stack-test-build-cloud stack-test-up stack-test-down stack-test-seed stack-test-playwright stack-test-export stack-test-ml stack-test-cloud-thin stack-test-ml-ci deploy-codespace restore-corpus restore-corpus-prod reprocess-corpus-from-transcripts corpus-compat-check index-two-tier upgrade-status upgrade-check upgrade-dry-run upgrade-corpus upgrade-verify smoke-prod corpus-snapshot-manifest-validate corpus-snapshot-select-tag corpus-snapshot-select-tag-prod corpus-snapshot-selftest corpus-snapshot-integration
 SERVE_OUTPUT_DIR ?= ./output
 # Optional corpus-editing + jobs routes (health shows green when on). Override with SERVE_ARGS= to disable.
 SERVE_ARGS ?= --enable-feeds-api --enable-operator-config-api --enable-jobs-api
@@ -1016,6 +1016,12 @@ reprocess-corpus-from-transcripts:
 corpus-compat-check:
 	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
 	$(PYTHON) -c "from pathlib import Path; from podcast_scraper.corpus_version import read_produced_by, assess_corpus_version_compat, MIN_SUPPORTED_CORPUS_CODE_VERSION; from podcast_scraper import __version__; root = Path('$${CORPUS_DIR}').expanduser().resolve(); pb = read_produced_by(root); ver, warn = assess_corpus_version_compat(pb); print(f'server={__version__} min_supported={MIN_SUPPORTED_CORPUS_CODE_VERSION}'); print(f'corpus_code_version={ver!r}'); print(f'produced_by={pb!r}'); import sys; (print(f'WARNING: {warn}') or sys.exit(1)) if warn else print('COMPAT OK')"
+
+# Build the two-tier LanceDB index from corpus artifacts (RFC-090 Phase 2, follow-up
+# B). Native path for corpora without a FAISS index to migrate. CORPUS_DIR required.
+index-two-tier:
+	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
+	$(PYTHON) -m podcast_scraper.cli index-two-tier --output-dir "$${CORPUS_DIR}"
 
 # Corpus upgrade-path framework (#862). Managed, idempotent migrations for moving a
 # deployed corpus across releases (2.6 → 2.7 FAISS→LanceDB is step 0001). CORPUS_DIR

--- a/config/search.yaml
+++ b/config/search.yaml
@@ -5,6 +5,15 @@
 
 backend: lancedb
 
+# Live serving path (RFC-090 Phase 2). When hybrid_enabled is true AND a LanceDB
+# index exists for the corpus, GET /api/search routes through the two-tier hybrid
+# RetrievalLayer (BM25 + dense + KG-proximity → RRF); otherwise it uses FAISS. Kept
+# false by default: the two-tier index covers only the insight + segment(transcript)
+# tiers, so enabling it narrows coverage (no kg_entity/kg_topic/quote/summary) until
+# those tiers are added. Flip to true to A/B hybrid on a migrated/indexed corpus.
+serving:
+  hybrid_enabled: false
+
 lancedb:
   path: ./data/lance_index
 

--- a/docs/guides/CORPUS_UPGRADE.md
+++ b/docs/guides/CORPUS_UPGRADE.md
@@ -66,5 +66,15 @@ files-on-disk to a database:
 2. Register it in `upgrade/registry.py`.
 3. Add unit coverage in `tests/unit/upgrade/`.
 
-Known 2.6 → 2.7 migrations still to inventory/register: vector index rebuilds and the
-cross-episode entity canonical-map rebuild (#852).
+## Registered migrations
+
+- `0001_faiss_to_lance` — migrate an existing FAISS index into the two-tier LanceDB
+  layout (reuses embeddings). No-op when the corpus has no FAISS index.
+- `0002_two_tier_native_reindex` — build the two-tier index **natively** from corpus
+  artifacts, but only when `0001` left none (no FAISS to migrate). No-op when an index
+  already exists. Together, 0001 + 0002 guarantee a two-tier index via the cheapest
+  available path without double-building.
+
+**Not a migration:** the cross-episode entity canonical map (#852) is computed *live*
+at graph-build (`search/corpus_graph.py` → `build_entity_id_map`), not persisted —
+there is no artifact to rebuild, so it needs no migration.

--- a/docs/rfc/RFC-090-hybrid-retrieval.md
+++ b/docs/rfc/RFC-090-hybrid-retrieval.md
@@ -327,6 +327,11 @@ its own. **Decision: deprecate FAISS by notice, do not remove** (Phase 3 below i
 removal waits on a discriminating, human-judged query set — which is also the labeled-query source
 RFC-092 (#860) needs, so the two unblock together.
 
+The discriminating eval is built: `scripts/eval_hybrid_judged.py` (RFC-057) runs a query set
+through both backends, emits a graded-judgment template, and scores mean nDCG@k / recall@k per
+backend once a human fills relevance. Its verdict requires a clear margin over ≥30 judged queries —
+that result is what flips FAISS removal (#858) and ML-router promotion (#860) from gated to ready.
+
 ## Key Decisions
 
 1. **Separate ranked lists, client-side RRF.**

--- a/scripts/eval_hybrid_judged.py
+++ b/scripts/eval_hybrid_judged.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Human-judged hybrid-vs-FAISS eval (RFC-057 / wire-live follow-up C).
+
+The discriminating eval the saturated known-item proxy (eval_two_tier_retrieval.py)
+could not provide — it gates FAISS removal (#858) and ML-router promotion (#860).
+
+Two modes:
+
+  template  Run a query set through FAISS + hybrid, emit a judgment template JSONL
+            (one record per query, each candidate awaiting a `relevance` grade).
+              python scripts/eval_hybrid_judged.py template \
+                  --corpus-dir CORPUS --queries queries.txt --out template.jsonl
+
+  score     Read the human-graded JSONL back and print mean nDCG@k / recall@k per
+            backend + the verdict.
+              python scripts/eval_hybrid_judged.py score --judged template.jsonl
+
+Between the two, a human opens the template and fills `relevance` (0=irrelevant,
+1=related, 2=on-point) for the candidates that matter. The same queries carry an
+`intent` label (seeds #860 training data).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from podcast_scraper.search.faiss_store import FaissVectorStore  # noqa: E402
+from podcast_scraper.search.hybrid_search import hybrid_candidates, lance_index_dir  # noqa: E402
+from podcast_scraper.search.judged_eval import (  # noqa: E402
+    build_judgment_template,
+    JudgmentRecord,
+    score_from_judgments,
+)
+from podcast_scraper.search.router import classify_query  # noqa: E402
+
+_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def _faiss_ranks(corpus_dir: Path, k: int):
+    from podcast_scraper.providers.ml import embedding_loader
+
+    store = FaissVectorStore.load(corpus_dir / "search")
+
+    def ranks(query: str) -> Sequence[Tuple[str, str]]:
+        emb = embedding_loader.encode(
+            query, store.stats().embedding_model, return_numpy=False, allow_download=True
+        )
+        hits = store.search(list(emb), top_k=k * 4)
+        out = [(h.doc_id, str(h.metadata.get("text") or "")) for h in hits]
+        return out[:k]
+
+    return ranks
+
+
+def _hybrid_ranks(corpus_dir: Path, k: int):
+    def ranks(query: str) -> Sequence[Tuple[str, str]]:
+        rows = hybrid_candidates(corpus_dir, query, top_k=k, embedding_model=_MODEL) or []
+        return [(r.doc_id, str(r.metadata.get("text") or "")) for r in rows][:k]
+
+    return ranks
+
+
+def _cmd_template(args: argparse.Namespace) -> int:
+    corpus = Path(args.corpus_dir)
+    if not lance_index_dir(corpus).exists():
+        print(f"No LanceDB index at {lance_index_dir(corpus)} — run `make index-two-tier` first.")
+        return 1
+    queries = [
+        ln.strip()
+        for ln in Path(args.queries).read_text(encoding="utf-8").splitlines()
+        if ln.strip()
+    ]
+    records = build_judgment_template(
+        queries,
+        faiss_ranks=_faiss_ranks(corpus, args.k),
+        hybrid_ranks=_hybrid_ranks(corpus, args.k),
+        intent_of=classify_query,
+        k=args.k,
+    )
+    with Path(args.out).open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(dataclasses.asdict(rec)) + "\n")
+    print(f"Wrote {len(records)} judgment records → {args.out}. Fill `relevance`, then `score`.")
+    return 0
+
+
+def _cmd_score(args: argparse.Namespace) -> int:
+    records: List[JudgmentRecord] = []
+    for line in Path(args.judged).read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            d = json.loads(line)
+            d["relevance"] = {k: int(v) for k, v in (d.get("relevance") or {}).items()}
+            records.append(
+                JudgmentRecord(
+                    **{
+                        f: d.get(f)
+                        for f in (
+                            "query",
+                            "intent",
+                            "candidates",
+                            "faiss_ranking",
+                            "hybrid_ranking",
+                            "relevance",
+                        )
+                    }
+                )
+            )
+    scores = score_from_judgments(records, k=args.k)
+    n = int(scores["_judged_count"]["n"])
+    print(f"Judged queries with signal: {n}/{len(records)}")
+    print(f"\n  backend   nDCG@{args.k}   recall@{args.k}")
+    for b in ("faiss", "hybrid"):
+        print(f"  {b:7s}  {scores[b]['ndcg']:8.3f}  {scores[b]['recall']:8.3f}")
+    dn = scores["hybrid"]["ndcg"] - scores["faiss"]["ndcg"]
+    if dn > 0.02 and n >= 30:
+        verdict = "PASS — hybrid clearly beats FAISS (unblocks #858 removal + #860 promotion)"
+    else:
+        verdict = f"INCONCLUSIVE — need >=30 judged queries (have {n}) and a clear margin"
+    print(f"\n  Δ nDCG = {dn:+.3f}\n  VERDICT: {verdict}")
+    return 0
+
+
+def main() -> int:
+    """Dispatch the template / score subcommand."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    t = sub.add_parser("template", help="build a judgment template")
+    t.add_argument("--corpus-dir", required=True)
+    t.add_argument("--queries", required=True, help="one query per line")
+    t.add_argument("--out", default="judgment_template.jsonl")
+    t.add_argument("--k", type=int, default=10)
+    s = sub.add_parser("score", help="score graded judgments")
+    s.add_argument("--judged", required=True)
+    s.add_argument("--k", type=int, default=10)
+    args = ap.parse_args()
+    return _cmd_template(args) if args.cmd == "template" else _cmd_score(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/podcast_scraper/cli.py
+++ b/src/podcast_scraper/cli.py
@@ -3453,6 +3453,12 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         index_argv = list(argv[1:]) if len(argv) > 1 else []
         return parse_index_argv(index_argv)
 
+    if argv and len(argv) > 0 and argv[0] == "index-two-tier":
+        from .search.cli_handlers import parse_index_two_tier_argv
+
+        tt_argv = list(argv[1:]) if len(argv) > 1 else []
+        return parse_index_two_tier_argv(tt_argv)
+
     if argv and len(argv) > 0 and argv[0] == "topic-clusters":
         from .search.cli_handlers import parse_topic_clusters_argv
 
@@ -4529,6 +4535,11 @@ def main(  # noqa: C901 - main function handles multiple command paths
         from .search.cli_handlers import run_index_cli
 
         return run_index_cli(args, log)
+
+    if hasattr(args, "command") and args.command == "index-two-tier":
+        from .search.cli_handlers import run_index_two_tier_cli
+
+        return run_index_two_tier_cli(args, log)
 
     if hasattr(args, "command") and args.command == "topic-clusters":
         from .search.cli_handlers import run_topic_clusters_cli

--- a/src/podcast_scraper/search/cli_handlers.py
+++ b/src/podcast_scraper/search/cli_handlers.py
@@ -1343,3 +1343,49 @@ def run_topic_insights_cli(args: Namespace, logger: logging.Logger) -> int:
             print()
 
     return EXIT_SUCCESS
+
+
+def parse_index_two_tier_argv(argv: Sequence[str]) -> Namespace:
+    """Parse ``index-two-tier`` args (RFC-090 from-corpus two-tier indexer, follow-up B)."""
+    parser = argparse.ArgumentParser(prog="podcast_scraper index-two-tier")
+    parser.add_argument("--output-dir", required=True, help="Corpus root (parent of feeds/).")
+    parser.add_argument(
+        "--lance-path",
+        default=None,
+        help="LanceDB index dir (default: <output-dir>/search/lance_index).",
+    )
+    parser.add_argument("--embedding-model", default=None, help="Override embedding model id.")
+    parser.add_argument("--limit-episodes", type=int, default=None, help="Cap episodes (smoke).")
+    parser.add_argument(
+        "--allow-download", action="store_true", help="Allow embedding-model download."
+    )
+    args = parser.parse_args(list(argv))
+    args.command = "index-two-tier"
+    return args
+
+
+def run_index_two_tier_cli(args: Namespace, logger: logging.Logger) -> int:
+    """Build the two-tier LanceDB index from corpus artifacts (RFC-090 Phase 2 / B)."""
+    output_dir = getattr(args, "output_dir", None)
+    if not output_dir:
+        logger.error("index-two-tier: --output-dir is required")
+        return EXIT_INVALID_ARGS
+
+    from podcast_scraper.search.two_tier_indexer import build_two_tier_index, DEFAULT_MODEL
+
+    lance_path = getattr(args, "lance_path", None) or str(
+        Path(output_dir) / "search" / "lance_index"
+    )
+    model_id = getattr(args, "embedding_model", None) or DEFAULT_MODEL
+    stats = build_two_tier_index(
+        output_dir,
+        lance_path,
+        model_id=model_id,
+        limit_episodes=getattr(args, "limit_episodes", None),
+        allow_download=bool(getattr(args, "allow_download", False)),
+    )
+    print(
+        f"Two-tier index built at {lance_path}: "
+        f"episodes={stats.episodes} segments={stats.segments} insights={stats.insights}"
+    )
+    return EXIT_SUCCESS

--- a/src/podcast_scraper/search/corpus_search.py
+++ b/src/podcast_scraper/search/corpus_search.py
@@ -21,6 +21,7 @@ from podcast_scraper.search.cli_handlers import (
     merged_episode_gi_paths,
 )
 from podcast_scraper.search.faiss_store import FaissVectorStore, VECTORS_FILE
+from podcast_scraper.search.hybrid_search import hybrid_candidates, hybrid_search_enabled
 from podcast_scraper.search.protocol import SearchResult
 from podcast_scraper.search.topic_clusters import load_topic_cluster_enrichment_map
 from podcast_scraper.search.transcript_chunk_lift import (
@@ -203,6 +204,39 @@ def run_corpus_search(
     if not q:
         return CorpusSearchOutcome(error="empty_query")
 
+    top_k = max(1, min(int(top_k), 100))
+    types_norm: Optional[List[str]] = None
+    if doc_types:
+        types_norm = [x.strip().lower() for x in doc_types if isinstance(x, str) and x.strip()]
+        if not types_norm:
+            types_norm = None
+
+    # Hybrid path (RFC-090 Phase 2): opt-in via serving.hybrid_enabled. Returns None to
+    # fall back to FAISS (flag off, no LanceDB index, or embed failure), so this can
+    # never regress the FAISS path — only override it when explicitly enabled + ready.
+    if hybrid_search_enabled():
+        candidates = hybrid_candidates(
+            output_dir,
+            q,
+            top_k=top_k,
+            doc_types=doc_types,
+            embedding_model=embedding_model,
+        )
+        if candidates is not None:
+            logger.info("corpus_search: hybrid path (%d candidates)", len(candidates))
+            return _filter_and_enrich(
+                candidates,
+                output_dir,
+                types_norm=types_norm,
+                feed=feed,
+                since=since,
+                speaker=speaker,
+                grounded_only=grounded_only,
+                top_k=top_k,
+                dedupe_kg_surfaces=dedupe_kg_surfaces,
+                collect_cap=len(candidates),
+            )
+
     index_dir = _resolve_index_dir(output_dir, index_path)
     if not (index_dir / VECTORS_FILE).is_file():
         return CorpusSearchOutcome(error="no_index", detail=str(index_dir))
@@ -244,17 +278,10 @@ def run_corpus_search(
         return CorpusSearchOutcome(error="embed_failed", detail=str(exc))
     embed_sec = time.perf_counter() - t_embed0
 
-    types_norm: Optional[List[str]] = None
-    if doc_types:
-        types_norm = [x.strip().lower() for x in doc_types if isinstance(x, str) and x.strip()]
-        if not types_norm:
-            types_norm = None
-
     faiss_filters: Optional[Dict[str, Any]] = None
     if types_norm and len(types_norm) == 1:
         faiss_filters = {"doc_type": types_norm[0]}
 
-    top_k = max(1, min(int(top_k), 100))
     fetch_k = min(max(top_k * 25, top_k), max(store.ntotal, 1))
 
     t_search0 = time.perf_counter()
@@ -273,11 +300,42 @@ def run_corpus_search(
         fetch_k,
     )
 
+    return _filter_and_enrich(
+        hits,
+        output_dir,
+        types_norm=types_norm,
+        feed=feed,
+        since=since,
+        speaker=speaker,
+        grounded_only=grounded_only,
+        top_k=top_k,
+        dedupe_kg_surfaces=dedupe_kg_surfaces,
+        collect_cap=fetch_k if dedupe_kg_surfaces else top_k,
+    )
+
+
+def _filter_and_enrich(
+    hits: Sequence[SearchResult],
+    output_dir: Path,
+    *,
+    types_norm: Optional[List[str]],
+    feed: Optional[str],
+    since: Optional[str],
+    speaker: Optional[str],
+    grounded_only: bool,
+    top_k: int,
+    dedupe_kg_surfaces: bool,
+    collect_cap: int,
+) -> CorpusSearchOutcome:
+    """Apply metadata filters + enrich/lift/dedupe a candidate list (backend-agnostic).
+
+    Shared by the FAISS and hybrid (#RFC-090 Phase 2) retrieval paths so both return
+    the identical enriched response shape.
+    """
     since_dt = _parse_since(since) if isinstance(since, str) and since.strip() else None
     gi_cache = merged_episode_gi_paths(output_dir)
     rel_by_scope = _metadata_relpath_by_scope_from_corpus(output_dir)
     filtered: List[SearchResult] = []
-    collect_cap = fetch_k if dedupe_kg_surfaces else top_k
     for h in hits:
         dt = h.metadata.get("doc_type")
         if types_norm and len(types_norm) > 1:

--- a/src/podcast_scraper/search/hybrid_search.py
+++ b/src/podcast_scraper/search/hybrid_search.py
@@ -1,0 +1,141 @@
+"""Hybrid retrieval bridge for the live search path (RFC-090 Phase 2 / wire-live).
+
+Connects the dormant two-tier stack (``RetrievalLayer`` over ``LanceDBBackend``,
+#855-861) to the serving path (``corpus_search.run_corpus_search``) without changing
+the response contract: hybrid candidates are mapped to the same ``SearchResult``
+shape the FAISS path produces, then run through the *identical* filter/enrich/lift
+pipeline.
+
+**Opt-in and non-regressing.** It activates only when ``serving.hybrid_enabled`` is
+true in ``config/search.yaml`` (default false) *and* a LanceDB index exists for the
+corpus. Any miss — flag off, no index, embed failure — returns ``None`` so the caller
+falls back to FAISS. This matters because the two-tier index covers only the
+*insight* and *segment* (transcript) tiers; kg_entity / kg_topic / quote / summary
+still live only in FAISS, so flipping hybrid on narrows coverage to those two tiers
+by design. Full-coverage hybrid (kg/quote tiers in LanceDB) is a follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import cast, List, Optional, Sequence
+
+import yaml
+
+from ..providers.ml import embedding_loader
+from .backend import CompoundResult, ScoredResult, Tier
+from .protocol import SearchResult
+
+logger = logging.getLogger(__name__)
+
+_SEARCH_CONFIG = Path("config/search.yaml")
+_DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def hybrid_search_enabled() -> bool:
+    """True when ``serving.hybrid_enabled`` is set in ``config/search.yaml``."""
+    try:
+        doc = yaml.safe_load(_SEARCH_CONFIG.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return False
+    serving = doc.get("serving") if isinstance(doc, dict) else None
+    return bool(isinstance(serving, dict) and serving.get("hybrid_enabled"))
+
+
+def lance_index_dir(output_dir: Path) -> Path:
+    """Per-corpus LanceDB index location (co-located with the corpus, #858/#862)."""
+    return Path(output_dir) / "search" / "lance_index"
+
+
+def _tier_for(doc_types: Optional[Sequence[str]]) -> Tier:
+    """Map requested doc types to a two-tier scope (insight | segment | all)."""
+    if not doc_types:
+        return "all"
+    wanted = {t.strip().lower() for t in doc_types if isinstance(t, str) and t.strip()}
+    if wanted <= {"insight"}:
+        return "insight"
+    if wanted <= {"transcript", "segment"}:
+        return "segment"
+    return "all"
+
+
+def _doc_type_for_tier(source_tier: str) -> str:
+    # Segments are transcript chunks in the FAISS vocabulary the enrich/lift expects.
+    return "insight" if source_tier == "insight" else "transcript"
+
+
+def _to_search_result(result: ScoredResult) -> SearchResult:
+    payload = dict(result.payload or {})
+    metadata = {
+        "doc_type": _doc_type_for_tier(result.source_tier),
+        "text": payload.get("text", ""),
+        "episode_id": payload.get("episode_id", ""),
+        "feed_id": payload.get("show_id", ""),
+    }
+    # Carry segment timestamps (seconds → ms) so transcript lift can locate the span.
+    if "start_time" in payload:
+        metadata["timestamp_start_ms"] = int(float(payload.get("start_time") or 0.0) * 1000)
+        metadata["timestamp_end_ms"] = int(float(payload.get("end_time") or 0.0) * 1000)
+    if payload.get("speaker_id"):
+        metadata["speaker_id"] = payload["speaker_id"]
+    return SearchResult(doc_id=str(result.doc_id), score=float(result.score), metadata=metadata)
+
+
+def _flatten(result: object) -> List[ScoredResult]:
+    # A compound contributes both its insight and segment as standalone rows.
+    if isinstance(result, CompoundResult):
+        return [result.insight, result.segment]
+    if isinstance(result, ScoredResult):
+        return [result]
+    return []
+
+
+def hybrid_candidates(
+    output_dir: Path,
+    query: str,
+    *,
+    top_k: int,
+    doc_types: Optional[Sequence[str]] = None,
+    embedding_model: Optional[str] = None,
+    fetch_multiplier: int = 25,
+) -> Optional[List[SearchResult]]:
+    """Hybrid candidates as ``SearchResult`` rows, or ``None`` to fall back to FAISS.
+
+    Returns ``None`` (not an empty list) on any condition that should defer to FAISS:
+    missing LanceDB index or a query-embedding failure. An empty list means the index
+    was searched and genuinely had no hits.
+    """
+    index_dir = lance_index_dir(output_dir)
+    if not index_dir.exists():
+        return None
+
+    model_id = (
+        embedding_model.strip()
+        if isinstance(embedding_model, str) and embedding_model.strip()
+        else _DEFAULT_MODEL
+    )
+    try:
+        qvec = embedding_loader.encode(query, model_id, return_numpy=False, allow_download=False)
+    except Exception as exc:  # noqa: BLE001 - any embed failure → FAISS fallback
+        logger.warning("hybrid_search embed failed (%s); falling back to FAISS", exc)
+        return None
+    if not (isinstance(qvec, list) and qvec and isinstance(qvec[0], float)):
+        return None
+    qemb = cast(List[float], qvec)
+
+    try:
+        from .backends.lancedb_backend import LanceDBBackend
+        from .retrieval import RetrievalLayer
+
+        layer = RetrievalLayer(LanceDBBackend(str(index_dir)))
+        fetch_k = max(top_k * fetch_multiplier, top_k)
+        results = layer.retrieve(query, qemb, k=fetch_k, tier=_tier_for(doc_types))
+    except Exception as exc:  # noqa: BLE001 - backend/index error → FAISS fallback
+        logger.warning("hybrid_search retrieve failed (%s); falling back to FAISS", exc)
+        return None
+
+    rows: List[SearchResult] = []
+    for result in results:
+        rows.extend(_to_search_result(r) for r in _flatten(result))
+    return rows

--- a/src/podcast_scraper/search/judged_eval.py
+++ b/src/podcast_scraper/search/judged_eval.py
@@ -1,0 +1,125 @@
+"""Human-judged hybrid-vs-FAISS eval harness (RFC-057 / wire-live follow-up C).
+
+The shared unblocker for #858 (FAISS removal) and #860 (ML-router promotion). The
+Stage-4 known-item proxy (``scripts/eval_two_tier_retrieval.py``) *saturated* — it
+confirmed parity but could not discriminate, so it cannot justify removing FAISS or
+promoting the ML router. This harness produces a **discriminating, graded** eval:
+
+1. ``build_judgment_template`` runs a real query set through both backends, unions
+   the candidates, and emits a per-query record with each backend's ranking — ready
+   for a human to fill in graded relevance (0/1/2…) per candidate.
+2. ``score_from_judgments`` reads the filled-in judgments back and computes mean
+   nDCG@k + recall@k per backend — the discriminating number the gates need.
+
+The human grading step is the gate; everything around it (run both backends → merge
+→ template → score) is here and tested. The same query set, once intent-labeled,
+also seeds #860's real training data — so judging once unblocks both.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Sequence, Tuple
+
+# (doc_id, text) pairs in rank order, best first.
+RankFn = Callable[[str], Sequence[Tuple[str, str]]]
+
+
+@dataclass
+class JudgmentRecord:
+    """One query's candidates + each backend's ranking, awaiting graded relevance."""
+
+    query: str
+    intent: str
+    candidates: List[Dict] = field(default_factory=list)  # {doc_id, text, faiss_rank, hybrid_rank}
+    faiss_ranking: List[str] = field(default_factory=list)  # doc_ids, best first
+    hybrid_ranking: List[str] = field(default_factory=list)
+    relevance: Dict[str, int] = field(default_factory=dict)  # doc_id -> grade (human-filled)
+
+
+def build_judgment_template(
+    queries: Sequence[str],
+    *,
+    faiss_ranks: RankFn,
+    hybrid_ranks: RankFn,
+    intent_of: Callable[[str], str],
+    k: int = 10,
+) -> List[JudgmentRecord]:
+    """Run *queries* through both backends and build per-query judgment records.
+
+    ``faiss_ranks`` / ``hybrid_ranks`` return ranked ``(doc_id, text)`` for a query;
+    ``intent_of`` labels the query (seeds #860). Candidates from both backends are
+    unioned with each backend's 1-based rank (or ``None`` if a backend missed it).
+    """
+    records: List[JudgmentRecord] = []
+    for query in queries:
+        faiss_list = list(faiss_ranks(query))[:k]
+        hybrid_list = list(hybrid_ranks(query))[:k]
+        faiss_rank = {doc_id: i + 1 for i, (doc_id, _) in enumerate(faiss_list)}
+        hybrid_rank = {doc_id: i + 1 for i, (doc_id, _) in enumerate(hybrid_list)}
+        texts = {doc_id: text for doc_id, text in list(faiss_list) + list(hybrid_list)}
+
+        candidates = [
+            {
+                "doc_id": doc_id,
+                "text": texts.get(doc_id, ""),
+                "faiss_rank": faiss_rank.get(doc_id),
+                "hybrid_rank": hybrid_rank.get(doc_id),
+            }
+            for doc_id in sorted(
+                texts, key=lambda d: (faiss_rank.get(d, 999), hybrid_rank.get(d, 999))
+            )
+        ]
+        records.append(
+            JudgmentRecord(
+                query=query,
+                intent=intent_of(query),
+                candidates=candidates,
+                faiss_ranking=[doc_id for doc_id, _ in faiss_list],
+                hybrid_ranking=[doc_id for doc_id, _ in hybrid_list],
+            )
+        )
+    return records
+
+
+def _dcg(grades: Sequence[float]) -> float:
+    return sum(g / math.log2(i + 2) for i, g in enumerate(grades))
+
+
+def _ndcg_at(ranking: Sequence[str], relevance: Dict[str, int], k: int) -> float:
+    grades = [relevance.get(doc_id, 0) for doc_id in ranking[:k]]
+    ideal = sorted(relevance.values(), reverse=True)[:k]
+    idcg = _dcg(ideal)
+    return _dcg(grades) / idcg if idcg > 0 else 0.0
+
+
+def _recall_at(ranking: Sequence[str], relevance: Dict[str, int], k: int) -> float:
+    relevant = {doc_id for doc_id, g in relevance.items() if g > 0}
+    if not relevant:
+        return 0.0
+    hit = sum(1 for doc_id in ranking[:k] if doc_id in relevant)
+    return hit / len(relevant)
+
+
+def score_from_judgments(
+    records: Sequence[JudgmentRecord], *, k: int = 10
+) -> Dict[str, Dict[str, float]]:
+    """Mean nDCG@k + recall@k per backend over judged *records*.
+
+    Records with no positive grade are skipped (no signal). Returns
+    ``{"faiss": {...}, "hybrid": {...}}``; compare to gate FAISS removal / ML promotion.
+    """
+    agg = {b: {"ndcg": 0.0, "recall": 0.0} for b in ("faiss", "hybrid")}
+    judged = [r for r in records if any(g > 0 for g in r.relevance.values())]
+    n = len(judged)
+    for rec in judged:
+        agg["faiss"]["ndcg"] += _ndcg_at(rec.faiss_ranking, rec.relevance, k)
+        agg["faiss"]["recall"] += _recall_at(rec.faiss_ranking, rec.relevance, k)
+        agg["hybrid"]["ndcg"] += _ndcg_at(rec.hybrid_ranking, rec.relevance, k)
+        agg["hybrid"]["recall"] += _recall_at(rec.hybrid_ranking, rec.relevance, k)
+    for backend in agg:
+        for metric in agg[backend]:
+            agg[backend][metric] /= max(n, 1)
+    agg["_judged_count"] = {"n": float(n)}  # for transparency / no-silent-truncation
+    return agg

--- a/src/podcast_scraper/search/two_tier_indexer.py
+++ b/src/podcast_scraper/search/two_tier_indexer.py
@@ -1,0 +1,120 @@
+"""From-corpus two-tier indexer (RFC-090 / wire-live follow-up B).
+
+Builds the two-tier LanceDB index (#855) directly from corpus artifacts, so a
+**fresh** corpus becomes hybrid-searchable without first having a FAISS index to
+migrate (#858). It reuses the proven FAISS-indexer extraction —
+``discover_metadata_files`` → ``_collect_docs_for_episode`` — which already yields
+insight rows and timestamped transcript chunks, then re-embeds the text and upserts
+into the ``insight`` (Tier 2) and ``segment`` (Tier 1) tables.
+
+Relationship to the migration (#858): the migration is the fast path for a corpus
+that already has FAISS (it reuses those embeddings verbatim); this indexer is the
+native path for corpora that don't. Both produce the same two-tier layout the live
+hybrid search (RFC-090 Phase 2) reads. Insight↔segment linking
+(``linked_insight_ids`` for compound results) is not populated here yet — like the
+migration — so compounds degrade to separate insight+segment rows; wiring the
+SUPPORTED_BY edges through is a follow-up.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast, List, Optional
+
+from ..providers.ml import embedding_loader
+from .backend import InsightDocument, SegmentDocument
+from .backends.lancedb_backend import DEFAULT_EMBED_DIM, LanceDBBackend
+from .corpus_scope import discover_metadata_files, episode_root_from_metadata_path
+from .indexer import _collect_docs_for_episode, _load_metadata_file
+
+DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+DEFAULT_TARGET_TOKENS = 256
+DEFAULT_OVERLAP_TOKENS = 32
+
+
+@dataclass
+class TwoTierIndexStats:
+    """Counts from a from-corpus two-tier index build."""
+
+    episodes: int = 0
+    segments: int = 0
+    insights: int = 0
+
+
+def _embed(text: str, model_id: str, *, allow_download: bool) -> List[float]:
+    vec = embedding_loader.encode(text, model_id, return_numpy=False, allow_download=allow_download)
+    return [float(x) for x in cast(List[float], vec)]
+
+
+def build_two_tier_index(
+    corpus_dir: str | Path,
+    lance_path: str | Path,
+    *,
+    model_id: str = DEFAULT_MODEL,
+    target_tokens: int = DEFAULT_TARGET_TOKENS,
+    overlap_tokens: int = DEFAULT_OVERLAP_TOKENS,
+    embed_dim: int = DEFAULT_EMBED_DIM,
+    limit_episodes: Optional[int] = None,
+    allow_download: bool = False,
+) -> TwoTierIndexStats:
+    """Build the two-tier LanceDB index at *lance_path* from the corpus at *corpus_dir*.
+
+    Walks episode metadata, extracts insight + transcript-chunk rows, embeds each with
+    *model_id*, and upserts into the segment/insight tables (idempotent merge on id).
+    ``limit_episodes`` caps the walk for smoke runs. Returns per-tier counts.
+    """
+    out = Path(corpus_dir)
+    backend = LanceDBBackend(str(lance_path), embed_dim=embed_dim)
+    stats = TwoTierIndexStats()
+
+    for meta_path in discover_metadata_files(out):
+        if limit_episodes is not None and stats.episodes >= limit_episodes:
+            break
+        doc = _load_metadata_file(meta_path)
+        if not doc:
+            continue
+        stats.episodes += 1
+        episode_root = episode_root_from_metadata_path(meta_path)
+        meta_rel = meta_path.resolve().relative_to(out.resolve()).as_posix()
+        rows = _collect_docs_for_episode(
+            episode_root,
+            meta_path,
+            doc,
+            target_tokens=target_tokens,
+            overlap_tokens=overlap_tokens,
+            metadata_relative_path=meta_rel,
+        )
+        for doc_id, text, meta in rows:
+            doc_type = meta.get("doc_type")
+            if doc_type == "insight":
+                backend.upsert_insight(
+                    InsightDocument(
+                        id=doc_id,
+                        text=text,
+                        show_id=meta.get("feed_id") or "",
+                        episode_id=meta.get("episode_id") or "",
+                        entity_type="insight",
+                        confidence=0.0,
+                        derived=bool(meta.get("grounded")),
+                        embedding=_embed(text, model_id, allow_download=allow_download),
+                    )
+                )
+                stats.insights += 1
+            elif doc_type == "transcript":
+                backend.upsert_segment(
+                    SegmentDocument(
+                        id=doc_id,
+                        text=text,
+                        show_id=meta.get("feed_id") or "",
+                        episode_id=meta.get("episode_id") or "",
+                        start_time=float(meta.get("timestamp_start_ms") or 0.0) / 1000.0,
+                        end_time=float(meta.get("timestamp_end_ms") or 0.0) / 1000.0,
+                        embedding=_embed(text, model_id, allow_download=allow_download),
+                    )
+                )
+                stats.segments += 1
+
+    if stats.segments or stats.insights:
+        backend.create_indices()
+    return stats

--- a/src/podcast_scraper/server/routes/search.py
+++ b/src/podcast_scraper/server/routes/search.py
@@ -55,7 +55,12 @@ async def search_corpus(
         ),
     ),
 ) -> CorpusSearchApiResponse:
-    """Semantic search via FAISS + sentence embeddings."""
+    """Semantic corpus search.
+
+    Routes through the two-tier hybrid ``RetrievalLayer`` when ``serving.hybrid_enabled``
+    is set and a LanceDB index exists (RFC-090 Phase 2); otherwise FAISS. The response
+    shape is identical for both backends.
+    """
     fallback = getattr(request.app.state, "output_dir", None)
     root = _resolve_corpus_root(path, fallback)
     if root is None:

--- a/src/podcast_scraper/upgrade/migrations/m0002_two_tier_native_reindex.py
+++ b/src/podcast_scraper/upgrade/migrations/m0002_two_tier_native_reindex.py
@@ -1,0 +1,89 @@
+"""0002 — native two-tier reindex fallback (2.6 → 2.7, follow-up B under #862).
+
+Completes the chain that 0001 starts. 0001 (FAISS→LanceDB) is a **no-op when a
+corpus has no FAISS index** to migrate. This step covers exactly that gap: if no
+LanceDB index exists yet, build it **natively** from corpus artifacts
+(``build_two_tier_index``, follow-up B); if one already exists (0001 built it, or a
+prior run), it is a no-op. Together the two guarantee every upgraded corpus ends
+with a two-tier index via the cheapest available path, without double-building.
+
+Why this and not the originally-speculated migrations: the cross-episode entity
+canonical map (#852) is computed **live** at graph-build (``corpus_graph`` →
+``build_entity_id_map``), not persisted, so there is nothing to migrate; and the
+basic vector-index build is already 0001. Registering those would be busy-work — see
+the upgrade guide.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+from ..migration import Migration, MigrationContext, MigrationResult
+
+
+class TwoTierNativeReindexMigration(Migration):
+    """Build the two-tier LanceDB index natively when 0001 left none."""
+
+    id = "0002_two_tier_native_reindex"
+    to_version = "2.7.0"
+    description = "Native two-tier index build for corpora without a FAISS index (RFC-090 B)"
+
+    def _lance_path(self, ctx: MigrationContext) -> Path:
+        return Path(ctx.options.get("lance_path") or ctx.corpus_root / "search" / "lance_index")
+
+    def plan(self, ctx: MigrationContext) -> str:
+        """Describe whether a native build is needed for this corpus."""
+        if self._lance_path(ctx).exists():
+            return "LanceDB index already present — no-op."
+        return (
+            f"Build two-tier LanceDB index natively from {ctx.corpus_root} (no FAISS to migrate)."
+        )
+
+    def apply(self, ctx: MigrationContext) -> MigrationResult:
+        """Build the native index only if one does not already exist."""
+        lance_path = self._lance_path(ctx)
+        if lance_path.exists():
+            ctx.log(f"LanceDB index already present at {lance_path}; skipping native build")
+            return MigrationResult(
+                self.id, applied=True, dry_run=ctx.dry_run, message="index already present — no-op"
+            )
+        if ctx.dry_run:
+            ctx.log(self.plan(ctx))
+            return MigrationResult(self.id, applied=False, dry_run=True, message=self.plan(ctx))
+
+        from ...search.two_tier_indexer import build_two_tier_index
+
+        ctx.log(f"building native two-tier index at {lance_path}")
+        stats = build_two_tier_index(ctx.corpus_root, lance_path)
+        return MigrationResult(
+            self.id,
+            applied=True,
+            dry_run=False,
+            message=f"native build: episodes={stats.episodes} segments={stats.segments} "
+            f"insights={stats.insights}",
+            details={
+                "episodes": stats.episodes,
+                "segments": stats.segments,
+                "insights": stats.insights,
+                "lance_path": str(lance_path),
+            },
+        )
+
+    def verify(self, ctx: MigrationContext) -> Tuple[bool, str]:
+        """Confirm a LanceDB index exists (built here or by 0001)."""
+        lance_path = self._lance_path(ctx)
+        if not lance_path.exists():
+            # Acceptable only if the corpus genuinely has no indexable content.
+            return True, "no LanceDB index (empty corpus or nothing to index)"
+        try:
+            from ...search.backends.lancedb_backend import LanceDBBackend
+
+            health = LanceDBBackend(str(lance_path)).health()
+        except Exception as exc:  # noqa: BLE001 - surface as verify failure
+            return False, f"LanceDB health check failed: {exc}"
+        total = int(health.get("segments", 0)) + int(health.get("insights", 0))
+        return (
+            (total >= 0),
+            f"LanceDB present: segments={health.get('segments')} insights={health.get('insights')}",
+        )

--- a/src/podcast_scraper/upgrade/registry.py
+++ b/src/podcast_scraper/upgrade/registry.py
@@ -11,10 +11,15 @@ from typing import List
 
 from .migration import Migration
 from .migrations.m0001_faiss_to_lance import FaissToLanceMigration
+from .migrations.m0002_two_tier_native_reindex import TwoTierNativeReindexMigration
 
-# Source of truth, declared in intended apply order.
+# Source of truth, declared in intended apply order. 0001 migrates from FAISS when
+# present; 0002 builds natively only when 0001 left no index — together they
+# guarantee a two-tier index via the cheapest path. The entity canonical map (#852)
+# is intentionally NOT a migration: it is computed live at graph-build, not persisted.
 _MIGRATIONS: List[Migration] = [
     FaissToLanceMigration(),
+    TwoTierNativeReindexMigration(),
 ]
 
 

--- a/tests/integration/search/test_hybrid_search.py
+++ b/tests/integration/search/test_hybrid_search.py
@@ -1,0 +1,80 @@
+"""Integration tests for the hybrid serving bridge (RFC-090 Phase 2 wire-live).
+
+Real LanceDB index + real MiniLM query embedding; asserts candidate mapping, tier
+scoping, and the FAISS-fallback signal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+pytest.importorskip("lancedb")
+
+from podcast_scraper.providers.ml import embedding_loader  # noqa: E402
+from podcast_scraper.search import hybrid_search as hs  # noqa: E402
+from podcast_scraper.search.backend import InsightDocument, SegmentDocument  # noqa: E402
+from podcast_scraper.search.backends.lancedb_backend import LanceDBBackend  # noqa: E402
+
+_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def _emb(text):
+    return list(embedding_loader.encode(text, _MODEL, return_numpy=False, allow_download=True))
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    idx = tmp_path / "corpus" / "search" / "lance_index"
+    idx.parent.mkdir(parents=True)
+    b = LanceDBBackend(str(idx), embed_dim=384)
+    b.upsert_segment(
+        SegmentDocument(
+            id="chunk:1",
+            text="raw transcript about AI scaling laws",
+            show_id="A",
+            episode_id="ep1",
+            start_time=2.0,
+            end_time=5.0,
+            embedding=_emb("raw transcript about AI scaling laws"),
+        )
+    )
+    b.upsert_insight(
+        InsightDocument(
+            id="insight:1",
+            text="Altman argues AI scaling continues",
+            show_id="A",
+            episode_id="ep1",
+            entity_type="insight",
+            confidence=0.8,
+            derived=True,
+            embedding=_emb("Altman argues AI scaling continues"),
+        )
+    )
+    b.create_indices()
+    return tmp_path / "corpus"
+
+
+def test_maps_both_tiers_with_doc_type_and_timestamps(corpus):
+    rows = hs.hybrid_candidates(corpus, "AI scaling", top_k=5)
+    by_id = {r.doc_id: r for r in rows}
+    assert by_id["insight:1"].metadata["doc_type"] == "insight"
+    seg = by_id["chunk:1"]
+    assert seg.metadata["doc_type"] == "transcript"  # segment → transcript vocab
+    assert seg.metadata["timestamp_start_ms"] == 2000  # seconds → ms
+    assert seg.metadata["episode_id"] == "ep1"
+
+
+def test_tier_scoping(corpus):
+    assert [
+        r.doc_id for r in hs.hybrid_candidates(corpus, "AI", top_k=5, doc_types=["insight"])
+    ] == ["insight:1"]
+    assert [
+        r.doc_id for r in hs.hybrid_candidates(corpus, "AI", top_k=5, doc_types=["transcript"])
+    ] == ["chunk:1"]
+
+
+def test_missing_index_returns_none(tmp_path):
+    # No LanceDB index → None (signals FAISS fallback), not an empty list.
+    assert hs.hybrid_candidates(tmp_path / "nope", "AI", top_k=5) is None

--- a/tests/integration/search/test_two_tier_indexer.py
+++ b/tests/integration/search/test_two_tier_indexer.py
@@ -1,0 +1,81 @@
+"""Integration test for the from-corpus two-tier indexer (RFC-090 Phase 2 / B).
+
+Stubs the (already-tested) FAISS-indexer corpus extraction and exercises this
+module's own logic — embed → map → upsert → both tiers queryable — against a real
+LanceDB index with real MiniLM embeddings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+pytest.importorskip("lancedb")
+
+from podcast_scraper.search import hybrid_search as hs, two_tier_indexer as tti  # noqa: E402
+from podcast_scraper.search.backends.lancedb_backend import LanceDBBackend  # noqa: E402
+
+
+def _stub_extraction(monkeypatch, tmp_path, rows):
+    meta_path = tmp_path / "corpus" / "metadata" / "ep1.json"
+    monkeypatch.setattr(tti, "discover_metadata_files", lambda root: [meta_path])
+    monkeypatch.setattr(tti, "_load_metadata_file", lambda p: {"episode": {"episode_id": "ep1"}})
+    monkeypatch.setattr(tti, "episode_root_from_metadata_path", lambda p: tmp_path / "corpus")
+    monkeypatch.setattr(tti, "_collect_docs_for_episode", lambda *a, **k: rows)
+
+
+def test_builds_both_tiers_and_is_queryable(tmp_path, monkeypatch):
+    rows = [
+        (
+            "insight:1",
+            "The central bank is shifting monetary policy",
+            {"doc_type": "insight", "episode_id": "ep1", "feed_id": "show1", "grounded": True},
+        ),
+        (
+            "chunk:1",
+            "Markets moved sharply as the central bank signaled a policy shift",
+            {
+                "doc_type": "transcript",
+                "episode_id": "ep1",
+                "feed_id": "show1",
+                "timestamp_start_ms": 2000,
+                "timestamp_end_ms": 5000,
+            },
+        ),
+        # A non-two-tier row (quote) must be ignored.
+        ("quote:1", "we are shifting", {"doc_type": "quote", "episode_id": "ep1"}),
+    ]
+    _stub_extraction(monkeypatch, tmp_path, rows)
+
+    corpus = tmp_path / "corpus"
+    (corpus / "metadata").mkdir(parents=True)
+    lance = corpus / "search" / "lance_index"
+    stats = tti.build_two_tier_index(corpus, lance, allow_download=True)
+
+    assert stats.episodes == 1
+    assert stats.insights == 1 and stats.segments == 1  # quote ignored
+
+    health = LanceDBBackend(str(lance)).health()
+    assert health["insights"] == 1 and health["segments"] == 1
+
+    rows_out = hs.hybrid_candidates(corpus, "central bank policy shift", top_k=5)
+    assert rows_out is not None and len(rows_out) >= 1
+    by_id = {r.doc_id: r for r in rows_out}
+    assert by_id["chunk:1"].metadata["timestamp_start_ms"] == 2000  # ms preserved via seconds
+
+
+def test_limit_episodes_caps_walk(tmp_path, monkeypatch):
+    rows = [("insight:1", "x", {"doc_type": "insight", "episode_id": "ep1", "feed_id": "s"})]
+    # Two metadata files, but limit_episodes=0 stops before any work.
+    meta = tmp_path / "corpus" / "metadata" / "ep1.json"
+    monkeypatch.setattr(tti, "discover_metadata_files", lambda root: [meta, meta])
+    monkeypatch.setattr(tti, "_load_metadata_file", lambda p: {"episode": {"episode_id": "ep1"}})
+    monkeypatch.setattr(tti, "episode_root_from_metadata_path", lambda p: tmp_path / "corpus")
+    monkeypatch.setattr(tti, "_collect_docs_for_episode", lambda *a, **k: rows)
+    (tmp_path / "corpus" / "metadata").mkdir(parents=True)
+
+    stats = tti.build_two_tier_index(
+        tmp_path / "corpus", tmp_path / "corpus" / "search" / "li", limit_episodes=0
+    )
+    assert stats.episodes == 0 and stats.insights == 0

--- a/tests/integration/upgrade/test_end_to_end.py
+++ b/tests/integration/upgrade/test_end_to_end.py
@@ -61,10 +61,14 @@ def test_status_then_run_then_verify(tmp_path):
     # status before: pending → exit 2.
     assert _run(corpus, "status") == 2
 
-    # run --yes applies it.
+    # run --yes applies the chain: 0001 migrates from FAISS, 0002 sees the index and
+    # no-ops.
     assert _run(corpus, "run", "--yes") == 0
     store = FilesystemStateStore(corpus)
-    assert store.applied_migration_ids() == {"0001_faiss_to_lance"}
+    assert store.applied_migration_ids() == {
+        "0001_faiss_to_lance",
+        "0002_two_tier_native_reindex",
+    }
     assert store.current_version() == "2.7.0"
     assert (corpus / "search" / "lance_index").exists()
 
@@ -74,9 +78,9 @@ def test_status_then_run_then_verify(tmp_path):
     # verify passes.
     assert _run(corpus, "verify") == 0
 
-    # idempotent: a second run is a no-op (still exit 0, still one ledger entry).
+    # idempotent: a second run is a no-op (still exit 0, ledger unchanged).
     assert _run(corpus, "run", "--yes") == 0
-    assert len(store.applied_records()) == 1
+    assert len(store.applied_records()) == 2
 
 
 def test_run_dry_run_writes_nothing(tmp_path):

--- a/tests/unit/search/test_hybrid_dispatch.py
+++ b/tests/unit/search/test_hybrid_dispatch.py
@@ -1,0 +1,60 @@
+"""Unit tests for the hybrid flag reader + corpus_search dispatch (RFC-090 Phase 2).
+
+No LanceDB/FAISS — the flag reader is exercised against a temp config and the
+dispatch is exercised by stubbing the hybrid bridge, so the FAISS-vs-hybrid routing
+logic is verified in isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search import corpus_search, hybrid_search
+from podcast_scraper.search.protocol import SearchResult
+
+pytestmark = pytest.mark.unit
+
+
+def test_flag_reader_defaults_false_and_reads_yaml(tmp_path, monkeypatch):
+    cfg = tmp_path / "search.yaml"
+    monkeypatch.setattr(hybrid_search, "_SEARCH_CONFIG", cfg)
+    assert hybrid_search.hybrid_search_enabled() is False  # missing file → False
+
+    cfg.write_text("serving:\n  hybrid_enabled: true\n", encoding="utf-8")
+    assert hybrid_search.hybrid_search_enabled() is True
+
+    cfg.write_text("serving:\n  hybrid_enabled: false\n", encoding="utf-8")
+    assert hybrid_search.hybrid_search_enabled() is False
+
+
+def test_dispatch_uses_hybrid_when_enabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(corpus_search, "hybrid_search_enabled", lambda: True)
+    row = SearchResult(
+        doc_id="insight:1",
+        score=0.9,
+        metadata={"doc_type": "insight", "text": "hybrid hit", "episode_id": "ep1"},
+    )
+    monkeypatch.setattr(corpus_search, "hybrid_candidates", lambda *a, **k: [row])
+
+    outcome = corpus_search.run_corpus_search(tmp_path, "AI scaling", top_k=5)
+    assert outcome.error is None
+    assert any(r.get("doc_id") == "insight:1" for r in outcome.results)  # hybrid path, no FAISS
+
+
+def test_dispatch_falls_back_to_faiss_when_hybrid_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(corpus_search, "hybrid_search_enabled", lambda: True)
+    monkeypatch.setattr(corpus_search, "hybrid_candidates", lambda *a, **k: None)  # signal fallback
+    # No FAISS index in tmp_path → FAISS path reports no_index (proves we fell through).
+    outcome = corpus_search.run_corpus_search(tmp_path, "AI scaling", top_k=5)
+    assert outcome.error == "no_index"
+
+
+def test_dispatch_skips_hybrid_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(corpus_search, "hybrid_search_enabled", lambda: False)
+
+    def _boom(*a, **k):
+        raise AssertionError("hybrid_candidates must not be called when disabled")
+
+    monkeypatch.setattr(corpus_search, "hybrid_candidates", _boom)
+    outcome = corpus_search.run_corpus_search(tmp_path, "AI scaling", top_k=5)
+    assert outcome.error == "no_index"  # straight to FAISS path

--- a/tests/unit/search/test_judged_eval.py
+++ b/tests/unit/search/test_judged_eval.py
@@ -1,0 +1,68 @@
+"""Unit tests for the judged hybrid-vs-FAISS eval harness (RFC-057 / C)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.judged_eval import (
+    build_judgment_template,
+    JudgmentRecord,
+    score_from_judgments,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_template_unions_candidates_with_per_backend_ranks():
+    faiss = {"q": [("a", "text-a"), ("b", "text-b")]}
+    hybrid = {"q": [("b", "text-b"), ("c", "text-c")]}
+    records = build_judgment_template(
+        ["q"],
+        faiss_ranks=lambda q: faiss[q],
+        hybrid_ranks=lambda q: hybrid[q],
+        intent_of=lambda q: "semantic",
+        k=10,
+    )
+    rec = records[0]
+    assert rec.intent == "semantic"
+    assert rec.faiss_ranking == ["a", "b"] and rec.hybrid_ranking == ["b", "c"]
+    cand = {c["doc_id"]: c for c in rec.candidates}
+    assert set(cand) == {"a", "b", "c"}  # unioned
+    assert cand["a"]["faiss_rank"] == 1 and cand["a"]["hybrid_rank"] is None
+    assert cand["b"]["faiss_rank"] == 2 and cand["b"]["hybrid_rank"] == 1
+
+
+def test_score_rewards_ranking_relevant_doc_higher():
+    # Same relevant doc "good" (grade 2); hybrid ranks it #1, FAISS ranks it #3.
+    rec = JudgmentRecord(
+        query="q",
+        intent="semantic",
+        faiss_ranking=["x", "y", "good"],
+        hybrid_ranking=["good", "x", "y"],
+        relevance={"good": 2, "x": 0, "y": 0},
+    )
+    scores = score_from_judgments([rec], k=10)
+    assert scores["hybrid"]["ndcg"] > scores["faiss"]["ndcg"]
+    assert scores["hybrid"]["ndcg"] == pytest.approx(1.0)  # relevant doc at rank 1 → ideal
+    assert scores["_judged_count"]["n"] == 1.0
+
+
+def test_recall_counts_relevant_in_top_k():
+    rec = JudgmentRecord(
+        query="q",
+        intent="semantic",
+        faiss_ranking=["a", "b", "c", "d"],
+        hybrid_ranking=["a", "b", "c", "d"],
+        relevance={"a": 1, "d": 1},  # two relevant
+    )
+    scores = score_from_judgments([rec], k=2)  # top-2 contains only "a"
+    assert scores["faiss"]["recall"] == pytest.approx(0.5)
+
+
+def test_unjudged_records_are_skipped():
+    rec = JudgmentRecord(
+        query="q", intent="semantic", faiss_ranking=["a"], hybrid_ranking=["a"], relevance={"a": 0}
+    )
+    scores = score_from_judgments([rec], k=10)
+    assert scores["_judged_count"]["n"] == 0.0  # no positive grade → no signal
+    assert scores["hybrid"]["ndcg"] == 0.0

--- a/tests/unit/upgrade/test_migration_0002.py
+++ b/tests/unit/upgrade/test_migration_0002.py
@@ -1,0 +1,54 @@
+"""Unit tests for the native two-tier reindex migration (0002, #862 / B).
+
+Stubs ``build_two_tier_index`` so the migration's own gating logic — no-op when an
+index exists, build when absent, dry-run — is tested without LanceDB.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search import two_tier_indexer
+from podcast_scraper.upgrade.migration import MigrationContext
+from podcast_scraper.upgrade.migrations.m0002_two_tier_native_reindex import (
+    TwoTierNativeReindexMigration,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx(tmp_path, dry_run=False):
+    return MigrationContext(corpus_root=tmp_path, dry_run=dry_run)
+
+
+def test_noop_when_index_already_exists(tmp_path, monkeypatch):
+    (tmp_path / "search" / "lance_index").mkdir(parents=True)  # 0001 already built it
+
+    def _boom(*a, **k):
+        raise AssertionError("must not rebuild when an index already exists")
+
+    monkeypatch.setattr(two_tier_indexer, "build_two_tier_index", _boom)
+    result = TwoTierNativeReindexMigration().apply(_ctx(tmp_path))
+    assert result.applied and "no-op" in result.message
+
+
+def test_builds_natively_when_absent(tmp_path, monkeypatch):
+    calls = {}
+
+    def _fake(corpus, lance, **k):
+        calls["corpus"] = corpus
+        return two_tier_indexer.TwoTierIndexStats(episodes=3, segments=10, insights=7)
+
+    monkeypatch.setattr(two_tier_indexer, "build_two_tier_index", _fake)
+    result = TwoTierNativeReindexMigration().apply(_ctx(tmp_path))
+    assert result.applied and result.details["segments"] == 10
+    assert calls["corpus"] == tmp_path  # built from the corpus root
+
+
+def test_dry_run_does_not_build(tmp_path, monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("dry-run must not build")
+
+    monkeypatch.setattr(two_tier_indexer, "build_two_tier_index", _boom)
+    result = TwoTierNativeReindexMigration().apply(_ctx(tmp_path, dry_run=True))
+    assert result.applied is False and result.dry_run is True


### PR DESCRIPTION
## Summary

Phase 2 of RFC-090: **activates the hybrid retrieval stack** (built dormant in #863) and closes the loop around it. Stacked on #863 — review/merge that first.

The keystone is **A**: until now ~2,600 lines of two-tier retrieval machinery existed but nothing queried it. This wires it into the live search path, then adds the pieces that make it usable on any corpus (B), guarantee it after an upgrade (D), and unblock the gates it depends on (C).

## Commits (sequence B→A→D→C, as agreed)

| # | What | Notes |
|---|---|---|
| **A** | Wire two-tier hybrid into `GET /api/search` | Opt-in (`serving.hybrid_enabled`, default off) + FAISS fallback; identical response shape |
| **B** | From-corpus two-tier indexer + `index-two-tier` CLI/make | Fresh corpora get a LanceDB index natively (no FAISS needed) |
| **D** | Upgrade migration `0002` native reindex | Covers the gap where `0001` no-ops (no FAISS); chain now guarantees an index |
| **C** | Human-judged hybrid-vs-FAISS eval harness (RFC-057) | The discriminating eval that re-gates #858 + #860 |

## Key decisions / honesty notes

- **A is non-regressing by construction.** Hybrid activates only when the flag is on *and* a LanceDB index exists; any miss returns `None` → FAISS. Default off because the two-tier index covers only insight + segment tiers (kg/quote/summary stay FAISS-only until added).
- **D corrected a speculated scope.** Investigation showed the originally-listed migrations weren't real: the entity canonical map (#852) is computed **live** at graph-build (not persisted → nothing to migrate), and the basic vector build is already `0001`. So instead of busy-work, `0002` fills the one real gap (native build when no FAISS existed), and the guide says why.
- **C makes the gates actionable.** The Stage-4 known-item proxy saturated (parity, no signal). The judged harness runs both backends → graded template → nDCG/recall verdict (needs a clear margin over ≥30 judged queries). The same queries, intent-labeled, seed #860's real training data — judging once unblocks both #858 and #860.

## Tests & gates

- Unit: hybrid dispatch/flag, judged-eval scoring (nDCG/recall), migration 0002 gating.
- Integration (real lancedb): hybrid candidate mapping + tier scoping, from-corpus indexer, upgrade chain e2e.
- All verified on the real corpus; `make ci-fast` green.

## Try it

```bash
make index-two-tier CORPUS_DIR=<corpus>      # build the two-tier index
# set serving.hybrid_enabled: true in config/search.yaml
make serve                                    # /api/search now hybrid, FAISS fallback
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
