### PR TITLE
feat(search): RFC-090 Phase 2 wire-live + audit-driven hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,7 @@ validate-kg-schema:
 	fi
 
 # GI/KG viewer v2 (#489): FastAPI + Vite. ``make init`` includes FastAPI via ``[dev]``; cd $(WEB_VIEWER_DIR) && npm install
-.PHONY: serve serve-api serve-ui serve-e2e-mock stack-build stack-build-llm stack-compose-validate stack-up stack-down stack-logs verify-stack-profiles stack-test-build stack-test-build-cloud stack-test-up stack-test-down stack-test-seed stack-test-playwright stack-test-export stack-test-ml stack-test-cloud-thin stack-test-ml-ci deploy-codespace restore-corpus restore-corpus-prod reprocess-corpus-from-transcripts corpus-compat-check upgrade-status upgrade-check upgrade-dry-run upgrade-corpus upgrade-verify smoke-prod corpus-snapshot-manifest-validate corpus-snapshot-select-tag corpus-snapshot-select-tag-prod corpus-snapshot-selftest corpus-snapshot-integration
+.PHONY: serve serve-api serve-ui serve-e2e-mock stack-build stack-build-llm stack-compose-validate stack-up stack-down stack-logs verify-stack-profiles stack-test-build stack-test-build-cloud stack-test-up stack-test-down stack-test-seed stack-test-playwright stack-test-export stack-test-ml stack-test-cloud-thin stack-test-ml-ci deploy-codespace restore-corpus restore-corpus-prod reprocess-corpus-from-transcripts corpus-compat-check index-two-tier upgrade-status upgrade-check upgrade-dry-run upgrade-corpus upgrade-verify smoke-prod corpus-snapshot-manifest-validate corpus-snapshot-select-tag corpus-snapshot-select-tag-prod corpus-snapshot-selftest corpus-snapshot-integration
 SERVE_OUTPUT_DIR ?= ./output
 # Optional corpus-editing + jobs routes (health shows green when on). Override with SERVE_ARGS= to disable.
 SERVE_ARGS ?= --enable-feeds-api --enable-operator-config-api --enable-jobs-api
@@ -1016,6 +1016,12 @@ reprocess-corpus-from-transcripts:
 corpus-compat-check:
 	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
 	$(PYTHON) -c "from pathlib import Path; from podcast_scraper.corpus_version import read_produced_by, assess_corpus_version_compat, MIN_SUPPORTED_CORPUS_CODE_VERSION; from podcast_scraper import __version__; root = Path('$${CORPUS_DIR}').expanduser().resolve(); pb = read_produced_by(root); ver, warn = assess_corpus_version_compat(pb); print(f'server={__version__} min_supported={MIN_SUPPORTED_CORPUS_CODE_VERSION}'); print(f'corpus_code_version={ver!r}'); print(f'produced_by={pb!r}'); import sys; (print(f'WARNING: {warn}') or sys.exit(1)) if warn else print('COMPAT OK')"
+
+# Build the two-tier LanceDB index from corpus artifacts (RFC-090 Phase 2, follow-up
+# B). Native path for corpora without a FAISS index to migrate. CORPUS_DIR required.
+index-two-tier:
+	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
+	$(PYTHON) -m podcast_scraper.cli index-two-tier --output-dir "$${CORPUS_DIR}"
 
 # Corpus upgrade-path framework (#862). Managed, idempotent migrations for moving a
 # deployed corpus across releases (2.6 → 2.7 FAISS→LanceDB is step 0001). CORPUS_DIR

--- a/config/search.yaml
+++ b/config/search.yaml
@@ -5,6 +5,15 @@
 
 backend: lancedb
 
+# Live serving path (RFC-090 Phase 2). When hybrid_enabled is true AND a LanceDB
+# index exists for the corpus, GET /api/search routes through the two-tier hybrid
+# RetrievalLayer (BM25 + dense + KG-proximity → RRF); otherwise it uses FAISS. Kept
+# false by default: the two-tier index covers only the insight + segment(transcript)
+# tiers, so enabling it narrows coverage (no kg_entity/kg_topic/quote/summary) until
+# those tiers are added. Flip to true to A/B hybrid on a migrated/indexed corpus.
+serving:
+  hybrid_enabled: false
+
 lancedb:
   path: ./data/lance_index
 

--- a/config/search.yaml
+++ b/config/search.yaml
@@ -1,9 +1,11 @@
 # Two-tier hybrid search backend configuration (RFC-090 §3.10).
-# Selects the SearchBackend implementation for hybrid retrieval. LanceDB embedded
-# is the initial backend; cloud backends are supported by the abstraction but not
-# yet implemented (swapping backends costs zero changes outside this file).
+# NOTE: `backend` and `lancedb.path` below are RESERVED — the live serving path
+# (`search.hybrid_search`) currently instantiates LanceDB unconditionally at a
+# per-corpus path (`<corpus>/search/lance_index`), so it does not yet read these two
+# keys. `serving.hybrid_enabled` and the `router` block ARE read. Keep this in mind
+# until a backend factory honors `backend`.
 
-backend: lancedb
+backend: lancedb  # reserved: only LanceDB is implemented; not yet read by code
 
 # Live serving path (RFC-090 Phase 2). When hybrid_enabled is true AND a LanceDB
 # index exists for the corpus, GET /api/search routes through the two-tier hybrid
@@ -15,7 +17,7 @@ serving:
   hybrid_enabled: false
 
 lancedb:
-  path: ./data/lance_index
+  path: ./data/lance_index  # reserved: live path is <corpus>/search/lance_index (not read)
 
 # Query router (RFC-092 / #860): how a query's intent is classified, which drives
 # the per-intent signal/tier weights. `rules` is deterministic and dependency-free;

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -79,6 +79,12 @@ COPY config/profiles/ ./config/profiles/
 # the Python package), so it can't ride along in the wheel.
 COPY config/examples/ ./config/examples/
 
+# Ship the search backend/serving config so hybrid retrieval (RFC-090 Phase 2) is
+# togglable in the container via ``serving.hybrid_enabled`` — it lives outside the
+# wheel like the profiles above, and ``search.hybrid_search`` reads it at this
+# cwd-relative path (or via the PODCAST_SEARCH_CONFIG / PODCAST_HYBRID_SEARCH envs).
+COPY config/search.yaml ./config/search.yaml
+
 COPY docker/api/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/docs/ci/CODEQL_DISMISSALS.md
+++ b/docs/ci/CODEQL_DISMISSALS.md
@@ -238,6 +238,9 @@ number, file, line, date, and a short comment.
 | 1 | #330 | server/pathutil.py | 115 | 2026-05-24 | Type 1: post-refactor ``corpus_s`` inline ``normpath`` + ``startswith`` (PR #815) |
 | 1 | #331 | server/pathutil.py | 123 | 2026-05-24 | Type 1: ``manifest_s`` inline sanitizer before ``os.path.isfile`` (PR #815) |
 | 1 | #332 | server/pathutil.py | 126 | 2026-05-24 | Type 1: ``manifest_s`` inline sanitizer before ``read_text`` (PR #815) |
+| 1 | #342 | search/backends/lancedb_backend.py | 131 | 2026-06-01 | Type 1: ``meta_path`` via ``normpath_if_under_root`` after ``safe_resolve_directory`` + ``safe_relpath_under_corpus_root`` (constant ``index_meta.json``) before ``open`` in ``read_index_meta``; corpus root confined at the route by ``resolve_corpus_path_param`` (raises on escape). Same shape as ``jobs_log_path:74``. Dismissed ``gh api`` (PR #865) |
+| 1 | #338 | search/backends/lancedb_backend.py | 135 | 2026-06-01 | Type 1: same sanitizer chain, ``os.path.isfile(meta_path)`` sink in ``read_index_meta`` (PR #865) |
+| 1 | #341 | search/hybrid_search.py | 172 | 2026-06-01 | Type 1: ``index_dir_str`` via ``normpath_if_under_root`` after ``safe_resolve_directory`` + ``safe_relpath_under_corpus_root`` (constant ``search/lance_index``) before ``os.path.isdir`` in ``hybrid_candidates``; corpus root confined at the route by ``resolve_corpus_path_param``. Dismissed ``gh api`` (PR #865) |
 
 ## Still open (not yet dismissed)
 

--- a/docs/guides/CORPUS_UPGRADE.md
+++ b/docs/guides/CORPUS_UPGRADE.md
@@ -66,5 +66,15 @@ files-on-disk to a database:
 2. Register it in `upgrade/registry.py`.
 3. Add unit coverage in `tests/unit/upgrade/`.
 
-Known 2.6 → 2.7 migrations still to inventory/register: vector index rebuilds and the
-cross-episode entity canonical-map rebuild (#852).
+## Registered migrations
+
+- `0001_faiss_to_lance` — migrate an existing FAISS index into the two-tier LanceDB
+  layout (reuses embeddings). No-op when the corpus has no FAISS index.
+- `0002_two_tier_native_reindex` — build the two-tier index **natively** from corpus
+  artifacts, but only when `0001` left none (no FAISS to migrate). No-op when an index
+  already exists. Together, 0001 + 0002 guarantee a two-tier index via the cheapest
+  available path without double-building.
+
+**Not a migration:** the cross-episode entity canonical map (#852) is computed *live*
+at graph-build (`search/corpus_graph.py` → `build_entity_id_map`), not persisted —
+there is no artifact to rebuild, so it needs no migration.

--- a/docs/guides/CORPUS_UPGRADE.md
+++ b/docs/guides/CORPUS_UPGRADE.md
@@ -18,10 +18,10 @@ make upgrade-verify   CORPUS_DIR=$CORPUS_DIR  # verify applied migrations
 Or drive the CLI directly (interactive confirmation, JSON, version ceiling):
 
 ```bash
-podcast upgrade status  --corpus-dir $CORPUS_DIR [--json]
-podcast upgrade list    --corpus-dir $CORPUS_DIR
-podcast upgrade run     --corpus-dir $CORPUS_DIR [--dry-run] [--yes] [--to 2.7.0]
-podcast upgrade verify  --corpus-dir $CORPUS_DIR
+python -m podcast_scraper.cli upgrade status  --corpus-dir $CORPUS_DIR [--json]
+python -m podcast_scraper.cli upgrade list    --corpus-dir $CORPUS_DIR
+python -m podcast_scraper.cli upgrade run     --corpus-dir $CORPUS_DIR [--dry-run] [--yes] [--to 2.7.0]
+python -m podcast_scraper.cli upgrade verify  --corpus-dir $CORPUS_DIR
 ```
 
 ## Manual vs automated
@@ -32,8 +32,8 @@ podcast upgrade verify  --corpus-dir $CORPUS_DIR
   (distinct from error=1), so a boot script or CI job can gate on it:
 
   ```bash
-  podcast upgrade status --corpus-dir "$CORPUS_DIR" --json || \
-    podcast upgrade run --corpus-dir "$CORPUS_DIR" --yes
+  python -m podcast_scraper.cli upgrade status --corpus-dir "$CORPUS_DIR" --json || \
+    python -m podcast_scraper.cli upgrade run --corpus-dir "$CORPUS_DIR" --yes
   ```
 
 ## How it works

--- a/docs/rfc/RFC-090-hybrid-retrieval.md
+++ b/docs/rfc/RFC-090-hybrid-retrieval.md
@@ -233,6 +233,11 @@ class RetrievalLayer:
     def __init__(self, backend: SearchBackend):
         self.backend = backend
 
+    # SHIPPED signature (search/retrieval.py): keyword-only, intent-driven.
+    #   retrieve(self, text, embedding, *, filters=None, k=20,
+    #            intent=None, signals="hybrid", tier="all")
+    # Weights are derived internally from `intent` (signal_weights_for/tier_weights_for),
+    # not passed in. The illustrative sketch below predates that.
     def retrieve(self, text, embedding, filters=None, k=20,
                  query_type="hybrid", tier="all",
                  signal_weights=None, tier_weights=None):
@@ -402,7 +407,7 @@ index (not per-PR).
   discriminating human-judged eval, because the known-item proxy saturated. Cutover orchestration:
   #862.
 
-**Monitoring:** `make search-health` (segment/insight counts); eval metrics tracked over time;
+**Monitoring:** `LanceDBBackend.health()` (segment/insight counts; no make target yet); eval metrics tracked over time;
 log unlinked insights post-migration to inspect linking miss rate.
 
 **Success Criteria:** nDCG@10 improvement over FAISS; named-entity recall ≥ 90% @10; >20% of top-10

--- a/docs/rfc/RFC-090-hybrid-retrieval.md
+++ b/docs/rfc/RFC-090-hybrid-retrieval.md
@@ -327,6 +327,11 @@ its own. **Decision: deprecate FAISS by notice, do not remove** (Phase 3 below i
 removal waits on a discriminating, human-judged query set — which is also the labeled-query source
 RFC-092 (#860) needs, so the two unblock together.
 
+The discriminating eval is built: `scripts/eval_hybrid_judged.py` (RFC-057) runs a query set
+through both backends, emits a graded-judgment template, and scores mean nDCG@k / recall@k per
+backend once a human fills relevance. Its verdict requires a clear margin over ≥30 judged queries —
+that result is what flips FAISS removal (#858) and ML-router promotion (#860) from gated to ready.
+
 ## Key Decisions
 
 1. **Separate ranked lists, client-side RRF.**

--- a/docs/rfc/RFC-091-kg-proximity-signal.md
+++ b/docs/rfc/RFC-091-kg-proximity-signal.md
@@ -109,11 +109,13 @@ access layer and enriching the edge set.
 ```python
 # src/podcast_scraper/search/kg_proximity.py
 #
-# PREREQUISITE: requires an in-memory KG access layer exposing neighbors()/get_node().
-# No such class exists today (KG is artifact-based). See Constraints.
+# PREREQUISITE (now shipped, #849): the in-memory ``CorpusGraph`` provides
+# bfs()/get_node()/neighbors(). As built, traversal delegates to ``CorpusGraph.bfs``
+# rather than the hand-rolled queue below, and the param is named ``graph`` (keyword-
+# only). This sketch is illustrative; see ``search/kg_proximity.py`` for the real code.
 
 class KGProximitySearch:
-    def __init__(self, kg, max_hops: int = 3):
+    def __init__(self, graph, *, max_hops: int = 3):
         self.kg = kg
         self.max_hops = max_hops
 
@@ -250,7 +252,8 @@ from a small committed corpus slice with the new typed edges.
 - **Phase 1 — KG proximity**: `KGProximitySearch`, wire into `RetrievalLayer`, signal weight for
   `kg` in `SIGNAL_WEIGHTS`, tests.
 
-**Monitoring:** `make search-kg-index` builds/refreshes adjacency; track p99 traversal latency and
+**Monitoring:** adjacency is built live from the corpus graph (no pre-build target; see the
+"live BFS, no pre-computation" decision below); track p99 traversal latency and
 KG-signal contribution to nDCG.
 
 **Success Criteria:** KG signal improves nDCG@10 on entity/relational queries over hybrid-only,

--- a/docs/rfc/RFC-092-ml-query-router.md
+++ b/docs/rfc/RFC-092-ml-query-router.md
@@ -28,6 +28,10 @@ selects signal and tier weights for retrieval. The model is a small fine-tuned s
 classification head exported to ONNX for local inference. Activation is config-driven; the rules
 router stays the default until the model is trained on ≥500 labeled queries.
 
+> **As built (§4):** superseded — shipped as a scikit-learn `LogisticRegression` over MiniLM
+> embeddings persisted with joblib, **not** ONNX (no `onnxruntime`/`skl2onnx` dependency). The ONNX
+> references throughout this RFC are the original design; §4 records the deviation and rationale.
+
 **Architecture Alignment:** Implements the existing `QueryRouter` interface
 (`src/podcast_scraper/search/router.py`) so `RulesQueryRouter` and `MLQueryRouter` are
 interchangeable behind a config flag. No retrieval-layer change. ONNX local inference keeps the

--- a/docs/rfc/RFC-093-litm-context-packs.md
+++ b/docs/rfc/RFC-093-litm-context-packs.md
@@ -166,6 +166,10 @@ def build_briefing_pack(query, query_type, results, canonical_entity, max_tokens
 )
 def corpus_briefing_pack(query: str, max_tokens: int = 2000) -> CorpusBriefingPack:
     query_type = router.classify(query)
+    # NOTE: the shipped RetrievalLayer.retrieve is keyword-only and intent-driven —
+    #   retrieve(query, embed(query), intent=query_type)
+    # It derives weights from `intent` internally; query_type=/signal_weights= below
+    # are the original sketch and do not match the real signature.
     results = retrieval_layer.retrieve(
         text=query, embedding=embed(query), query_type=query_type,
         signal_weights=SIGNAL_WEIGHTS[query_type],

--- a/scripts/eval_hybrid_judged.py
+++ b/scripts/eval_hybrid_judged.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Human-judged hybrid-vs-FAISS eval (RFC-057 / wire-live follow-up C).
+
+The discriminating eval the saturated known-item proxy (eval_two_tier_retrieval.py)
+could not provide — it gates FAISS removal (#858) and ML-router promotion (#860).
+
+Two modes:
+
+  template  Run a query set through FAISS + hybrid, emit a judgment template JSONL
+            (one record per query, each candidate awaiting a `relevance` grade).
+              python scripts/eval_hybrid_judged.py template \
+                  --corpus-dir CORPUS --queries queries.txt --out template.jsonl
+
+  score     Read the human-graded JSONL back and print mean nDCG@k / recall@k per
+            backend + the verdict.
+              python scripts/eval_hybrid_judged.py score --judged template.jsonl
+
+Between the two, a human opens the template and fills `relevance` (0=irrelevant,
+1=related, 2=on-point) for the candidates that matter. The same queries carry an
+`intent` label (seeds #860 training data).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from podcast_scraper.search.faiss_store import FaissVectorStore  # noqa: E402
+from podcast_scraper.search.hybrid_search import hybrid_candidates, lance_index_dir  # noqa: E402
+from podcast_scraper.search.judged_eval import (  # noqa: E402
+    build_judgment_template,
+    JudgmentRecord,
+    score_from_judgments,
+)
+from podcast_scraper.search.router import classify_query  # noqa: E402
+
+_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def _faiss_ranks(corpus_dir: Path, k: int):
+    from podcast_scraper.providers.ml import embedding_loader
+
+    store = FaissVectorStore.load(corpus_dir / "search")
+
+    def ranks(query: str) -> Sequence[Tuple[str, str]]:
+        emb = embedding_loader.encode(
+            query, store.stats().embedding_model, return_numpy=False, allow_download=True
+        )
+        hits = store.search(list(emb), top_k=k * 4)
+        out = [(h.doc_id, str(h.metadata.get("text") or "")) for h in hits]
+        return out[:k]
+
+    return ranks
+
+
+def _hybrid_ranks(corpus_dir: Path, k: int):
+    def ranks(query: str) -> Sequence[Tuple[str, str]]:
+        rows = hybrid_candidates(corpus_dir, query, top_k=k, embedding_model=_MODEL) or []
+        return [(r.doc_id, str(r.metadata.get("text") or "")) for r in rows][:k]
+
+    return ranks
+
+
+def _cmd_template(args: argparse.Namespace) -> int:
+    corpus = Path(args.corpus_dir)
+    if not lance_index_dir(corpus).exists():
+        print(f"No LanceDB index at {lance_index_dir(corpus)} — run `make index-two-tier` first.")
+        return 1
+    queries = [
+        ln.strip()
+        for ln in Path(args.queries).read_text(encoding="utf-8").splitlines()
+        if ln.strip()
+    ]
+    records = build_judgment_template(
+        queries,
+        faiss_ranks=_faiss_ranks(corpus, args.k),
+        hybrid_ranks=_hybrid_ranks(corpus, args.k),
+        intent_of=classify_query,
+        k=args.k,
+    )
+    with Path(args.out).open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(dataclasses.asdict(rec)) + "\n")
+    print(f"Wrote {len(records)} judgment records → {args.out}. Fill `relevance`, then `score`.")
+    return 0
+
+
+def _cmd_score(args: argparse.Namespace) -> int:
+    records: List[JudgmentRecord] = []
+    for line in Path(args.judged).read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            d = json.loads(line)
+            d["relevance"] = {k: int(v) for k, v in (d.get("relevance") or {}).items()}
+            records.append(
+                JudgmentRecord(
+                    **{
+                        f: d.get(f)
+                        for f in (
+                            "query",
+                            "intent",
+                            "candidates",
+                            "faiss_ranking",
+                            "hybrid_ranking",
+                            "relevance",
+                        )
+                    }
+                )
+            )
+    scores = score_from_judgments(records, k=args.k)
+    n = int(scores["_judged_count"]["n"])
+    print(f"Judged queries with signal: {n}/{len(records)}")
+    print(f"\n  backend   nDCG@{args.k}   recall@{args.k}")
+    for b in ("faiss", "hybrid"):
+        print(f"  {b:7s}  {scores[b]['ndcg']:8.3f}  {scores[b]['recall']:8.3f}")
+    dn = scores["hybrid"]["ndcg"] - scores["faiss"]["ndcg"]
+    if dn > 0.02 and n >= 30:
+        verdict = "PASS — hybrid clearly beats FAISS (unblocks #858 removal + #860 promotion)"
+    else:
+        verdict = f"INCONCLUSIVE — need >=30 judged queries (have {n}) and a clear margin"
+    print(f"\n  Δ nDCG = {dn:+.3f}\n  VERDICT: {verdict}")
+    return 0
+
+
+def main() -> int:
+    """Dispatch the template / score subcommand."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    t = sub.add_parser("template", help="build a judgment template")
+    t.add_argument("--corpus-dir", required=True)
+    t.add_argument("--queries", required=True, help="one query per line")
+    t.add_argument("--out", default="judgment_template.jsonl")
+    t.add_argument("--k", type=int, default=10)
+    s = sub.add_parser("score", help="score graded judgments")
+    s.add_argument("--judged", required=True)
+    s.add_argument("--k", type=int, default=10)
+    args = ap.parse_args()
+    return _cmd_template(args) if args.cmd == "template" else _cmd_score(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/podcast_scraper/cli.py
+++ b/src/podcast_scraper/cli.py
@@ -3453,6 +3453,12 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         index_argv = list(argv[1:]) if len(argv) > 1 else []
         return parse_index_argv(index_argv)
 
+    if argv and len(argv) > 0 and argv[0] == "index-two-tier":
+        from .search.cli_handlers import parse_index_two_tier_argv
+
+        tt_argv = list(argv[1:]) if len(argv) > 1 else []
+        return parse_index_two_tier_argv(tt_argv)
+
     if argv and len(argv) > 0 and argv[0] == "topic-clusters":
         from .search.cli_handlers import parse_topic_clusters_argv
 
@@ -4529,6 +4535,11 @@ def main(  # noqa: C901 - main function handles multiple command paths
         from .search.cli_handlers import run_index_cli
 
         return run_index_cli(args, log)
+
+    if hasattr(args, "command") and args.command == "index-two-tier":
+        from .search.cli_handlers import run_index_two_tier_cli
+
+        return run_index_two_tier_cli(args, log)
 
     if hasattr(args, "command") and args.command == "topic-clusters":
         from .search.cli_handlers import run_topic_clusters_cli

--- a/src/podcast_scraper/search/backends/lancedb_backend.py
+++ b/src/podcast_scraper/search/backends/lancedb_backend.py
@@ -80,14 +80,23 @@ class LanceDBBackend:
 
     # --- index metadata sidecar ------------------------------------------------
 
+    # The sidecar file name is a constant under the connected db dir. Each FS sink
+    # below repeats an inline normpath + startswith barrier in its OWN function: that
+    # is the form CodeQL recognizes as a py/path-injection sanitizer for a
+    # request-derived corpus root (docs/ci/CODEQL_DISMISSALS.md Type 1) — it does not
+    # model the cross-function sanitisation done upstream at the route boundary.
+
     def write_index_meta(self, embedding_model: str) -> None:
         """Record the embedding model + dim alongside the index (queries must match)."""
         import json
         import os
 
-        os.makedirs(self.path, exist_ok=True)
+        base = os.path.normpath(self.path)
+        meta_path = os.path.normpath(os.path.join(base, self.INDEX_META_FILE))
+        if meta_path != base and not meta_path.startswith(base + os.sep):
+            return  # path escapes the index dir — refuse
         meta = {"embedding_model": embedding_model, "embed_dim": self.embed_dim}
-        with open(os.path.join(self.path, self.INDEX_META_FILE), "w", encoding="utf-8") as fh:
+        with open(meta_path, "w", encoding="utf-8") as fh:
             json.dump(meta, fh)
 
     def read_index_meta(self) -> Optional[Dict[str, Any]]:
@@ -95,7 +104,10 @@ class LanceDBBackend:
         import json
         import os
 
-        meta_path = os.path.join(self.path, self.INDEX_META_FILE)
+        base = os.path.normpath(self.path)
+        meta_path = os.path.normpath(os.path.join(base, self.INDEX_META_FILE))
+        if meta_path != base and not meta_path.startswith(base + os.sep):
+            return None
         if not os.path.isfile(meta_path):
             return None
         try:

--- a/src/podcast_scraper/search/backends/lancedb_backend.py
+++ b/src/podcast_scraper/search/backends/lancedb_backend.py
@@ -10,9 +10,10 @@ instantiating the backend requires the dependency.
 from __future__ import annotations
 
 import dataclasses
+from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
-from ...utils.path_validation import normpath_if_under_root
+from ...utils.path_validation import safe_resolve_directory
 from ..backend import InsightDocument, ScoredResult, SearchQuery, SegmentDocument, Tier
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -81,19 +82,21 @@ class LanceDBBackend:
 
     # --- index metadata sidecar ------------------------------------------------
 
-    # The sidecar is a constant file under the connected db dir. Each FS sink resolves
-    # it via ``normpath_if_under_root`` — the repo's CodeQL-recognized py/path-injection
-    # sanitizer (docs/ci/CODEQL_DISMISSALS.md Type 1) — since CodeQL does not model the
-    # cross-function sanitisation done upstream at the route boundary.
+    # The sidecar is a CONSTANT file under the connected db dir. Each FS sink resolves
+    # the dir with ``safe_resolve_directory`` (realpath — a CodeQL-recognized
+    # py/path-injection sanitizer) inline, then joins the constant name: the pattern the
+    # registry prescribes (docs/ci/CODEQL_DISMISSALS.md Type 1), since CodeQL cannot
+    # model the route's cross-function corpus-path sanitisation.
 
     def write_index_meta(self, embedding_model: str) -> None:
         """Record the embedding model + dim alongside the index (queries must match)."""
         import json
         import os
 
-        meta_path = normpath_if_under_root(os.path.join(self.path, self.INDEX_META_FILE), self.path)
-        if meta_path is None:
+        safe_dir = safe_resolve_directory(Path(self.path))
+        if safe_dir is None:
             return
+        meta_path = os.path.join(str(safe_dir), self.INDEX_META_FILE)
         meta = {"embedding_model": embedding_model, "embed_dim": self.embed_dim}
         with open(meta_path, "w", encoding="utf-8") as fh:
             json.dump(meta, fh)
@@ -103,8 +106,11 @@ class LanceDBBackend:
         import json
         import os
 
-        meta_path = normpath_if_under_root(os.path.join(self.path, self.INDEX_META_FILE), self.path)
-        if meta_path is None or not os.path.isfile(meta_path):
+        safe_dir = safe_resolve_directory(Path(self.path))
+        if safe_dir is None:
+            return None
+        meta_path = os.path.join(str(safe_dir), self.INDEX_META_FILE)
+        if not os.path.isfile(meta_path):
             return None
         try:
             with open(meta_path, encoding="utf-8") as fh:

--- a/src/podcast_scraper/search/backends/lancedb_backend.py
+++ b/src/podcast_scraper/search/backends/lancedb_backend.py
@@ -10,7 +10,7 @@ instantiating the backend requires the dependency.
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from ..backend import InsightDocument, ScoredResult, SearchQuery, SegmentDocument, Tier
 
@@ -68,12 +68,42 @@ class LanceDBBackend:
 
     TABLES = {"segment": _SEGMENT_TABLE, "insight": _INSIGHT_TABLE}
 
+    INDEX_META_FILE = "index_meta.json"
+
     def __init__(self, path: str, *, embed_dim: int = DEFAULT_EMBED_DIM) -> None:
         import lancedb
 
+        self.path = path
         self.db = lancedb.connect(path)
         self.embed_dim = embed_dim
         self._tables: Dict[str, Any] = {}  # tier -> open table (list_tables() is cached)
+
+    # --- index metadata sidecar ------------------------------------------------
+
+    def write_index_meta(self, embedding_model: str) -> None:
+        """Record the embedding model + dim alongside the index (queries must match)."""
+        import json
+        import os
+
+        os.makedirs(self.path, exist_ok=True)
+        meta = {"embedding_model": embedding_model, "embed_dim": self.embed_dim}
+        with open(os.path.join(self.path, self.INDEX_META_FILE), "w", encoding="utf-8") as fh:
+            json.dump(meta, fh)
+
+    def read_index_meta(self) -> Optional[Dict[str, Any]]:
+        """Return ``{embedding_model, embed_dim}`` written at build time, or ``None``."""
+        import json
+        import os
+
+        meta_path = os.path.join(self.path, self.INDEX_META_FILE)
+        if not os.path.isfile(meta_path):
+            return None
+        try:
+            with open(meta_path, encoding="utf-8") as fh:
+                data = json.load(fh)
+            return data if isinstance(data, dict) else None
+        except (OSError, ValueError):
+            return None
 
     # --- table lifecycle -------------------------------------------------------
 
@@ -129,7 +159,9 @@ class LanceDBBackend:
         where = self._to_sql(query.filters)
         hits: List[tuple[float, Dict[str, Any], str]] = []
         for tier in self._tables_for_tier(query.tier):
-            table = self._ensure_table(tier)
+            table = self._open_if_exists(tier)  # read must not create empty tables on disk
+            if table is None:
+                continue
             search_target = query.text if query_type == "fts" else query.embedding
             req = table.search(search_target, query_type=query_type)
             if where:
@@ -182,10 +214,12 @@ class LanceDBBackend:
         self._upsert("insight", dataclasses.asdict(doc))
 
     def delete(self, doc_id: str, tier: Tier) -> None:
-        """Delete a document by id from the given tier's table."""
-        table = self._open_if_exists(tier if tier != "all" else "segment")
-        if table is not None:
-            table.delete(f"id = '{doc_id}'")
+        """Delete a document by id; ``tier="all"`` removes from both tables."""
+        tiers = ("segment", "insight") if tier == "all" else (tier,)
+        for t in tiers:
+            table = self._open_if_exists(t)
+            if table is not None:
+                table.delete(f"id = '{doc_id}'")
 
     def health(self) -> Dict:
         """Return backend status + per-table row counts."""

--- a/src/podcast_scraper/search/backends/lancedb_backend.py
+++ b/src/podcast_scraper/search/backends/lancedb_backend.py
@@ -13,7 +13,11 @@ import dataclasses
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
-from ...utils.path_validation import safe_resolve_directory
+from ...utils.path_validation import (
+    normpath_if_under_root,
+    safe_relpath_under_corpus_root,
+    safe_resolve_directory,
+)
 from ..backend import InsightDocument, ScoredResult, SearchQuery, SegmentDocument, Tier
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -82,22 +86,29 @@ class LanceDBBackend:
 
     # --- index metadata sidecar ------------------------------------------------
 
-    # The sidecar is a CONSTANT file under the connected db dir. Each FS sink resolves
-    # the dir with ``safe_resolve_directory`` (realpath — a CodeQL-recognized
-    # py/path-injection sanitizer) inline, then joins the constant name: the pattern the
-    # registry prescribes (docs/ci/CODEQL_DISMISSALS.md Type 1), since CodeQL cannot
-    # model the route's cross-function corpus-path sanitisation.
+    # Each FS sink below resolves the sidecar inline via the recognized sanitizer chain
+    # (mirrors the proven jobs_log_path idiom): safe_resolve_directory →
+    # safe_relpath_under_corpus_root → normpath_if_under_root, then an inline
+    # ``# codeql[...]`` pragma at the sink (docs/ci/CODEQL_DISMISSALS.md Type 1; the
+    # corpus path is sanitized cross-function at the route, which CodeQL cannot model).
 
     def write_index_meta(self, embedding_model: str) -> None:
         """Record the embedding model + dim alongside the index (queries must match)."""
         import json
         import os
 
-        safe_dir = safe_resolve_directory(Path(self.path))
-        if safe_dir is None:
+        root_res = safe_resolve_directory(Path(self.path))
+        if root_res is None:
             return
-        meta_path = os.path.join(str(safe_dir), self.INDEX_META_FILE)
+        root_s = os.path.normpath(str(root_res))
+        verified = safe_relpath_under_corpus_root(root_res, self.INDEX_META_FILE)
+        if not verified:
+            return
+        meta_path = normpath_if_under_root(os.path.normpath(verified), root_s)
+        if not meta_path:
+            return
         meta = {"embedding_model": embedding_model, "embed_dim": self.embed_dim}
+        # codeql[py/path-injection] -- meta_path via normpath_if_under_root (Type 1).
         with open(meta_path, "w", encoding="utf-8") as fh:
             json.dump(meta, fh)
 
@@ -106,13 +117,21 @@ class LanceDBBackend:
         import json
         import os
 
-        safe_dir = safe_resolve_directory(Path(self.path))
-        if safe_dir is None:
+        root_res = safe_resolve_directory(Path(self.path))
+        if root_res is None:
             return None
-        meta_path = os.path.join(str(safe_dir), self.INDEX_META_FILE)
+        root_s = os.path.normpath(str(root_res))
+        verified = safe_relpath_under_corpus_root(root_res, self.INDEX_META_FILE)
+        if not verified:
+            return None
+        meta_path = normpath_if_under_root(os.path.normpath(verified), root_s)
+        if not meta_path:
+            return None
+        # codeql[py/path-injection] -- meta_path via normpath_if_under_root (Type 1).
         if not os.path.isfile(meta_path):
             return None
         try:
+            # codeql[py/path-injection] -- meta_path via normpath_if_under_root (Type 1).
             with open(meta_path, encoding="utf-8") as fh:
                 data = json.load(fh)
             return data if isinstance(data, dict) else None

--- a/src/podcast_scraper/search/backends/lancedb_backend.py
+++ b/src/podcast_scraper/search/backends/lancedb_backend.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
+from ...utils.path_validation import normpath_if_under_root
 from ..backend import InsightDocument, ScoredResult, SearchQuery, SegmentDocument, Tier
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -80,21 +81,19 @@ class LanceDBBackend:
 
     # --- index metadata sidecar ------------------------------------------------
 
-    # The sidecar file name is a constant under the connected db dir. Each FS sink
-    # below repeats an inline normpath + startswith barrier in its OWN function: that
-    # is the form CodeQL recognizes as a py/path-injection sanitizer for a
-    # request-derived corpus root (docs/ci/CODEQL_DISMISSALS.md Type 1) — it does not
-    # model the cross-function sanitisation done upstream at the route boundary.
+    # The sidecar is a constant file under the connected db dir. Each FS sink resolves
+    # it via ``normpath_if_under_root`` — the repo's CodeQL-recognized py/path-injection
+    # sanitizer (docs/ci/CODEQL_DISMISSALS.md Type 1) — since CodeQL does not model the
+    # cross-function sanitisation done upstream at the route boundary.
 
     def write_index_meta(self, embedding_model: str) -> None:
         """Record the embedding model + dim alongside the index (queries must match)."""
         import json
         import os
 
-        base = os.path.normpath(self.path)
-        meta_path = os.path.normpath(os.path.join(base, self.INDEX_META_FILE))
-        if meta_path != base and not meta_path.startswith(base + os.sep):
-            return  # path escapes the index dir — refuse
+        meta_path = normpath_if_under_root(os.path.join(self.path, self.INDEX_META_FILE), self.path)
+        if meta_path is None:
+            return
         meta = {"embedding_model": embedding_model, "embed_dim": self.embed_dim}
         with open(meta_path, "w", encoding="utf-8") as fh:
             json.dump(meta, fh)
@@ -104,11 +103,8 @@ class LanceDBBackend:
         import json
         import os
 
-        base = os.path.normpath(self.path)
-        meta_path = os.path.normpath(os.path.join(base, self.INDEX_META_FILE))
-        if meta_path != base and not meta_path.startswith(base + os.sep):
-            return None
-        if not os.path.isfile(meta_path):
+        meta_path = normpath_if_under_root(os.path.join(self.path, self.INDEX_META_FILE), self.path)
+        if meta_path is None or not os.path.isfile(meta_path):
             return None
         try:
             with open(meta_path, encoding="utf-8") as fh:

--- a/src/podcast_scraper/search/cli_handlers.py
+++ b/src/podcast_scraper/search/cli_handlers.py
@@ -1343,3 +1343,49 @@ def run_topic_insights_cli(args: Namespace, logger: logging.Logger) -> int:
             print()
 
     return EXIT_SUCCESS
+
+
+def parse_index_two_tier_argv(argv: Sequence[str]) -> Namespace:
+    """Parse ``index-two-tier`` args (RFC-090 from-corpus two-tier indexer, follow-up B)."""
+    parser = argparse.ArgumentParser(prog="podcast_scraper index-two-tier")
+    parser.add_argument("--output-dir", required=True, help="Corpus root (parent of feeds/).")
+    parser.add_argument(
+        "--lance-path",
+        default=None,
+        help="LanceDB index dir (default: <output-dir>/search/lance_index).",
+    )
+    parser.add_argument("--embedding-model", default=None, help="Override embedding model id.")
+    parser.add_argument("--limit-episodes", type=int, default=None, help="Cap episodes (smoke).")
+    parser.add_argument(
+        "--allow-download", action="store_true", help="Allow embedding-model download."
+    )
+    args = parser.parse_args(list(argv))
+    args.command = "index-two-tier"
+    return args
+
+
+def run_index_two_tier_cli(args: Namespace, logger: logging.Logger) -> int:
+    """Build the two-tier LanceDB index from corpus artifacts (RFC-090 Phase 2 / B)."""
+    output_dir = getattr(args, "output_dir", None)
+    if not output_dir:
+        logger.error("index-two-tier: --output-dir is required")
+        return EXIT_INVALID_ARGS
+
+    from podcast_scraper.search.two_tier_indexer import build_two_tier_index, DEFAULT_MODEL
+
+    lance_path = getattr(args, "lance_path", None) or str(
+        Path(output_dir) / "search" / "lance_index"
+    )
+    model_id = getattr(args, "embedding_model", None) or DEFAULT_MODEL
+    stats = build_two_tier_index(
+        output_dir,
+        lance_path,
+        model_id=model_id,
+        limit_episodes=getattr(args, "limit_episodes", None),
+        allow_download=bool(getattr(args, "allow_download", False)),
+    )
+    print(
+        f"Two-tier index built at {lance_path}: "
+        f"episodes={stats.episodes} segments={stats.segments} insights={stats.insights}"
+    )
+    return EXIT_SUCCESS

--- a/src/podcast_scraper/search/corpus_search.py
+++ b/src/podcast_scraper/search/corpus_search.py
@@ -21,6 +21,7 @@ from podcast_scraper.search.cli_handlers import (
     merged_episode_gi_paths,
 )
 from podcast_scraper.search.faiss_store import FaissVectorStore, VECTORS_FILE
+from podcast_scraper.search.hybrid_search import hybrid_candidates, hybrid_search_enabled
 from podcast_scraper.search.protocol import SearchResult
 from podcast_scraper.search.topic_clusters import load_topic_cluster_enrichment_map
 from podcast_scraper.search.transcript_chunk_lift import (
@@ -203,6 +204,39 @@ def run_corpus_search(
     if not q:
         return CorpusSearchOutcome(error="empty_query")
 
+    top_k = max(1, min(int(top_k), 100))
+    types_norm: Optional[List[str]] = None
+    if doc_types:
+        types_norm = [x.strip().lower() for x in doc_types if isinstance(x, str) and x.strip()]
+        if not types_norm:
+            types_norm = None
+
+    # Hybrid path (RFC-090 Phase 2): opt-in via serving.hybrid_enabled. Returns None to
+    # fall back to FAISS (flag off, no LanceDB index, or embed failure), so this can
+    # never regress the FAISS path — only override it when explicitly enabled + ready.
+    if hybrid_search_enabled():
+        candidates = hybrid_candidates(
+            output_dir,
+            q,
+            top_k=top_k,
+            doc_types=doc_types,
+            embedding_model=embedding_model,
+        )
+        if candidates is not None:
+            logger.info("corpus_search: hybrid path (%d candidates)", len(candidates))
+            return _filter_and_enrich(
+                candidates,
+                output_dir,
+                types_norm=types_norm,
+                feed=feed,
+                since=since,
+                speaker=speaker,
+                grounded_only=grounded_only,
+                top_k=top_k,
+                dedupe_kg_surfaces=dedupe_kg_surfaces,
+                collect_cap=len(candidates),
+            )
+
     index_dir = _resolve_index_dir(output_dir, index_path)
     if not (index_dir / VECTORS_FILE).is_file():
         return CorpusSearchOutcome(error="no_index", detail=str(index_dir))
@@ -244,17 +278,10 @@ def run_corpus_search(
         return CorpusSearchOutcome(error="embed_failed", detail=str(exc))
     embed_sec = time.perf_counter() - t_embed0
 
-    types_norm: Optional[List[str]] = None
-    if doc_types:
-        types_norm = [x.strip().lower() for x in doc_types if isinstance(x, str) and x.strip()]
-        if not types_norm:
-            types_norm = None
-
     faiss_filters: Optional[Dict[str, Any]] = None
     if types_norm and len(types_norm) == 1:
         faiss_filters = {"doc_type": types_norm[0]}
 
-    top_k = max(1, min(int(top_k), 100))
     fetch_k = min(max(top_k * 25, top_k), max(store.ntotal, 1))
 
     t_search0 = time.perf_counter()
@@ -273,11 +300,42 @@ def run_corpus_search(
         fetch_k,
     )
 
+    return _filter_and_enrich(
+        hits,
+        output_dir,
+        types_norm=types_norm,
+        feed=feed,
+        since=since,
+        speaker=speaker,
+        grounded_only=grounded_only,
+        top_k=top_k,
+        dedupe_kg_surfaces=dedupe_kg_surfaces,
+        collect_cap=fetch_k if dedupe_kg_surfaces else top_k,
+    )
+
+
+def _filter_and_enrich(
+    hits: Sequence[SearchResult],
+    output_dir: Path,
+    *,
+    types_norm: Optional[List[str]],
+    feed: Optional[str],
+    since: Optional[str],
+    speaker: Optional[str],
+    grounded_only: bool,
+    top_k: int,
+    dedupe_kg_surfaces: bool,
+    collect_cap: int,
+) -> CorpusSearchOutcome:
+    """Apply metadata filters + enrich/lift/dedupe a candidate list (backend-agnostic).
+
+    Shared by the FAISS and hybrid (#RFC-090 Phase 2) retrieval paths so both return
+    the identical enriched response shape.
+    """
     since_dt = _parse_since(since) if isinstance(since, str) and since.strip() else None
     gi_cache = merged_episode_gi_paths(output_dir)
     rel_by_scope = _metadata_relpath_by_scope_from_corpus(output_dir)
     filtered: List[SearchResult] = []
-    collect_cap = fetch_k if dedupe_kg_surfaces else top_k
     for h in hits:
         dt = h.metadata.get("doc_type")
         if types_norm and len(types_norm) > 1:

--- a/src/podcast_scraper/search/hybrid_search.py
+++ b/src/podcast_scraper/search/hybrid_search.py
@@ -25,7 +25,11 @@ from typing import Any, cast, Dict, List, Optional, Sequence, TYPE_CHECKING
 import yaml
 
 from ..providers.ml import embedding_loader
-from ..utils.path_validation import safe_resolve_directory
+from ..utils.path_validation import (
+    normpath_if_under_root,
+    safe_relpath_under_corpus_root,
+    safe_resolve_directory,
+)
 from .backend import CompoundResult, ScoredResult, Tier
 from .protocol import SearchResult
 
@@ -150,13 +154,21 @@ def hybrid_candidates(
     missing LanceDB index or a query-embedding failure. An empty list means the index
     was searched and genuinely had no hits.
     """
-    # py/path-injection sanitizer (CodeQL Type 1, docs/ci/CODEQL_DISMISSALS.md): resolve
-    # the corpus dir via safe_resolve_directory (realpath — CodeQL-recognized) inline,
-    # then join the CONSTANT index subpath, before any filesystem access.
-    safe_corpus = safe_resolve_directory(Path(output_dir))
-    if safe_corpus is None:
+    # py/path-injection sanitizer chain (CodeQL Type 1, docs/ci/CODEQL_DISMISSALS.md;
+    # mirrors jobs_log_path): resolve the corpus dir, confine the CONSTANT index subpath
+    # under it, then pragma the sink. The corpus path is sanitized cross-function at the
+    # route, which CodeQL cannot model.
+    root_res = safe_resolve_directory(Path(output_dir))
+    if root_res is None:
         return None
-    index_dir_str = os.path.join(str(safe_corpus), "search", "lance_index")
+    root_s = os.path.normpath(str(root_res))
+    verified = safe_relpath_under_corpus_root(root_res, "search/lance_index")
+    if not verified:
+        return None
+    index_dir_str = normpath_if_under_root(os.path.normpath(verified), root_s)
+    if not index_dir_str:
+        return None
+    # codeql[py/path-injection] -- index_dir_str via normpath_if_under_root (Type 1).
     if not os.path.isdir(index_dir_str):
         return None
     index_dir = Path(index_dir_str)

--- a/src/podcast_scraper/search/hybrid_search.py
+++ b/src/podcast_scraper/search/hybrid_search.py
@@ -110,10 +110,23 @@ def hybrid_candidates(
     if not index_dir.exists():
         return None
 
+    try:
+        from .backends.lancedb_backend import LanceDBBackend
+        from .retrieval import RetrievalLayer
+
+        backend = LanceDBBackend(str(index_dir))
+    except Exception as exc:  # noqa: BLE001 - cannot open index → FAISS fallback
+        logger.warning("hybrid_search open failed (%s); falling back to FAISS", exc)
+        return None
+
+    # Embed the query in the SAME space the index was built in: explicit override >
+    # the model recorded at build time > MiniLM default. Mismatched models silently
+    # return wrong results, so the index's own model is the source of truth.
+    meta = backend.read_index_meta() or {}
     model_id = (
         embedding_model.strip()
         if isinstance(embedding_model, str) and embedding_model.strip()
-        else _DEFAULT_MODEL
+        else str(meta.get("embedding_model") or _DEFAULT_MODEL)
     )
     try:
         qvec = embedding_loader.encode(query, model_id, return_numpy=False, allow_download=False)
@@ -124,11 +137,18 @@ def hybrid_candidates(
         return None
     qemb = cast(List[float], qvec)
 
-    try:
-        from .backends.lancedb_backend import LanceDBBackend
-        from .retrieval import RetrievalLayer
+    expected_dim = meta.get("embed_dim")
+    if isinstance(expected_dim, int) and len(qemb) != expected_dim:
+        logger.warning(
+            "hybrid_search dim mismatch (query %d != index %d for model %s); FAISS fallback",
+            len(qemb),
+            expected_dim,
+            model_id,
+        )
+        return None
 
-        layer = RetrievalLayer(LanceDBBackend(str(index_dir)))
+    try:
+        layer = RetrievalLayer(backend)
         fetch_k = max(top_k * fetch_multiplier, top_k)
         results = layer.retrieve(query, qemb, k=fetch_k, tier=_tier_for(doc_types))
     except Exception as exc:  # noqa: BLE001 - backend/index error → FAISS fallback

--- a/src/podcast_scraper/search/hybrid_search.py
+++ b/src/podcast_scraper/search/hybrid_search.py
@@ -1,0 +1,141 @@
+"""Hybrid retrieval bridge for the live search path (RFC-090 Phase 2 / wire-live).
+
+Connects the dormant two-tier stack (``RetrievalLayer`` over ``LanceDBBackend``,
+#855-861) to the serving path (``corpus_search.run_corpus_search``) without changing
+the response contract: hybrid candidates are mapped to the same ``SearchResult``
+shape the FAISS path produces, then run through the *identical* filter/enrich/lift
+pipeline.
+
+**Opt-in and non-regressing.** It activates only when ``serving.hybrid_enabled`` is
+true in ``config/search.yaml`` (default false) *and* a LanceDB index exists for the
+corpus. Any miss — flag off, no index, embed failure — returns ``None`` so the caller
+falls back to FAISS. This matters because the two-tier index covers only the
+*insight* and *segment* (transcript) tiers; kg_entity / kg_topic / quote / summary
+still live only in FAISS, so flipping hybrid on narrows coverage to those two tiers
+by design. Full-coverage hybrid (kg/quote tiers in LanceDB) is a follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import cast, List, Optional, Sequence
+
+import yaml
+
+from ..providers.ml import embedding_loader
+from .backend import CompoundResult, ScoredResult, Tier
+from .protocol import SearchResult
+
+logger = logging.getLogger(__name__)
+
+_SEARCH_CONFIG = Path("config/search.yaml")
+_DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def hybrid_search_enabled() -> bool:
+    """True when ``serving.hybrid_enabled`` is set in ``config/search.yaml``."""
+    try:
+        doc = yaml.safe_load(_SEARCH_CONFIG.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return False
+    serving = doc.get("serving") if isinstance(doc, dict) else None
+    return bool(isinstance(serving, dict) and serving.get("hybrid_enabled"))
+
+
+def lance_index_dir(output_dir: Path) -> Path:
+    """Per-corpus LanceDB index location (co-located with the corpus, #858/#862)."""
+    return Path(output_dir) / "search" / "lance_index"
+
+
+def _tier_for(doc_types: Optional[Sequence[str]]) -> Tier:
+    """Map requested doc types to a two-tier scope (insight | segment | all)."""
+    if not doc_types:
+        return "all"
+    wanted = {t.strip().lower() for t in doc_types if isinstance(t, str) and t.strip()}
+    if wanted <= {"insight"}:
+        return "insight"
+    if wanted <= {"transcript", "segment"}:
+        return "segment"
+    return "all"
+
+
+def _doc_type_for_tier(source_tier: str) -> str:
+    # Segments are transcript chunks in the FAISS vocabulary the enrich/lift expects.
+    return "insight" if source_tier == "insight" else "transcript"
+
+
+def _to_search_result(result: ScoredResult) -> SearchResult:
+    payload = dict(result.payload or {})
+    metadata = {
+        "doc_type": _doc_type_for_tier(result.source_tier),
+        "text": payload.get("text", ""),
+        "episode_id": payload.get("episode_id", ""),
+        "feed_id": payload.get("show_id", ""),
+    }
+    # Carry segment timestamps (seconds → ms) so transcript lift can locate the span.
+    if "start_time" in payload:
+        metadata["timestamp_start_ms"] = int(float(payload.get("start_time") or 0.0) * 1000)
+        metadata["timestamp_end_ms"] = int(float(payload.get("end_time") or 0.0) * 1000)
+    if payload.get("speaker_id"):
+        metadata["speaker_id"] = payload["speaker_id"]
+    return SearchResult(doc_id=str(result.doc_id), score=float(result.score), metadata=metadata)
+
+
+def _flatten(result: object) -> List[ScoredResult]:
+    # A compound contributes both its insight and segment as standalone rows.
+    if isinstance(result, CompoundResult):
+        return [result.insight, result.segment]
+    if isinstance(result, ScoredResult):
+        return [result]
+    return []
+
+
+def hybrid_candidates(
+    output_dir: Path,
+    query: str,
+    *,
+    top_k: int,
+    doc_types: Optional[Sequence[str]] = None,
+    embedding_model: Optional[str] = None,
+    fetch_multiplier: int = 25,
+) -> Optional[List[SearchResult]]:
+    """Hybrid candidates as ``SearchResult`` rows, or ``None`` to fall back to FAISS.
+
+    Returns ``None`` (not an empty list) on any condition that should defer to FAISS:
+    missing LanceDB index or a query-embedding failure. An empty list means the index
+    was searched and genuinely had no hits.
+    """
+    index_dir = lance_index_dir(output_dir)
+    if not index_dir.exists():
+        return None
+
+    model_id = (
+        embedding_model.strip()
+        if isinstance(embedding_model, str) and embedding_model.strip()
+        else _DEFAULT_MODEL
+    )
+    try:
+        qvec = embedding_loader.encode(query, model_id, return_numpy=False, allow_download=False)
+    except Exception as exc:  # noqa: BLE001 - any embed failure → FAISS fallback
+        logger.warning("hybrid_search embed failed (%s); falling back to FAISS", exc)
+        return None
+    if not (isinstance(qvec, list) and qvec and isinstance(qvec[0], float)):
+        return None
+    qemb = cast(List[float], qvec)
+
+    try:
+        from .backends.lancedb_backend import LanceDBBackend
+        from .retrieval import RetrievalLayer
+
+        layer = RetrievalLayer(LanceDBBackend(str(index_dir)))
+        fetch_k = max(top_k * fetch_multiplier, top_k)
+        results = layer.retrieve(query, qemb, k=fetch_k, tier=_tier_for(doc_types))
+    except Exception as exc:  # noqa: BLE001 - backend/index error → FAISS fallback
+        logger.warning("hybrid_search retrieve failed (%s); falling back to FAISS", exc)
+        return None
+
+    rows: List[SearchResult] = []
+    for result in results:
+        rows.extend(_to_search_result(r) for r in _flatten(result))
+    return rows

--- a/src/podcast_scraper/search/hybrid_search.py
+++ b/src/podcast_scraper/search/hybrid_search.py
@@ -18,8 +18,9 @@ by design. Full-coverage hybrid (kg/quote tiers in LanceDB) is a follow-up.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
-from typing import cast, List, Optional, Sequence
+from typing import Any, cast, Dict, List, Optional, Sequence, TYPE_CHECKING
 
 import yaml
 
@@ -27,20 +28,62 @@ from ..providers.ml import embedding_loader
 from .backend import CompoundResult, ScoredResult, Tier
 from .protocol import SearchResult
 
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .query_router import QueryRouter
+
 logger = logging.getLogger(__name__)
 
-_SEARCH_CONFIG = Path("config/search.yaml")
 _DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _search_config_path() -> Optional[Path]:
+    """Locate ``search.yaml`` robustly (env override > CWD > repo-root anchor).
+
+    A bare ``Path("config/search.yaml")`` is CWD-relative and silently missing in a
+    deployed container (audit H1). Candidates cover dev (CWD / editable source tree)
+    and prod (the file shipped next to the working dir).
+    """
+    env = os.getenv("PODCAST_SEARCH_CONFIG")
+    candidates = [Path(env)] if env else []
+    candidates.append(Path("config/search.yaml"))
+    candidates.append(Path(__file__).resolve().parents[3] / "config" / "search.yaml")
+    return next((p for p in candidates if p.is_file()), None)
+
+
+def _load_search_config() -> Dict[str, Any]:
+    """Parse ``search.yaml`` if found, else ``{}`` (never raises)."""
+    path = _search_config_path()
+    if path is None:
+        return {}
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return {}
+    return doc if isinstance(doc, dict) else {}
 
 
 def hybrid_search_enabled() -> bool:
-    """True when ``serving.hybrid_enabled`` is set in ``config/search.yaml``."""
-    try:
-        doc = yaml.safe_load(_SEARCH_CONFIG.read_text(encoding="utf-8")) or {}
-    except (OSError, yaml.YAMLError):
-        return False
-    serving = doc.get("serving") if isinstance(doc, dict) else None
+    """True when hybrid is enabled via env (``PODCAST_HYBRID_SEARCH``) or config.
+
+    The env override exists so an operator can enable hybrid in a container where the
+    config file may not be on the CWD path (audit H1).
+    """
+    env = os.getenv("PODCAST_HYBRID_SEARCH")
+    if env is not None:
+        return env.strip().lower() in _TRUTHY
+    serving = _load_search_config().get("serving")
     return bool(isinstance(serving, dict) and serving.get("hybrid_enabled"))
+
+
+def _serving_router() -> "Optional[QueryRouter]":
+    """Build the configured query router (RFC-092 #860), or None to use rules default."""
+    cfg = _load_search_config().get("router")
+    if not isinstance(cfg, dict):
+        return None
+    from .query_router import get_query_router
+
+    return get_query_router(str(cfg.get("mode") or "rules"), model_path=cfg.get("model_path"))
 
 
 def lance_index_dir(output_dir: Path) -> Path:
@@ -148,7 +191,7 @@ def hybrid_candidates(
         return None
 
     try:
-        layer = RetrievalLayer(backend)
+        layer = RetrievalLayer(backend, router=_serving_router())
         fetch_k = max(top_k * fetch_multiplier, top_k)
         results = layer.retrieve(query, qemb, k=fetch_k, tier=_tier_for(doc_types))
     except Exception as exc:  # noqa: BLE001 - backend/index error → FAISS fallback

--- a/src/podcast_scraper/search/hybrid_search.py
+++ b/src/podcast_scraper/search/hybrid_search.py
@@ -25,7 +25,7 @@ from typing import Any, cast, Dict, List, Optional, Sequence, TYPE_CHECKING
 import yaml
 
 from ..providers.ml import embedding_loader
-from ..utils.path_validation import normpath_if_under_root
+from ..utils.path_validation import safe_resolve_directory
 from .backend import CompoundResult, ScoredResult, Tier
 from .protocol import SearchResult
 
@@ -150,13 +150,16 @@ def hybrid_candidates(
     missing LanceDB index or a query-embedding failure. An empty list means the index
     was searched and genuinely had no hits.
     """
-    # py/path-injection sanitizer (CodeQL Type 1, docs/ci/CODEQL_DISMISSALS.md): the
-    # index dir is constant segments under the route-sanitized corpus dir; resolve it
-    # through the recognized helper before any filesystem access.
-    safe_index_dir = normpath_if_under_root(str(lance_index_dir(output_dir)), str(output_dir))
-    if safe_index_dir is None or not os.path.isdir(safe_index_dir):
+    # py/path-injection sanitizer (CodeQL Type 1, docs/ci/CODEQL_DISMISSALS.md): resolve
+    # the corpus dir via safe_resolve_directory (realpath — CodeQL-recognized) inline,
+    # then join the CONSTANT index subpath, before any filesystem access.
+    safe_corpus = safe_resolve_directory(Path(output_dir))
+    if safe_corpus is None:
         return None
-    index_dir = Path(safe_index_dir)
+    index_dir_str = os.path.join(str(safe_corpus), "search", "lance_index")
+    if not os.path.isdir(index_dir_str):
+        return None
+    index_dir = Path(index_dir_str)
 
     try:
         from .backends.lancedb_backend import LanceDBBackend

--- a/src/podcast_scraper/search/hybrid_search.py
+++ b/src/podcast_scraper/search/hybrid_search.py
@@ -150,6 +150,12 @@ def hybrid_candidates(
     was searched and genuinely had no hits.
     """
     index_dir = lance_index_dir(output_dir)
+    # Inline py/path-injection barrier (CodeQL Type 1, docs/ci/CODEQL_DISMISSALS.md):
+    # the index dir is constant segments under the route-sanitized corpus dir; confirm
+    # it doesn't escape before any filesystem access.
+    _root = os.path.normpath(str(output_dir))
+    if not os.path.normpath(str(index_dir)).startswith(_root):
+        return None
     if not index_dir.exists():
         return None
 

--- a/src/podcast_scraper/search/hybrid_search.py
+++ b/src/podcast_scraper/search/hybrid_search.py
@@ -25,6 +25,7 @@ from typing import Any, cast, Dict, List, Optional, Sequence, TYPE_CHECKING
 import yaml
 
 from ..providers.ml import embedding_loader
+from ..utils.path_validation import normpath_if_under_root
 from .backend import CompoundResult, ScoredResult, Tier
 from .protocol import SearchResult
 
@@ -149,15 +150,13 @@ def hybrid_candidates(
     missing LanceDB index or a query-embedding failure. An empty list means the index
     was searched and genuinely had no hits.
     """
-    index_dir = lance_index_dir(output_dir)
-    # Inline py/path-injection barrier (CodeQL Type 1, docs/ci/CODEQL_DISMISSALS.md):
-    # the index dir is constant segments under the route-sanitized corpus dir; confirm
-    # it doesn't escape before any filesystem access.
-    _root = os.path.normpath(str(output_dir))
-    if not os.path.normpath(str(index_dir)).startswith(_root):
+    # py/path-injection sanitizer (CodeQL Type 1, docs/ci/CODEQL_DISMISSALS.md): the
+    # index dir is constant segments under the route-sanitized corpus dir; resolve it
+    # through the recognized helper before any filesystem access.
+    safe_index_dir = normpath_if_under_root(str(lance_index_dir(output_dir)), str(output_dir))
+    if safe_index_dir is None or not os.path.isdir(safe_index_dir):
         return None
-    if not index_dir.exists():
-        return None
+    index_dir = Path(safe_index_dir)
 
     try:
         from .backends.lancedb_backend import LanceDBBackend

--- a/src/podcast_scraper/search/judged_eval.py
+++ b/src/podcast_scraper/search/judged_eval.py
@@ -1,0 +1,125 @@
+"""Human-judged hybrid-vs-FAISS eval harness (RFC-057 / wire-live follow-up C).
+
+The shared unblocker for #858 (FAISS removal) and #860 (ML-router promotion). The
+Stage-4 known-item proxy (``scripts/eval_two_tier_retrieval.py``) *saturated* — it
+confirmed parity but could not discriminate, so it cannot justify removing FAISS or
+promoting the ML router. This harness produces a **discriminating, graded** eval:
+
+1. ``build_judgment_template`` runs a real query set through both backends, unions
+   the candidates, and emits a per-query record with each backend's ranking — ready
+   for a human to fill in graded relevance (0/1/2…) per candidate.
+2. ``score_from_judgments`` reads the filled-in judgments back and computes mean
+   nDCG@k + recall@k per backend — the discriminating number the gates need.
+
+The human grading step is the gate; everything around it (run both backends → merge
+→ template → score) is here and tested. The same query set, once intent-labeled,
+also seeds #860's real training data — so judging once unblocks both.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Sequence, Tuple
+
+# (doc_id, text) pairs in rank order, best first.
+RankFn = Callable[[str], Sequence[Tuple[str, str]]]
+
+
+@dataclass
+class JudgmentRecord:
+    """One query's candidates + each backend's ranking, awaiting graded relevance."""
+
+    query: str
+    intent: str
+    candidates: List[Dict] = field(default_factory=list)  # {doc_id, text, faiss_rank, hybrid_rank}
+    faiss_ranking: List[str] = field(default_factory=list)  # doc_ids, best first
+    hybrid_ranking: List[str] = field(default_factory=list)
+    relevance: Dict[str, int] = field(default_factory=dict)  # doc_id -> grade (human-filled)
+
+
+def build_judgment_template(
+    queries: Sequence[str],
+    *,
+    faiss_ranks: RankFn,
+    hybrid_ranks: RankFn,
+    intent_of: Callable[[str], str],
+    k: int = 10,
+) -> List[JudgmentRecord]:
+    """Run *queries* through both backends and build per-query judgment records.
+
+    ``faiss_ranks`` / ``hybrid_ranks`` return ranked ``(doc_id, text)`` for a query;
+    ``intent_of`` labels the query (seeds #860). Candidates from both backends are
+    unioned with each backend's 1-based rank (or ``None`` if a backend missed it).
+    """
+    records: List[JudgmentRecord] = []
+    for query in queries:
+        faiss_list = list(faiss_ranks(query))[:k]
+        hybrid_list = list(hybrid_ranks(query))[:k]
+        faiss_rank = {doc_id: i + 1 for i, (doc_id, _) in enumerate(faiss_list)}
+        hybrid_rank = {doc_id: i + 1 for i, (doc_id, _) in enumerate(hybrid_list)}
+        texts = {doc_id: text for doc_id, text in list(faiss_list) + list(hybrid_list)}
+
+        candidates = [
+            {
+                "doc_id": doc_id,
+                "text": texts.get(doc_id, ""),
+                "faiss_rank": faiss_rank.get(doc_id),
+                "hybrid_rank": hybrid_rank.get(doc_id),
+            }
+            for doc_id in sorted(
+                texts, key=lambda d: (faiss_rank.get(d, 999), hybrid_rank.get(d, 999))
+            )
+        ]
+        records.append(
+            JudgmentRecord(
+                query=query,
+                intent=intent_of(query),
+                candidates=candidates,
+                faiss_ranking=[doc_id for doc_id, _ in faiss_list],
+                hybrid_ranking=[doc_id for doc_id, _ in hybrid_list],
+            )
+        )
+    return records
+
+
+def _dcg(grades: Sequence[float]) -> float:
+    return sum(g / math.log2(i + 2) for i, g in enumerate(grades))
+
+
+def _ndcg_at(ranking: Sequence[str], relevance: Dict[str, int], k: int) -> float:
+    grades = [relevance.get(doc_id, 0) for doc_id in ranking[:k]]
+    ideal = sorted(relevance.values(), reverse=True)[:k]
+    idcg = _dcg(ideal)
+    return _dcg(grades) / idcg if idcg > 0 else 0.0
+
+
+def _recall_at(ranking: Sequence[str], relevance: Dict[str, int], k: int) -> float:
+    relevant = {doc_id for doc_id, g in relevance.items() if g > 0}
+    if not relevant:
+        return 0.0
+    hit = sum(1 for doc_id in ranking[:k] if doc_id in relevant)
+    return hit / len(relevant)
+
+
+def score_from_judgments(
+    records: Sequence[JudgmentRecord], *, k: int = 10
+) -> Dict[str, Dict[str, float]]:
+    """Mean nDCG@k + recall@k per backend over judged *records*.
+
+    Records with no positive grade are skipped (no signal). Returns
+    ``{"faiss": {...}, "hybrid": {...}}``; compare to gate FAISS removal / ML promotion.
+    """
+    agg = {b: {"ndcg": 0.0, "recall": 0.0} for b in ("faiss", "hybrid")}
+    judged = [r for r in records if any(g > 0 for g in r.relevance.values())]
+    n = len(judged)
+    for rec in judged:
+        agg["faiss"]["ndcg"] += _ndcg_at(rec.faiss_ranking, rec.relevance, k)
+        agg["faiss"]["recall"] += _recall_at(rec.faiss_ranking, rec.relevance, k)
+        agg["hybrid"]["ndcg"] += _ndcg_at(rec.hybrid_ranking, rec.relevance, k)
+        agg["hybrid"]["recall"] += _recall_at(rec.hybrid_ranking, rec.relevance, k)
+    for backend in agg:
+        for metric in agg[backend]:
+            agg[backend][metric] /= max(n, 1)
+    agg["_judged_count"] = {"n": float(n)}  # for transparency / no-silent-truncation
+    return agg

--- a/src/podcast_scraper/search/migration.py
+++ b/src/podcast_scraper/search/migration.py
@@ -111,5 +111,8 @@ def migrate_faiss_to_lance(
         else:
             stats.skipped += 1
 
-    backend.create_indices()
+    # Record the model so the query path embeds in the same space (else silent mismatch).
+    backend.write_index_meta(store.embedding_model)
+    if stats.segments or stats.insights:
+        backend.create_indices()
     return stats

--- a/src/podcast_scraper/search/query_router.py
+++ b/src/podcast_scraper/search/query_router.py
@@ -87,7 +87,9 @@ class MLQueryRouter:
 
         from ..providers.ml.embedding_loader import encode
 
-        arr = np.asarray(encode(text, "minilm-l6", allow_download=True), dtype=float).ravel()
+        # Inference-time embedding on the serving path: do not download (the model is
+        # preloaded in prod), matching hybrid_search's query-embed policy.
+        arr = np.asarray(encode(text, "minilm-l6", allow_download=False), dtype=float).ravel()
         return [float(x) for x in arr.tolist()]
 
     def classify(self, text: str) -> str:

--- a/src/podcast_scraper/search/two_tier_indexer.py
+++ b/src/podcast_scraper/search/two_tier_indexer.py
@@ -1,0 +1,120 @@
+"""From-corpus two-tier indexer (RFC-090 / wire-live follow-up B).
+
+Builds the two-tier LanceDB index (#855) directly from corpus artifacts, so a
+**fresh** corpus becomes hybrid-searchable without first having a FAISS index to
+migrate (#858). It reuses the proven FAISS-indexer extraction —
+``discover_metadata_files`` → ``_collect_docs_for_episode`` — which already yields
+insight rows and timestamped transcript chunks, then re-embeds the text and upserts
+into the ``insight`` (Tier 2) and ``segment`` (Tier 1) tables.
+
+Relationship to the migration (#858): the migration is the fast path for a corpus
+that already has FAISS (it reuses those embeddings verbatim); this indexer is the
+native path for corpora that don't. Both produce the same two-tier layout the live
+hybrid search (RFC-090 Phase 2) reads. Insight↔segment linking
+(``linked_insight_ids`` for compound results) is not populated here yet — like the
+migration — so compounds degrade to separate insight+segment rows; wiring the
+SUPPORTED_BY edges through is a follow-up.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast, List, Optional
+
+from ..providers.ml import embedding_loader
+from .backend import InsightDocument, SegmentDocument
+from .backends.lancedb_backend import DEFAULT_EMBED_DIM, LanceDBBackend
+from .corpus_scope import discover_metadata_files, episode_root_from_metadata_path
+from .indexer import _collect_docs_for_episode, _load_metadata_file
+
+DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+DEFAULT_TARGET_TOKENS = 256
+DEFAULT_OVERLAP_TOKENS = 32
+
+
+@dataclass
+class TwoTierIndexStats:
+    """Counts from a from-corpus two-tier index build."""
+
+    episodes: int = 0
+    segments: int = 0
+    insights: int = 0
+
+
+def _embed(text: str, model_id: str, *, allow_download: bool) -> List[float]:
+    vec = embedding_loader.encode(text, model_id, return_numpy=False, allow_download=allow_download)
+    return [float(x) for x in cast(List[float], vec)]
+
+
+def build_two_tier_index(
+    corpus_dir: str | Path,
+    lance_path: str | Path,
+    *,
+    model_id: str = DEFAULT_MODEL,
+    target_tokens: int = DEFAULT_TARGET_TOKENS,
+    overlap_tokens: int = DEFAULT_OVERLAP_TOKENS,
+    embed_dim: int = DEFAULT_EMBED_DIM,
+    limit_episodes: Optional[int] = None,
+    allow_download: bool = False,
+) -> TwoTierIndexStats:
+    """Build the two-tier LanceDB index at *lance_path* from the corpus at *corpus_dir*.
+
+    Walks episode metadata, extracts insight + transcript-chunk rows, embeds each with
+    *model_id*, and upserts into the segment/insight tables (idempotent merge on id).
+    ``limit_episodes`` caps the walk for smoke runs. Returns per-tier counts.
+    """
+    out = Path(corpus_dir)
+    backend = LanceDBBackend(str(lance_path), embed_dim=embed_dim)
+    stats = TwoTierIndexStats()
+
+    for meta_path in discover_metadata_files(out):
+        if limit_episodes is not None and stats.episodes >= limit_episodes:
+            break
+        doc = _load_metadata_file(meta_path)
+        if not doc:
+            continue
+        stats.episodes += 1
+        episode_root = episode_root_from_metadata_path(meta_path)
+        meta_rel = meta_path.resolve().relative_to(out.resolve()).as_posix()
+        rows = _collect_docs_for_episode(
+            episode_root,
+            meta_path,
+            doc,
+            target_tokens=target_tokens,
+            overlap_tokens=overlap_tokens,
+            metadata_relative_path=meta_rel,
+        )
+        for doc_id, text, meta in rows:
+            doc_type = meta.get("doc_type")
+            if doc_type == "insight":
+                backend.upsert_insight(
+                    InsightDocument(
+                        id=doc_id,
+                        text=text,
+                        show_id=meta.get("feed_id") or "",
+                        episode_id=meta.get("episode_id") or "",
+                        entity_type="insight",
+                        confidence=0.0,
+                        derived=bool(meta.get("grounded")),
+                        embedding=_embed(text, model_id, allow_download=allow_download),
+                    )
+                )
+                stats.insights += 1
+            elif doc_type == "transcript":
+                backend.upsert_segment(
+                    SegmentDocument(
+                        id=doc_id,
+                        text=text,
+                        show_id=meta.get("feed_id") or "",
+                        episode_id=meta.get("episode_id") or "",
+                        start_time=float(meta.get("timestamp_start_ms") or 0.0) / 1000.0,
+                        end_time=float(meta.get("timestamp_end_ms") or 0.0) / 1000.0,
+                        embedding=_embed(text, model_id, allow_download=allow_download),
+                    )
+                )
+                stats.segments += 1
+
+    if stats.segments or stats.insights:
+        backend.create_indices()
+    return stats

--- a/src/podcast_scraper/search/two_tier_indexer.py
+++ b/src/podcast_scraper/search/two_tier_indexer.py
@@ -24,7 +24,7 @@ from typing import cast, List, Optional
 
 from ..providers.ml import embedding_loader
 from .backend import InsightDocument, SegmentDocument
-from .backends.lancedb_backend import DEFAULT_EMBED_DIM, LanceDBBackend
+from .backends.lancedb_backend import LanceDBBackend
 from .corpus_scope import discover_metadata_files, episode_root_from_metadata_path
 from .indexer import _collect_docs_for_episode, _load_metadata_file
 
@@ -54,7 +54,7 @@ def build_two_tier_index(
     model_id: str = DEFAULT_MODEL,
     target_tokens: int = DEFAULT_TARGET_TOKENS,
     overlap_tokens: int = DEFAULT_OVERLAP_TOKENS,
-    embed_dim: int = DEFAULT_EMBED_DIM,
+    embed_dim: Optional[int] = None,
     limit_episodes: Optional[int] = None,
     allow_download: bool = False,
 ) -> TwoTierIndexStats:
@@ -62,11 +62,21 @@ def build_two_tier_index(
 
     Walks episode metadata, extracts insight + transcript-chunk rows, embeds each with
     *model_id*, and upserts into the segment/insight tables (idempotent merge on id).
-    ``limit_episodes`` caps the walk for smoke runs. Returns per-tier counts.
+    ``embed_dim`` is derived from *model_id* when None (so a non-MiniLM model can't
+    silently mismatch the schema). ``limit_episodes`` caps the walk. Returns counts.
     """
     out = Path(corpus_dir)
-    backend = LanceDBBackend(str(lance_path), embed_dim=embed_dim)
     stats = TwoTierIndexStats()
+    backend: Optional[LanceDBBackend] = None
+
+    def _ensure_backend(vec_len: int) -> LanceDBBackend:
+        # Lazy: size the schema from the model's real dim (or an explicit override) on
+        # the first embedded doc, so a non-MiniLM model can't silently mismatch — and an
+        # empty corpus creates no index at all.
+        nonlocal backend
+        if backend is None:
+            backend = LanceDBBackend(str(lance_path), embed_dim=embed_dim or vec_len)
+        return backend
 
     for meta_path in discover_metadata_files(out):
         if limit_episodes is not None and stats.episodes >= limit_episodes:
@@ -88,7 +98,8 @@ def build_two_tier_index(
         for doc_id, text, meta in rows:
             doc_type = meta.get("doc_type")
             if doc_type == "insight":
-                backend.upsert_insight(
+                emb = _embed(text, model_id, allow_download=allow_download)
+                _ensure_backend(len(emb)).upsert_insight(
                     InsightDocument(
                         id=doc_id,
                         text=text,
@@ -97,12 +108,13 @@ def build_two_tier_index(
                         entity_type="insight",
                         confidence=0.0,
                         derived=bool(meta.get("grounded")),
-                        embedding=_embed(text, model_id, allow_download=allow_download),
+                        embedding=emb,
                     )
                 )
                 stats.insights += 1
             elif doc_type == "transcript":
-                backend.upsert_segment(
+                emb = _embed(text, model_id, allow_download=allow_download)
+                _ensure_backend(len(emb)).upsert_segment(
                     SegmentDocument(
                         id=doc_id,
                         text=text,
@@ -110,11 +122,12 @@ def build_two_tier_index(
                         episode_id=meta.get("episode_id") or "",
                         start_time=float(meta.get("timestamp_start_ms") or 0.0) / 1000.0,
                         end_time=float(meta.get("timestamp_end_ms") or 0.0) / 1000.0,
-                        embedding=_embed(text, model_id, allow_download=allow_download),
+                        embedding=emb,
                     )
                 )
                 stats.segments += 1
 
-    if stats.segments or stats.insights:
+    if backend is not None:
+        backend.write_index_meta(model_id)  # query path must embed in the same space
         backend.create_indices()
     return stats

--- a/src/podcast_scraper/search/two_tier_indexer.py
+++ b/src/podcast_scraper/search/two_tier_indexer.py
@@ -10,23 +10,26 @@ into the ``insight`` (Tier 2) and ``segment`` (Tier 1) tables.
 Relationship to the migration (#858): the migration is the fast path for a corpus
 that already has FAISS (it reuses those embeddings verbatim); this indexer is the
 native path for corpora that don't. Both produce the same two-tier layout the live
-hybrid search (RFC-090 Phase 2) reads. Insight↔segment linking
-(``linked_insight_ids`` for compound results) is not populated here yet — like the
-migration — so compounds degrade to separate insight+segment rows; wiring the
-SUPPORTED_BY edges through is a follow-up.
+hybrid search (RFC-090 Phase 2) reads. Unlike the migration, this path **populates
+insight↔segment links** (``linked_insight_ids`` / ``source_segment_id``) from the
+gi.json ``SUPPORTED_BY`` edges + quote timestamps, so the compound-result path
+(``dedup``) actually fires on a natively-built index. The migration leaves them
+empty (FAISS gives it no edges), so compounds need a native (re)index.
 """
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast, List, Optional
+from typing import cast, Dict, List, Optional, Tuple
 
 from ..providers.ml import embedding_loader
 from .backend import InsightDocument, SegmentDocument
 from .backends.lancedb_backend import LanceDBBackend
 from .corpus_scope import discover_metadata_files, episode_root_from_metadata_path
-from .indexer import _collect_docs_for_episode, _load_metadata_file
+from .indexer import _collect_docs_for_episode, _gi_path, _load_metadata_file
+from .segments import link_insights_to_segments
 
 DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 DEFAULT_TARGET_TOKENS = 256
@@ -40,11 +43,46 @@ class TwoTierIndexStats:
     episodes: int = 0
     segments: int = 0
     insights: int = 0
+    linked: int = 0
 
 
 def _embed(text: str, model_id: str, *, allow_download: bool) -> List[float]:
     vec = embedding_loader.encode(text, model_id, return_numpy=False, allow_download=allow_download)
     return [float(x) for x in cast(List[float], vec)]
+
+
+def _insight_grounding_quotes(gi_path: Path) -> Dict[str, Tuple[float, Optional[float]]]:
+    """Map each insight node id → its first grounding quote's (start_s, end_s).
+
+    Reads the episode's ``*.gi.json`` (Insight ``SUPPORTED_BY`` Quote; quotes carry
+    ``timestamp_*_ms``). This is what lets ``link_insights_to_segments`` connect an
+    insight to the transcript segment it was spoken in — the input the compound-result
+    path (``dedup``) needs but the FAISS-derived migration can't supply.
+    """
+    if not gi_path.is_file():
+        return {}
+    try:
+        art = json.loads(gi_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    quote_ts: Dict[str, Tuple[float, Optional[float]]] = {}
+    for node in art.get("nodes") or []:
+        if node.get("type") == "Quote":
+            props = node.get("properties") or {}
+            start = props.get("timestamp_start_ms")
+            if start is not None:
+                end = props.get("timestamp_end_ms")
+                quote_ts[node.get("id")] = (
+                    float(start) / 1000.0,
+                    float(end) / 1000.0 if end is not None else None,
+                )
+    out: Dict[str, Tuple[float, Optional[float]]] = {}
+    for edge in art.get("edges") or []:
+        if edge.get("type") == "SUPPORTED_BY":
+            insight_id, quote_id = edge.get("from"), edge.get("to")
+            if insight_id not in out and quote_id in quote_ts:
+                out[insight_id] = quote_ts[quote_id]
+    return out
 
 
 def build_two_tier_index(
@@ -95,11 +133,16 @@ def build_two_tier_index(
             overlap_tokens=overlap_tokens,
             metadata_relative_path=meta_rel,
         )
+        # Collect this episode's docs first, then link insights to the segment that
+        # contains their grounding quote, then upsert — so linked_insight_ids /
+        # source_segment_id are populated (the compound-result path needs them).
+        seg_docs: List[SegmentDocument] = []
+        ins_docs: List[InsightDocument] = []
+        node_id_by_insight: Dict[str, Optional[str]] = {}
         for doc_id, text, meta in rows:
             doc_type = meta.get("doc_type")
             if doc_type == "insight":
-                emb = _embed(text, model_id, allow_download=allow_download)
-                _ensure_backend(len(emb)).upsert_insight(
+                ins_docs.append(
                     InsightDocument(
                         id=doc_id,
                         text=text,
@@ -108,13 +151,12 @@ def build_two_tier_index(
                         entity_type="insight",
                         confidence=0.0,
                         derived=bool(meta.get("grounded")),
-                        embedding=emb,
+                        embedding=_embed(text, model_id, allow_download=allow_download),
                     )
                 )
-                stats.insights += 1
+                node_id_by_insight[doc_id] = meta.get("source_id")
             elif doc_type == "transcript":
-                emb = _embed(text, model_id, allow_download=allow_download)
-                _ensure_backend(len(emb)).upsert_segment(
+                seg_docs.append(
                     SegmentDocument(
                         id=doc_id,
                         text=text,
@@ -122,10 +164,28 @@ def build_two_tier_index(
                         episode_id=meta.get("episode_id") or "",
                         start_time=float(meta.get("timestamp_start_ms") or 0.0) / 1000.0,
                         end_time=float(meta.get("timestamp_end_ms") or 0.0) / 1000.0,
-                        embedding=emb,
+                        embedding=_embed(text, model_id, allow_download=allow_download),
                     )
                 )
-                stats.segments += 1
+
+        grounding = _insight_grounding_quotes(_gi_path(episode_root, meta_path, doc))
+        insight_quotes = [
+            (ins.id, *grounding[node_id])
+            for ins in ins_docs
+            if (node_id := node_id_by_insight.get(ins.id)) in grounding
+        ]
+        mapping = link_insights_to_segments(seg_docs, insight_quotes)
+        for ins in ins_docs:
+            if ins.id in mapping:
+                ins.source_segment_id = mapping[ins.id]
+        stats.linked += len(mapping)
+
+        for seg in seg_docs:
+            _ensure_backend(len(seg.embedding)).upsert_segment(seg)
+            stats.segments += 1
+        for ins in ins_docs:
+            _ensure_backend(len(ins.embedding)).upsert_insight(ins)
+            stats.insights += 1
 
     if backend is not None:
         backend.write_index_meta(model_id)  # query path must embed in the same space

--- a/src/podcast_scraper/server/routes/search.py
+++ b/src/podcast_scraper/server/routes/search.py
@@ -55,7 +55,12 @@ async def search_corpus(
         ),
     ),
 ) -> CorpusSearchApiResponse:
-    """Semantic search via FAISS + sentence embeddings."""
+    """Semantic corpus search.
+
+    Routes through the two-tier hybrid ``RetrievalLayer`` when ``serving.hybrid_enabled``
+    is set and a LanceDB index exists (RFC-090 Phase 2); otherwise FAISS. The response
+    shape is identical for both backends.
+    """
     fallback = getattr(request.app.state, "output_dir", None)
     root = _resolve_corpus_root(path, fallback)
     if root is None:

--- a/src/podcast_scraper/upgrade/migrations/m0002_two_tier_native_reindex.py
+++ b/src/podcast_scraper/upgrade/migrations/m0002_two_tier_native_reindex.py
@@ -83,7 +83,9 @@ class TwoTierNativeReindexMigration(Migration):
         except Exception as exc:  # noqa: BLE001 - surface as verify failure
             return False, f"LanceDB health check failed: {exc}"
         total = int(health.get("segments", 0)) + int(health.get("insights", 0))
+        if total <= 0:
+            return False, "LanceDB index present but empty"
         return (
-            (total >= 0),
+            True,
             f"LanceDB present: segments={health.get('segments')} insights={health.get('insights')}",
         )

--- a/src/podcast_scraper/upgrade/migrations/m0002_two_tier_native_reindex.py
+++ b/src/podcast_scraper/upgrade/migrations/m0002_two_tier_native_reindex.py
@@ -1,0 +1,89 @@
+"""0002 — native two-tier reindex fallback (2.6 → 2.7, follow-up B under #862).
+
+Completes the chain that 0001 starts. 0001 (FAISS→LanceDB) is a **no-op when a
+corpus has no FAISS index** to migrate. This step covers exactly that gap: if no
+LanceDB index exists yet, build it **natively** from corpus artifacts
+(``build_two_tier_index``, follow-up B); if one already exists (0001 built it, or a
+prior run), it is a no-op. Together the two guarantee every upgraded corpus ends
+with a two-tier index via the cheapest available path, without double-building.
+
+Why this and not the originally-speculated migrations: the cross-episode entity
+canonical map (#852) is computed **live** at graph-build (``corpus_graph`` →
+``build_entity_id_map``), not persisted, so there is nothing to migrate; and the
+basic vector-index build is already 0001. Registering those would be busy-work — see
+the upgrade guide.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+from ..migration import Migration, MigrationContext, MigrationResult
+
+
+class TwoTierNativeReindexMigration(Migration):
+    """Build the two-tier LanceDB index natively when 0001 left none."""
+
+    id = "0002_two_tier_native_reindex"
+    to_version = "2.7.0"
+    description = "Native two-tier index build for corpora without a FAISS index (RFC-090 B)"
+
+    def _lance_path(self, ctx: MigrationContext) -> Path:
+        return Path(ctx.options.get("lance_path") or ctx.corpus_root / "search" / "lance_index")
+
+    def plan(self, ctx: MigrationContext) -> str:
+        """Describe whether a native build is needed for this corpus."""
+        if self._lance_path(ctx).exists():
+            return "LanceDB index already present — no-op."
+        return (
+            f"Build two-tier LanceDB index natively from {ctx.corpus_root} (no FAISS to migrate)."
+        )
+
+    def apply(self, ctx: MigrationContext) -> MigrationResult:
+        """Build the native index only if one does not already exist."""
+        lance_path = self._lance_path(ctx)
+        if lance_path.exists():
+            ctx.log(f"LanceDB index already present at {lance_path}; skipping native build")
+            return MigrationResult(
+                self.id, applied=True, dry_run=ctx.dry_run, message="index already present — no-op"
+            )
+        if ctx.dry_run:
+            ctx.log(self.plan(ctx))
+            return MigrationResult(self.id, applied=False, dry_run=True, message=self.plan(ctx))
+
+        from ...search.two_tier_indexer import build_two_tier_index
+
+        ctx.log(f"building native two-tier index at {lance_path}")
+        stats = build_two_tier_index(ctx.corpus_root, lance_path)
+        return MigrationResult(
+            self.id,
+            applied=True,
+            dry_run=False,
+            message=f"native build: episodes={stats.episodes} segments={stats.segments} "
+            f"insights={stats.insights}",
+            details={
+                "episodes": stats.episodes,
+                "segments": stats.segments,
+                "insights": stats.insights,
+                "lance_path": str(lance_path),
+            },
+        )
+
+    def verify(self, ctx: MigrationContext) -> Tuple[bool, str]:
+        """Confirm a LanceDB index exists (built here or by 0001)."""
+        lance_path = self._lance_path(ctx)
+        if not lance_path.exists():
+            # Acceptable only if the corpus genuinely has no indexable content.
+            return True, "no LanceDB index (empty corpus or nothing to index)"
+        try:
+            from ...search.backends.lancedb_backend import LanceDBBackend
+
+            health = LanceDBBackend(str(lance_path)).health()
+        except Exception as exc:  # noqa: BLE001 - surface as verify failure
+            return False, f"LanceDB health check failed: {exc}"
+        total = int(health.get("segments", 0)) + int(health.get("insights", 0))
+        return (
+            (total >= 0),
+            f"LanceDB present: segments={health.get('segments')} insights={health.get('insights')}",
+        )

--- a/src/podcast_scraper/upgrade/registry.py
+++ b/src/podcast_scraper/upgrade/registry.py
@@ -11,10 +11,15 @@ from typing import List
 
 from .migration import Migration
 from .migrations.m0001_faiss_to_lance import FaissToLanceMigration
+from .migrations.m0002_two_tier_native_reindex import TwoTierNativeReindexMigration
 
-# Source of truth, declared in intended apply order.
+# Source of truth, declared in intended apply order. 0001 migrates from FAISS when
+# present; 0002 builds natively only when 0001 left no index — together they
+# guarantee a two-tier index via the cheapest path. The entity canonical map (#852)
+# is intentionally NOT a migration: it is computed live at graph-build, not persisted.
 _MIGRATIONS: List[Migration] = [
     FaissToLanceMigration(),
+    TwoTierNativeReindexMigration(),
 ]
 
 

--- a/tests/integration/search/test_hybrid_search.py
+++ b/tests/integration/search/test_hybrid_search.py
@@ -1,0 +1,80 @@
+"""Integration tests for the hybrid serving bridge (RFC-090 Phase 2 wire-live).
+
+Real LanceDB index + real MiniLM query embedding; asserts candidate mapping, tier
+scoping, and the FAISS-fallback signal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+pytest.importorskip("lancedb")
+
+from podcast_scraper.providers.ml import embedding_loader  # noqa: E402
+from podcast_scraper.search import hybrid_search as hs  # noqa: E402
+from podcast_scraper.search.backend import InsightDocument, SegmentDocument  # noqa: E402
+from podcast_scraper.search.backends.lancedb_backend import LanceDBBackend  # noqa: E402
+
+_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def _emb(text):
+    return list(embedding_loader.encode(text, _MODEL, return_numpy=False, allow_download=True))
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    idx = tmp_path / "corpus" / "search" / "lance_index"
+    idx.parent.mkdir(parents=True)
+    b = LanceDBBackend(str(idx), embed_dim=384)
+    b.upsert_segment(
+        SegmentDocument(
+            id="chunk:1",
+            text="raw transcript about AI scaling laws",
+            show_id="A",
+            episode_id="ep1",
+            start_time=2.0,
+            end_time=5.0,
+            embedding=_emb("raw transcript about AI scaling laws"),
+        )
+    )
+    b.upsert_insight(
+        InsightDocument(
+            id="insight:1",
+            text="Altman argues AI scaling continues",
+            show_id="A",
+            episode_id="ep1",
+            entity_type="insight",
+            confidence=0.8,
+            derived=True,
+            embedding=_emb("Altman argues AI scaling continues"),
+        )
+    )
+    b.create_indices()
+    return tmp_path / "corpus"
+
+
+def test_maps_both_tiers_with_doc_type_and_timestamps(corpus):
+    rows = hs.hybrid_candidates(corpus, "AI scaling", top_k=5)
+    by_id = {r.doc_id: r for r in rows}
+    assert by_id["insight:1"].metadata["doc_type"] == "insight"
+    seg = by_id["chunk:1"]
+    assert seg.metadata["doc_type"] == "transcript"  # segment → transcript vocab
+    assert seg.metadata["timestamp_start_ms"] == 2000  # seconds → ms
+    assert seg.metadata["episode_id"] == "ep1"
+
+
+def test_tier_scoping(corpus):
+    assert [
+        r.doc_id for r in hs.hybrid_candidates(corpus, "AI", top_k=5, doc_types=["insight"])
+    ] == ["insight:1"]
+    assert [
+        r.doc_id for r in hs.hybrid_candidates(corpus, "AI", top_k=5, doc_types=["transcript"])
+    ] == ["chunk:1"]
+
+
+def test_missing_index_returns_none(tmp_path):
+    # No LanceDB index → None (signals FAISS fallback), not an empty list.
+    assert hs.hybrid_candidates(tmp_path / "nope", "AI", top_k=5) is None

--- a/tests/integration/search/test_migration.py
+++ b/tests/integration/search/test_migration.py
@@ -67,6 +67,10 @@ def test_migration_maps_tiers_and_skips_others(tmp_path):
     health = backend.health()
     assert health["insights"] == 1 and health["segments"] == 1
 
+    # Migration records the FAISS index's model so the query path matches it.
+    meta = backend.read_index_meta()
+    assert meta is not None and meta["embedding_model"]
+
 
 def test_migration_preserves_searchable_payload(tmp_path):
     faiss_dir = _build_faiss(tmp_path)

--- a/tests/integration/search/test_query_router_ml.py
+++ b/tests/integration/search/test_query_router_ml.py
@@ -1,0 +1,34 @@
+"""Integration test: MLQueryRouter real joblib load + embed (RFC-092, #860).
+
+Needs scikit-learn + joblib (ML extras), so it lives in integration — unit tests run
+[dev]-only and would fail to import sklearn.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+pytest.importorskip("sklearn")
+pytest.importorskip("joblib")
+
+from podcast_scraper.search.query_router import MLQueryRouter  # noqa: E402
+
+
+def test_loads_persisted_model_and_embeds(tmp_path, monkeypatch):
+    # Real joblib round-trip + real _embed (encode monkeypatched) → covers load + embed.
+    import joblib
+    from sklearn.dummy import DummyClassifier
+
+    clf = DummyClassifier(strategy="constant", constant="cross_show_synthesis")
+    clf.fit([[0.0, 0.0, 0.0]], ["cross_show_synthesis"])
+    model_path = tmp_path / "router.joblib"
+    joblib.dump(clf, model_path)
+
+    monkeypatch.setattr(
+        "podcast_scraper.providers.ml.embedding_loader.encode",
+        lambda *a, **k: [0.0, 0.0, 0.0],
+    )
+    router = MLQueryRouter(model_path)
+    assert router.classify("compare A and B") == "cross_show_synthesis"

--- a/tests/integration/search/test_two_tier_indexer.py
+++ b/tests/integration/search/test_two_tier_indexer.py
@@ -1,0 +1,81 @@
+"""Integration test for the from-corpus two-tier indexer (RFC-090 Phase 2 / B).
+
+Stubs the (already-tested) FAISS-indexer corpus extraction and exercises this
+module's own logic — embed → map → upsert → both tiers queryable — against a real
+LanceDB index with real MiniLM embeddings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+pytest.importorskip("lancedb")
+
+from podcast_scraper.search import hybrid_search as hs, two_tier_indexer as tti  # noqa: E402
+from podcast_scraper.search.backends.lancedb_backend import LanceDBBackend  # noqa: E402
+
+
+def _stub_extraction(monkeypatch, tmp_path, rows):
+    meta_path = tmp_path / "corpus" / "metadata" / "ep1.json"
+    monkeypatch.setattr(tti, "discover_metadata_files", lambda root: [meta_path])
+    monkeypatch.setattr(tti, "_load_metadata_file", lambda p: {"episode": {"episode_id": "ep1"}})
+    monkeypatch.setattr(tti, "episode_root_from_metadata_path", lambda p: tmp_path / "corpus")
+    monkeypatch.setattr(tti, "_collect_docs_for_episode", lambda *a, **k: rows)
+
+
+def test_builds_both_tiers_and_is_queryable(tmp_path, monkeypatch):
+    rows = [
+        (
+            "insight:1",
+            "The central bank is shifting monetary policy",
+            {"doc_type": "insight", "episode_id": "ep1", "feed_id": "show1", "grounded": True},
+        ),
+        (
+            "chunk:1",
+            "Markets moved sharply as the central bank signaled a policy shift",
+            {
+                "doc_type": "transcript",
+                "episode_id": "ep1",
+                "feed_id": "show1",
+                "timestamp_start_ms": 2000,
+                "timestamp_end_ms": 5000,
+            },
+        ),
+        # A non-two-tier row (quote) must be ignored.
+        ("quote:1", "we are shifting", {"doc_type": "quote", "episode_id": "ep1"}),
+    ]
+    _stub_extraction(monkeypatch, tmp_path, rows)
+
+    corpus = tmp_path / "corpus"
+    (corpus / "metadata").mkdir(parents=True)
+    lance = corpus / "search" / "lance_index"
+    stats = tti.build_two_tier_index(corpus, lance, allow_download=True)
+
+    assert stats.episodes == 1
+    assert stats.insights == 1 and stats.segments == 1  # quote ignored
+
+    health = LanceDBBackend(str(lance)).health()
+    assert health["insights"] == 1 and health["segments"] == 1
+
+    rows_out = hs.hybrid_candidates(corpus, "central bank policy shift", top_k=5)
+    assert rows_out is not None and len(rows_out) >= 1
+    by_id = {r.doc_id: r for r in rows_out}
+    assert by_id["chunk:1"].metadata["timestamp_start_ms"] == 2000  # ms preserved via seconds
+
+
+def test_limit_episodes_caps_walk(tmp_path, monkeypatch):
+    rows = [("insight:1", "x", {"doc_type": "insight", "episode_id": "ep1", "feed_id": "s"})]
+    # Two metadata files, but limit_episodes=0 stops before any work.
+    meta = tmp_path / "corpus" / "metadata" / "ep1.json"
+    monkeypatch.setattr(tti, "discover_metadata_files", lambda root: [meta, meta])
+    monkeypatch.setattr(tti, "_load_metadata_file", lambda p: {"episode": {"episode_id": "ep1"}})
+    monkeypatch.setattr(tti, "episode_root_from_metadata_path", lambda p: tmp_path / "corpus")
+    monkeypatch.setattr(tti, "_collect_docs_for_episode", lambda *a, **k: rows)
+    (tmp_path / "corpus" / "metadata").mkdir(parents=True)
+
+    stats = tti.build_two_tier_index(
+        tmp_path / "corpus", tmp_path / "corpus" / "search" / "li", limit_episodes=0
+    )
+    assert stats.episodes == 0 and stats.insights == 0

--- a/tests/integration/search/test_two_tier_indexer.py
+++ b/tests/integration/search/test_two_tier_indexer.py
@@ -56,8 +56,14 @@ def test_builds_both_tiers_and_is_queryable(tmp_path, monkeypatch):
     assert stats.episodes == 1
     assert stats.insights == 1 and stats.segments == 1  # quote ignored
 
-    health = LanceDBBackend(str(lance)).health()
+    backend = LanceDBBackend(str(lance))
+    health = backend.health()
     assert health["insights"] == 1 and health["segments"] == 1
+
+    # Index meta records the model + the model's real dim (derived, not assumed 384).
+    meta = backend.read_index_meta()
+    assert meta is not None and meta["embedding_model"]
+    assert meta["embed_dim"] == 384  # MiniLM
 
     rows_out = hs.hybrid_candidates(corpus, "central bank policy shift", top_k=5)
     assert rows_out is not None and len(rows_out) >= 1

--- a/tests/integration/search/test_two_tier_indexer.py
+++ b/tests/integration/search/test_two_tier_indexer.py
@@ -71,6 +71,71 @@ def test_builds_both_tiers_and_is_queryable(tmp_path, monkeypatch):
     assert by_id["chunk:1"].metadata["timestamp_start_ms"] == 2000  # ms preserved via seconds
 
 
+def test_linking_populates_compounds(tmp_path, monkeypatch):
+    """Native index links insight↔segment so dedup actually produces a CompoundResult."""
+    import json
+
+    from podcast_scraper.search.backend import SearchQuery
+    from podcast_scraper.search.backends.lancedb_backend import LanceDBBackend
+    from podcast_scraper.search.dedup import deduplicate
+
+    corpus = tmp_path / "corpus"
+    (corpus / "metadata").mkdir(parents=True)
+    gi = corpus / "ep1.gi.json"
+    gi.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {"id": "insight:n1", "type": "Insight", "properties": {"text": "x"}},
+                    {
+                        "id": "quote:q1",
+                        "type": "Quote",
+                        "properties": {"timestamp_start_ms": 1000, "timestamp_end_ms": 4000},
+                    },
+                ],
+                "edges": [{"type": "SUPPORTED_BY", "from": "insight:n1", "to": "quote:q1"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    rows = [
+        (
+            "insight:s:insight:n1",
+            "central bank policy shift",
+            {"doc_type": "insight", "episode_id": "ep1", "feed_id": "s", "source_id": "insight:n1"},
+        ),
+        (
+            "chunk:s:1",
+            "the central bank signaled a policy shift in markets",
+            {
+                "doc_type": "transcript",
+                "episode_id": "ep1",
+                "feed_id": "s",
+                "timestamp_start_ms": 0,
+                "timestamp_end_ms": 10000,
+            },
+        ),  # span covers the quote (1–4s)
+    ]
+    monkeypatch.setattr(
+        tti, "discover_metadata_files", lambda root: [corpus / "metadata" / "ep1.json"]
+    )
+    monkeypatch.setattr(tti, "_load_metadata_file", lambda p: {"episode": {"episode_id": "ep1"}})
+    monkeypatch.setattr(tti, "episode_root_from_metadata_path", lambda p: corpus)
+    monkeypatch.setattr(tti, "_collect_docs_for_episode", lambda *a, **k: rows)
+    monkeypatch.setattr(tti, "_gi_path", lambda root, mp, doc: gi)
+
+    lance = corpus / "search" / "lance_index"
+    stats = tti.build_two_tier_index(corpus, lance, allow_download=True)
+    assert stats.linked == 1  # the insight linked to the segment
+
+    backend = LanceDBBackend(str(lance))
+    hits = backend.search_bm25(
+        SearchQuery(text="central bank policy shift", embedding=[], tier="all")
+    )
+    compounds = [r for r in deduplicate(hits) if r.source_tier == "compound"]
+    assert compounds, "linked insight+segment must dedup into a CompoundResult"
+
+
 def test_limit_episodes_caps_walk(tmp_path, monkeypatch):
     rows = [("insight:1", "x", {"doc_type": "insight", "episode_id": "ep1", "feed_id": "s"})]
     # Two metadata files, but limit_episodes=0 stops before any work.

--- a/tests/integration/upgrade/test_end_to_end.py
+++ b/tests/integration/upgrade/test_end_to_end.py
@@ -61,10 +61,14 @@ def test_status_then_run_then_verify(tmp_path):
     # status before: pending → exit 2.
     assert _run(corpus, "status") == 2
 
-    # run --yes applies it.
+    # run --yes applies the chain: 0001 migrates from FAISS, 0002 sees the index and
+    # no-ops.
     assert _run(corpus, "run", "--yes") == 0
     store = FilesystemStateStore(corpus)
-    assert store.applied_migration_ids() == {"0001_faiss_to_lance"}
+    assert store.applied_migration_ids() == {
+        "0001_faiss_to_lance",
+        "0002_two_tier_native_reindex",
+    }
     assert store.current_version() == "2.7.0"
     assert (corpus / "search" / "lance_index").exists()
 
@@ -74,9 +78,9 @@ def test_status_then_run_then_verify(tmp_path):
     # verify passes.
     assert _run(corpus, "verify") == 0
 
-    # idempotent: a second run is a no-op (still exit 0, still one ledger entry).
+    # idempotent: a second run is a no-op (still exit 0, ledger unchanged).
     assert _run(corpus, "run", "--yes") == 0
-    assert len(store.applied_records()) == 1
+    assert len(store.applied_records()) == 2
 
 
 def test_run_dry_run_writes_nothing(tmp_path):

--- a/tests/unit/search/test_dedup.py
+++ b/tests/unit/search/test_dedup.py
@@ -1,0 +1,57 @@
+"""Unit tests for compound-result deduplication (RFC-090 §3.4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.backend import CompoundResult, ScoredResult
+from podcast_scraper.search.dedup import deduplicate
+
+pytestmark = pytest.mark.unit
+
+
+def _seg(doc_id, score, rank, linked=None):
+    return ScoredResult(
+        doc_id, score, rank, {"linked_insight_ids": linked or []}, "bm25", "segment"
+    )
+
+
+def _ins(doc_id, score, rank, src_seg=None):
+    return ScoredResult(doc_id, score, rank, {"source_segment_id": src_seg}, "vector", "insight")
+
+
+def test_compound_via_insight_source_segment_id():
+    seg = _seg("s1", 0.6, 3)
+    ins = _ins("i1", 0.9, 1, src_seg="s1")
+    out = deduplicate([seg, ins])
+    assert len(out) == 1
+    comp = out[0]
+    assert isinstance(comp, CompoundResult)
+    assert comp.doc_id == "s1" and comp.segment is seg and comp.insight is ins
+    assert comp.score == 0.9 and comp.rank == 1  # max score, min rank
+
+
+def test_compound_via_segment_linked_insight_ids():
+    seg = _seg("s1", 0.8, 2, linked=["i1"])
+    ins = _ins("i1", 0.5, 4)  # no source_segment_id → uses the reverse link
+    out = deduplicate([seg, ins])
+    assert len(out) == 1 and isinstance(out[0], CompoundResult)
+    assert out[0].score == 0.8 and out[0].rank == 2
+
+
+def test_unlinked_results_pass_through():
+    seg = _seg("s1", 0.7, 1)
+    ins = _ins("i1", 0.6, 2)  # no link either direction
+    out = deduplicate([seg, ins])
+    assert len(out) == 2 and all(isinstance(r, ScoredResult) for r in out)
+    assert [r.doc_id for r in out] == ["s1", "i1"]  # sorted by score desc
+
+
+def test_one_segment_consumed_once():
+    seg = _seg("s1", 0.5, 5, linked=["i1", "i2"])
+    i1 = _ins("i1", 0.9, 1, src_seg="s1")
+    i2 = _ins("i2", 0.8, 2, src_seg="s1")
+    out = deduplicate([seg, i1, i2])
+    compounds = [r for r in out if isinstance(r, CompoundResult)]
+    assert len(compounds) == 1  # segment consumed by the first insight only
+    assert any(r.doc_id == "i2" and isinstance(r, ScoredResult) for r in out)  # i2 left standalone

--- a/tests/unit/search/test_hybrid_dispatch.py
+++ b/tests/unit/search/test_hybrid_dispatch.py
@@ -15,9 +15,10 @@ from podcast_scraper.search.protocol import SearchResult
 pytestmark = pytest.mark.unit
 
 
-def test_flag_reader_defaults_false_and_reads_yaml(tmp_path, monkeypatch):
+def test_flag_reader_reads_config_via_env_path(tmp_path, monkeypatch):
     cfg = tmp_path / "search.yaml"
-    monkeypatch.setattr(hybrid_search, "_SEARCH_CONFIG", cfg)
+    monkeypatch.setenv("PODCAST_SEARCH_CONFIG", str(cfg))
+    monkeypatch.delenv("PODCAST_HYBRID_SEARCH", raising=False)
     assert hybrid_search.hybrid_search_enabled() is False  # missing file → False
 
     cfg.write_text("serving:\n  hybrid_enabled: true\n", encoding="utf-8")
@@ -25,6 +26,27 @@ def test_flag_reader_defaults_false_and_reads_yaml(tmp_path, monkeypatch):
 
     cfg.write_text("serving:\n  hybrid_enabled: false\n", encoding="utf-8")
     assert hybrid_search.hybrid_search_enabled() is False
+
+
+def test_env_var_overrides_config(monkeypatch):
+    # The container escape hatch (audit H1): env wins, no config file needed.
+    monkeypatch.setenv("PODCAST_HYBRID_SEARCH", "true")
+    assert hybrid_search.hybrid_search_enabled() is True
+    monkeypatch.setenv("PODCAST_HYBRID_SEARCH", "off")
+    assert hybrid_search.hybrid_search_enabled() is False
+
+
+def test_serving_router_built_from_config(tmp_path, monkeypatch):
+    from podcast_scraper.search.query_router import MLQueryRouter, RulesQueryRouter
+
+    cfg = tmp_path / "search.yaml"
+    monkeypatch.setenv("PODCAST_SEARCH_CONFIG", str(cfg))
+    cfg.write_text("router:\n  mode: ml\n  model_path: ./nope.joblib\n", encoding="utf-8")
+    assert isinstance(hybrid_search._serving_router(), MLQueryRouter)
+    cfg.write_text("router:\n  mode: rules\n", encoding="utf-8")
+    assert isinstance(hybrid_search._serving_router(), RulesQueryRouter)
+    cfg.write_text("backend: lancedb\n", encoding="utf-8")  # no router block
+    assert hybrid_search._serving_router() is None
 
 
 def test_dispatch_uses_hybrid_when_enabled(tmp_path, monkeypatch):

--- a/tests/unit/search/test_hybrid_dispatch.py
+++ b/tests/unit/search/test_hybrid_dispatch.py
@@ -1,0 +1,60 @@
+"""Unit tests for the hybrid flag reader + corpus_search dispatch (RFC-090 Phase 2).
+
+No LanceDB/FAISS — the flag reader is exercised against a temp config and the
+dispatch is exercised by stubbing the hybrid bridge, so the FAISS-vs-hybrid routing
+logic is verified in isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search import corpus_search, hybrid_search
+from podcast_scraper.search.protocol import SearchResult
+
+pytestmark = pytest.mark.unit
+
+
+def test_flag_reader_defaults_false_and_reads_yaml(tmp_path, monkeypatch):
+    cfg = tmp_path / "search.yaml"
+    monkeypatch.setattr(hybrid_search, "_SEARCH_CONFIG", cfg)
+    assert hybrid_search.hybrid_search_enabled() is False  # missing file → False
+
+    cfg.write_text("serving:\n  hybrid_enabled: true\n", encoding="utf-8")
+    assert hybrid_search.hybrid_search_enabled() is True
+
+    cfg.write_text("serving:\n  hybrid_enabled: false\n", encoding="utf-8")
+    assert hybrid_search.hybrid_search_enabled() is False
+
+
+def test_dispatch_uses_hybrid_when_enabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(corpus_search, "hybrid_search_enabled", lambda: True)
+    row = SearchResult(
+        doc_id="insight:1",
+        score=0.9,
+        metadata={"doc_type": "insight", "text": "hybrid hit", "episode_id": "ep1"},
+    )
+    monkeypatch.setattr(corpus_search, "hybrid_candidates", lambda *a, **k: [row])
+
+    outcome = corpus_search.run_corpus_search(tmp_path, "AI scaling", top_k=5)
+    assert outcome.error is None
+    assert any(r.get("doc_id") == "insight:1" for r in outcome.results)  # hybrid path, no FAISS
+
+
+def test_dispatch_falls_back_to_faiss_when_hybrid_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(corpus_search, "hybrid_search_enabled", lambda: True)
+    monkeypatch.setattr(corpus_search, "hybrid_candidates", lambda *a, **k: None)  # signal fallback
+    # No FAISS index in tmp_path → FAISS path reports no_index (proves we fell through).
+    outcome = corpus_search.run_corpus_search(tmp_path, "AI scaling", top_k=5)
+    assert outcome.error == "no_index"
+
+
+def test_dispatch_skips_hybrid_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(corpus_search, "hybrid_search_enabled", lambda: False)
+
+    def _boom(*a, **k):
+        raise AssertionError("hybrid_candidates must not be called when disabled")
+
+    monkeypatch.setattr(corpus_search, "hybrid_candidates", _boom)
+    outcome = corpus_search.run_corpus_search(tmp_path, "AI scaling", top_k=5)
+    assert outcome.error == "no_index"  # straight to FAISS path

--- a/tests/unit/search/test_hybrid_fallbacks.py
+++ b/tests/unit/search/test_hybrid_fallbacks.py
@@ -1,0 +1,91 @@
+"""Unit tests for hybrid_candidates FAISS-fallback branches (RFC-090 Phase 2).
+
+These are the non-regression guarantees the module sells — every failure must return
+None so the caller falls back to FAISS. Faked backend + encode keep this off LanceDB.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search import hybrid_search as hs
+
+pytestmark = pytest.mark.unit
+
+
+def _index(tmp_path):
+    idx = tmp_path / "corpus" / "search" / "lance_index"
+    idx.mkdir(parents=True)
+    return tmp_path / "corpus"
+
+
+class _FakeBackend:
+    def __init__(self, *a, **k):
+        pass
+
+    def read_index_meta(self):
+        return {"embedding_model": "m", "embed_dim": 384}
+
+
+def _patch_backend(monkeypatch, backend_cls=_FakeBackend):
+    monkeypatch.setattr(
+        "podcast_scraper.search.backends.lancedb_backend.LanceDBBackend", backend_cls
+    )
+
+
+def test_missing_index_returns_none(tmp_path):
+    assert hs.hybrid_candidates(tmp_path / "nope", "q", top_k=5) is None
+
+
+def test_open_failure_falls_back(tmp_path, monkeypatch):
+    class _Boom:
+        def __init__(self, *a, **k):
+            raise RuntimeError("cannot open")
+
+    _patch_backend(monkeypatch, _Boom)
+    assert hs.hybrid_candidates(_index(tmp_path), "q", top_k=5) is None
+
+
+def test_embed_failure_falls_back(tmp_path, monkeypatch):
+    _patch_backend(monkeypatch)
+
+    def _raise(*a, **k):
+        raise RuntimeError("embed boom")
+
+    monkeypatch.setattr(hs.embedding_loader, "encode", _raise)
+    assert hs.hybrid_candidates(_index(tmp_path), "q", top_k=5) is None
+
+
+def test_malformed_embedding_falls_back(tmp_path, monkeypatch):
+    _patch_backend(monkeypatch)
+    monkeypatch.setattr(hs.embedding_loader, "encode", lambda *a, **k: [])  # empty
+    assert hs.hybrid_candidates(_index(tmp_path), "q", top_k=5) is None
+
+
+def test_dim_mismatch_falls_back(tmp_path, monkeypatch):
+    _patch_backend(monkeypatch)  # meta says embed_dim 384
+    monkeypatch.setattr(hs.embedding_loader, "encode", lambda *a, **k: [0.1, 0.2, 0.3])  # 3 != 384
+    assert hs.hybrid_candidates(_index(tmp_path), "q", top_k=5) is None
+
+
+def test_retrieve_failure_falls_back(tmp_path, monkeypatch):
+    _patch_backend(monkeypatch)
+    monkeypatch.setattr(hs.embedding_loader, "encode", lambda *a, **k: [0.0] * 384)  # matches dim
+
+    class _BoomLayer:
+        def __init__(self, *a, **k):
+            pass
+
+        def retrieve(self, *a, **k):
+            raise RuntimeError("retrieve boom")
+
+    monkeypatch.setattr("podcast_scraper.search.retrieval.RetrievalLayer", _BoomLayer)
+    assert hs.hybrid_candidates(_index(tmp_path), "q", top_k=5) is None
+
+
+def test_tier_for_mixed_doc_types_is_all():
+    # Mixed insight+transcript request → must search both tiers.
+    assert hs._tier_for(["insight", "transcript"]) == "all"
+    assert hs._tier_for(None) == "all"
+    assert hs._tier_for(["insight"]) == "insight"
+    assert hs._tier_for(["transcript"]) == "segment"

--- a/tests/unit/search/test_index_two_tier_cli.py
+++ b/tests/unit/search/test_index_two_tier_cli.py
@@ -1,0 +1,43 @@
+"""Unit tests for the `index-two-tier` CLI handler (RFC-090 Phase 2 / B)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from podcast_scraper.search import two_tier_indexer
+from podcast_scraper.search.cli_handlers import (
+    EXIT_INVALID_ARGS,
+    EXIT_SUCCESS,
+    parse_index_two_tier_argv,
+    run_index_two_tier_cli,
+)
+
+pytestmark = pytest.mark.unit
+log = logging.getLogger("test")
+
+
+def test_parse_sets_command_and_defaults():
+    args = parse_index_two_tier_argv(["--output-dir", "/c"])
+    assert args.command == "index-two-tier"
+    assert args.output_dir == "/c" and args.lance_path is None
+
+
+def test_run_builds_and_reports(tmp_path, monkeypatch):
+    captured = {}
+
+    def _fake(corpus, lance, **k):
+        captured["lance"] = str(lance)
+        return two_tier_indexer.TwoTierIndexStats(episodes=2, segments=9, insights=4)
+
+    monkeypatch.setattr(two_tier_indexer, "build_two_tier_index", _fake)
+    args = parse_index_two_tier_argv(["--output-dir", str(tmp_path)])
+    assert run_index_two_tier_cli(args, log) == EXIT_SUCCESS
+    assert captured["lance"].endswith("search/lance_index")  # default co-located path
+
+
+def test_run_requires_output_dir():
+    args = parse_index_two_tier_argv(["--output-dir", "/c"])
+    args.output_dir = None  # simulate missing
+    assert run_index_two_tier_cli(args, log) == EXIT_INVALID_ARGS

--- a/tests/unit/search/test_judged_eval.py
+++ b/tests/unit/search/test_judged_eval.py
@@ -1,0 +1,68 @@
+"""Unit tests for the judged hybrid-vs-FAISS eval harness (RFC-057 / C)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.judged_eval import (
+    build_judgment_template,
+    JudgmentRecord,
+    score_from_judgments,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_template_unions_candidates_with_per_backend_ranks():
+    faiss = {"q": [("a", "text-a"), ("b", "text-b")]}
+    hybrid = {"q": [("b", "text-b"), ("c", "text-c")]}
+    records = build_judgment_template(
+        ["q"],
+        faiss_ranks=lambda q: faiss[q],
+        hybrid_ranks=lambda q: hybrid[q],
+        intent_of=lambda q: "semantic",
+        k=10,
+    )
+    rec = records[0]
+    assert rec.intent == "semantic"
+    assert rec.faiss_ranking == ["a", "b"] and rec.hybrid_ranking == ["b", "c"]
+    cand = {c["doc_id"]: c for c in rec.candidates}
+    assert set(cand) == {"a", "b", "c"}  # unioned
+    assert cand["a"]["faiss_rank"] == 1 and cand["a"]["hybrid_rank"] is None
+    assert cand["b"]["faiss_rank"] == 2 and cand["b"]["hybrid_rank"] == 1
+
+
+def test_score_rewards_ranking_relevant_doc_higher():
+    # Same relevant doc "good" (grade 2); hybrid ranks it #1, FAISS ranks it #3.
+    rec = JudgmentRecord(
+        query="q",
+        intent="semantic",
+        faiss_ranking=["x", "y", "good"],
+        hybrid_ranking=["good", "x", "y"],
+        relevance={"good": 2, "x": 0, "y": 0},
+    )
+    scores = score_from_judgments([rec], k=10)
+    assert scores["hybrid"]["ndcg"] > scores["faiss"]["ndcg"]
+    assert scores["hybrid"]["ndcg"] == pytest.approx(1.0)  # relevant doc at rank 1 → ideal
+    assert scores["_judged_count"]["n"] == 1.0
+
+
+def test_recall_counts_relevant_in_top_k():
+    rec = JudgmentRecord(
+        query="q",
+        intent="semantic",
+        faiss_ranking=["a", "b", "c", "d"],
+        hybrid_ranking=["a", "b", "c", "d"],
+        relevance={"a": 1, "d": 1},  # two relevant
+    )
+    scores = score_from_judgments([rec], k=2)  # top-2 contains only "a"
+    assert scores["faiss"]["recall"] == pytest.approx(0.5)
+
+
+def test_unjudged_records_are_skipped():
+    rec = JudgmentRecord(
+        query="q", intent="semantic", faiss_ranking=["a"], hybrid_ranking=["a"], relevance={"a": 0}
+    )
+    scores = score_from_judgments([rec], k=10)
+    assert scores["_judged_count"]["n"] == 0.0  # no positive grade → no signal
+    assert scores["hybrid"]["ndcg"] == 0.0

--- a/tests/unit/search/test_judged_eval.py
+++ b/tests/unit/search/test_judged_eval.py
@@ -66,3 +66,10 @@ def test_unjudged_records_are_skipped():
     scores = score_from_judgments([rec], k=10)
     assert scores["_judged_count"]["n"] == 0.0  # no positive grade → no signal
     assert scores["hybrid"]["ndcg"] == 0.0
+
+
+def test_recall_at_no_relevant_returns_zero():
+    from podcast_scraper.search.judged_eval import _recall_at
+
+    # Defensive guard: a ranking judged with no positive grades scores 0 recall.
+    assert _recall_at(["a", "b"], {"a": 0, "b": 0}, 10) == 0.0

--- a/tests/unit/search/test_query_router.py
+++ b/tests/unit/search/test_query_router.py
@@ -87,3 +87,40 @@ def test_retrieval_layer_default_router_is_rules():
     layer = RetrievalLayer(_FakeBackend())
     out = layer.retrieve("Sam Altman", [0.1])
     assert {r.doc_id for r in out} == {"seg1", "ins0"}
+
+
+def test_loads_persisted_model_and_embeds(tmp_path, monkeypatch):
+    # Real joblib round-trip + real _embed (encode monkeypatched) → covers load + embed.
+    import joblib
+    from sklearn.dummy import DummyClassifier
+
+    clf = DummyClassifier(strategy="constant", constant="cross_show_synthesis")
+    clf.fit([[0.0, 0.0, 0.0]], ["cross_show_synthesis"])
+    model_path = tmp_path / "router.joblib"
+    joblib.dump(clf, model_path)
+
+    monkeypatch.setattr(
+        "podcast_scraper.providers.ml.embedding_loader.encode",
+        lambda *a, **k: [0.0, 0.0, 0.0],
+    )
+    router = MLQueryRouter(model_path)
+    assert router.classify("compare A and B") == "cross_show_synthesis"
+
+
+def test_corrupt_model_file_falls_back_to_rules(tmp_path):
+    bad = tmp_path / "bad.joblib"
+    bad.write_text("not a joblib file", encoding="utf-8")
+    router = MLQueryRouter(bad)
+    assert router.classify("Sam Altman") == "entity_lookup"  # load failed → rules
+
+
+def test_predict_exception_falls_back_to_rules():
+    class _Raises:
+        def predict(self, X):
+            raise RuntimeError("inference boom")
+
+    router = MLQueryRouter()
+    router._model = _Raises()
+    router._loaded = True
+    router._embed = lambda text: [0.0]  # type: ignore[method-assign]
+    assert router.classify("Sam Altman") == "entity_lookup"  # predict raised → rules

--- a/tests/unit/search/test_query_router.py
+++ b/tests/unit/search/test_query_router.py
@@ -89,24 +89,6 @@ def test_retrieval_layer_default_router_is_rules():
     assert {r.doc_id for r in out} == {"seg1", "ins0"}
 
 
-def test_loads_persisted_model_and_embeds(tmp_path, monkeypatch):
-    # Real joblib round-trip + real _embed (encode monkeypatched) → covers load + embed.
-    import joblib
-    from sklearn.dummy import DummyClassifier
-
-    clf = DummyClassifier(strategy="constant", constant="cross_show_synthesis")
-    clf.fit([[0.0, 0.0, 0.0]], ["cross_show_synthesis"])
-    model_path = tmp_path / "router.joblib"
-    joblib.dump(clf, model_path)
-
-    monkeypatch.setattr(
-        "podcast_scraper.providers.ml.embedding_loader.encode",
-        lambda *a, **k: [0.0, 0.0, 0.0],
-    )
-    router = MLQueryRouter(model_path)
-    assert router.classify("compare A and B") == "cross_show_synthesis"
-
-
 def test_corrupt_model_file_falls_back_to_rules(tmp_path):
     bad = tmp_path / "bad.joblib"
     bad.write_text("not a joblib file", encoding="utf-8")

--- a/tests/unit/search/test_two_tier_linking.py
+++ b/tests/unit/search/test_two_tier_linking.py
@@ -1,0 +1,55 @@
+"""Unit tests for gi.json grounding-quote extraction (RFC-090 Phase 2 / C1).
+
+No LanceDB needed — _insight_grounding_quotes is pure parsing.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from podcast_scraper.search.two_tier_indexer import _insight_grounding_quotes
+
+pytestmark = pytest.mark.unit
+
+
+def test_missing_file_returns_empty(tmp_path):
+    assert _insight_grounding_quotes(tmp_path / "none.gi.json") == {}
+
+
+def test_corrupt_file_returns_empty(tmp_path):
+    p = tmp_path / "bad.gi.json"
+    p.write_text("{ not json", encoding="utf-8")
+    assert _insight_grounding_quotes(p) == {}
+
+
+def test_extracts_first_supporting_quote_timestamps(tmp_path):
+    p = tmp_path / "g.gi.json"
+    p.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": "quote:q1",
+                        "type": "Quote",
+                        "properties": {"timestamp_start_ms": 1000, "timestamp_end_ms": 4000},
+                    },
+                    {
+                        "id": "quote:q2",
+                        "type": "Quote",
+                        "properties": {"timestamp_start_ms": 9000},
+                    },  # no end → None
+                ],
+                "edges": [
+                    {"type": "SUPPORTED_BY", "from": "insight:n1", "to": "quote:q1"},
+                    {"type": "SUPPORTED_BY", "from": "insight:n2", "to": "quote:q2"},
+                    {"type": "ABOUT", "from": "insight:n1", "to": "topic:x"},  # ignored
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = _insight_grounding_quotes(p)
+    assert out["insight:n1"] == (1.0, 4.0)
+    assert out["insight:n2"] == (9.0, None)  # missing end tolerated

--- a/tests/unit/upgrade/test_cli_handlers.py
+++ b/tests/unit/upgrade/test_cli_handlers.py
@@ -1,0 +1,68 @@
+"""Unit tests for the upgrade CLI surface (#862): list, --json, non-TTY refusal."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from podcast_scraper.upgrade.cli_handlers import parse_upgrade_argv, run_upgrade_cli
+
+pytestmark = pytest.mark.unit
+log = logging.getLogger("test")
+
+
+def _run(corpus, *argv, capsys=None):
+    args = parse_upgrade_argv([argv[0], "--corpus-dir", str(corpus), *argv[1:]])
+    return run_upgrade_cli(args, log)
+
+
+def test_missing_corpus_dir_errors(monkeypatch):
+    monkeypatch.delenv("CORPUS_DIR", raising=False)
+    monkeypatch.delenv("OUTPUT_DIR", raising=False)
+    args = parse_upgrade_argv(["status"])
+    assert run_upgrade_cli(args, log) == 1  # no --corpus-dir → error
+
+
+def test_status_json(tmp_path, capsys):
+    assert _run(tmp_path, "status", "--json") == 2  # pending → exit 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["up_to_date"] is False
+    assert "0001_faiss_to_lance" in payload["pending"]
+
+
+def test_list_text_and_json(tmp_path, capsys):
+    assert _run(tmp_path, "list") == 0
+    assert "0001_faiss_to_lance" in capsys.readouterr().out
+    assert _run(tmp_path, "list", "--json") == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert all(r["state"] == "pending" for r in rows)
+
+
+def test_verify_json_with_nothing_applied(tmp_path, capsys):
+    assert _run(tmp_path, "verify", "--json") == 0  # nothing applied → vacuously ok
+    assert json.loads(capsys.readouterr().out) == []
+
+
+def test_run_without_yes_refuses_on_non_tty(tmp_path, capsys):
+    # pytest stdin is not a TTY → must refuse (safety gate), not apply.
+    assert _run(tmp_path, "run") == 1
+    assert "Aborted" in capsys.readouterr().out
+    assert not (tmp_path / "upgrade_ledger.json").exists()
+
+
+def test_run_up_to_date_is_noop(tmp_path, monkeypatch, capsys):
+    # Force "nothing pending" so the up-to-date branch runs.
+    from podcast_scraper.upgrade import cli_handlers
+
+    class _UpToDate:
+        state = type("S", (), {"current_version": staticmethod(lambda: "2.7.0")})()
+
+        def status(self):
+            return type("St", (), {"pending": []})()
+
+    monkeypatch.setattr(cli_handlers, "_runner_for", lambda root: _UpToDate())
+    args = parse_upgrade_argv(["run", "--corpus-dir", str(tmp_path), "--yes"])
+    assert run_upgrade_cli(args, log) == 0
+    assert "Up to date" in capsys.readouterr().out

--- a/tests/unit/upgrade/test_migration_0001.py
+++ b/tests/unit/upgrade/test_migration_0001.py
@@ -1,0 +1,31 @@
+"""Unit tests for migration 0001 verify branches (#858/#862)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.faiss_store import VECTORS_FILE
+from podcast_scraper.upgrade.migration import MigrationContext
+from podcast_scraper.upgrade.migrations.m0001_faiss_to_lance import FaissToLanceMigration
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx(tmp_path):
+    return MigrationContext(corpus_root=tmp_path)
+
+
+def test_verify_noop_when_no_faiss(tmp_path):
+    ok, msg = FaissToLanceMigration().verify(_ctx(tmp_path))
+    assert ok and "no source" in msg  # nothing to migrate → vacuously ok
+
+
+def test_verify_fails_when_faiss_present_but_lance_missing(tmp_path):
+    (tmp_path / "search").mkdir()
+    (tmp_path / "search" / VECTORS_FILE).write_text("", encoding="utf-8")  # FAISS exists
+    ok, msg = FaissToLanceMigration().verify(_ctx(tmp_path))  # but no lance_index
+    assert not ok and "missing" in msg
+
+
+def test_plan_noop_string_when_no_faiss(tmp_path):
+    assert "nothing to migrate" in FaissToLanceMigration().plan(_ctx(tmp_path))

--- a/tests/unit/upgrade/test_migration_0002.py
+++ b/tests/unit/upgrade/test_migration_0002.py
@@ -52,3 +52,10 @@ def test_dry_run_does_not_build(tmp_path, monkeypatch):
     monkeypatch.setattr(two_tier_indexer, "build_two_tier_index", _boom)
     result = TwoTierNativeReindexMigration().apply(_ctx(tmp_path, dry_run=True))
     assert result.applied is False and result.dry_run is True
+
+
+def test_plan_strings(tmp_path):
+    m = TwoTierNativeReindexMigration()
+    assert "natively" in m.plan(_ctx(tmp_path)).lower()  # no index → native build planned
+    (tmp_path / "search" / "lance_index").mkdir(parents=True)
+    assert "no-op" in m.plan(_ctx(tmp_path)).lower()  # index present → no-op

--- a/tests/unit/upgrade/test_migration_0002.py
+++ b/tests/unit/upgrade/test_migration_0002.py
@@ -1,0 +1,54 @@
+"""Unit tests for the native two-tier reindex migration (0002, #862 / B).
+
+Stubs ``build_two_tier_index`` so the migration's own gating logic — no-op when an
+index exists, build when absent, dry-run — is tested without LanceDB.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search import two_tier_indexer
+from podcast_scraper.upgrade.migration import MigrationContext
+from podcast_scraper.upgrade.migrations.m0002_two_tier_native_reindex import (
+    TwoTierNativeReindexMigration,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx(tmp_path, dry_run=False):
+    return MigrationContext(corpus_root=tmp_path, dry_run=dry_run)
+
+
+def test_noop_when_index_already_exists(tmp_path, monkeypatch):
+    (tmp_path / "search" / "lance_index").mkdir(parents=True)  # 0001 already built it
+
+    def _boom(*a, **k):
+        raise AssertionError("must not rebuild when an index already exists")
+
+    monkeypatch.setattr(two_tier_indexer, "build_two_tier_index", _boom)
+    result = TwoTierNativeReindexMigration().apply(_ctx(tmp_path))
+    assert result.applied and "no-op" in result.message
+
+
+def test_builds_natively_when_absent(tmp_path, monkeypatch):
+    calls = {}
+
+    def _fake(corpus, lance, **k):
+        calls["corpus"] = corpus
+        return two_tier_indexer.TwoTierIndexStats(episodes=3, segments=10, insights=7)
+
+    monkeypatch.setattr(two_tier_indexer, "build_two_tier_index", _fake)
+    result = TwoTierNativeReindexMigration().apply(_ctx(tmp_path))
+    assert result.applied and result.details["segments"] == 10
+    assert calls["corpus"] == tmp_path  # built from the corpus root
+
+
+def test_dry_run_does_not_build(tmp_path, monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("dry-run must not build")
+
+    monkeypatch.setattr(two_tier_indexer, "build_two_tier_index", _boom)
+    result = TwoTierNativeReindexMigration().apply(_ctx(tmp_path, dry_run=True))
+    assert result.applied is False and result.dry_run is True

--- a/tests/unit/upgrade/test_runner.py
+++ b/tests/unit/upgrade/test_runner.py
@@ -123,3 +123,13 @@ def test_verify_only_applied(tmp_path):
     runner.run(_ctx(tmp_path), to_version="2.7.0", now="t")  # only m1 applied
     verify = runner.verify(_ctx(tmp_path))
     assert verify == [("0001_a", True, "verified")]  # m2 not applied → not verified
+
+
+def test_invalid_to_version_is_gated_out(tmp_path):
+    # A migration with a non-PEP440 to_version maps to Version("0") and is gated below
+    # any real --to ceiling (covers _as_version fallback).
+    store = _FakeStore("2.6.0")
+    runner = UpgradeRunner(store, [_FakeMigration("0001_a", "not-a-version")])
+    runner.run(_ctx(tmp_path), to_version="2.7.0", now="t")
+    assert store.applied_migration_ids() == {"0001_a"}  # Version("0") <= 2.7.0 → applied
+    assert runner._as_version("nonsense") == runner._as_version("0")


### PR DESCRIPTION
## Summary

RFC-090 Phase 2 (wire hybrid retrieval live) **plus a full audit-driven hardening pass**. Replaces #864 (which was stacked on the now-merged #863 branch); rebased clean onto `main`.

Before adding this, we ran a deep code↔tests↔docs audit. It surfaced one **dead feature** and three **high-severity latent bugs** in the Phase-2 work — all fixed here, with tests.

## Phase 2 (the feature)

| # | What |
|---|---|
| **A** | Route `GET /api/search` through the two-tier hybrid `RetrievalLayer` (opt-in `serving.hybrid_enabled`, FAISS fallback, identical response shape) |
| **B** | From-corpus two-tier indexer + `index-two-tier` CLI/make (fresh corpora, no FAISS needed) |
| **C** | Native reindex migration `0002` (guarantees an index even when `0001` no-ops) |
| **D** | Human-judged hybrid-vs-FAISS eval harness (RFC-057) — the discriminating gate for #858/#860 |

## Audit fixes (the hardening)

- **C1 — compound results were dead end-to-end.** Neither writer set `linked_insight_ids`/`source_segment_id`, so `dedup` always no-op'd. The native indexer now links insight→segment from gi.json `SUPPORTED_BY` edges + quote timestamps; an end-to-end test proves a `CompoundResult` actually fires. `dedup` went from **0 tests → fully covered**.
- **H1 — hybrid was un-enablable in prod.** Config was read via a CWD-relative path the API image never shipped. Added an env override (`PODCAST_HYBRID_SEARCH`) + robust locator, shipped `config/search.yaml` in the image, and **wired the ML router (#860) into serving** (it previously had no caller).
- **H2/H3 — embedding-model blindness.** The index stored no model id and the query hardcoded MiniLM → silent wrong results / dim-mismatch on any other model. Now the index records model+dim, the query embeds in that space and bails to FAISS on mismatch, and the native indexer derives `embed_dim` from the model (a non-MiniLM `--embedding-model` no longer corrupts the schema).
- **MED/LOW:** read path no longer auto-creates empty tables; `delete("all")` hits both tiers; `migration.create_indices` guarded on empty; `m0002` verify no longer tautological; consistent router embed (no inference-time download).
- **Docs drift:** stale `RetrievalLayer.retrieve` sketches, the "no such class" CorpusGraph comment, ghost make targets, `podcast upgrade` invocation, reserved config keys, and the RFC-092 ONNX abstract — all corrected.

## Coverage (the original #863 codecov/patch failure)

Added the missing branch tests: all 6 hybrid FAISS-fallback paths, the index-two-tier CLI, the upgrade CLI surface (`list`/`--json`/non-TTY refusal), runner invalid-version gating, m0001 verify-failure, query-router load/fallback/predict-raises, dedup, judged-eval guards. New-module coverage: hybrid_search 92%, two_tier_indexer 95%, upgrade cli 93%, dedup/judged_eval/query_router ~100%.

`make ci-fast` green.

Supersedes #864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
