### PR TITLE
feat(search): coverage + full-coverage aux tier + LLM-judge eval (post-#865)

### DIFF
--- a/scripts/eval_hybrid_judged.py
+++ b/scripts/eval_hybrid_judged.py
@@ -15,9 +15,19 @@ Two modes:
             backend + the verdict.
               python scripts/eval_hybrid_judged.py score --judged template.jsonl
 
-Between the two, a human opens the template and fills `relevance` (0=irrelevant,
-1=related, 2=on-point) for the candidates that matter. The same queries carry an
-`intent` label (seeds #860 training data).
+  auto      Synthesize queries (or read --queries), run both backends, grade with an
+            LLM-as-judge, score, and write a graded JSONL for a human spot-check.
+              python scripts/eval_hybrid_judged.py auto \
+                  --corpus-dir CORPUS --synthesize 40 --model gpt-4o-mini
+
+Between template/score, a human fills `relevance` (0=irrelevant, 1=related,
+2=on-point); `auto` does it with an LLM and you validate a sample. The same queries
+carry an `intent` label (seeds #860 training data).
+
+Caveat: synthesized queries derive from the corpus's own kg surfaces, so they retain
+home-field bias toward FAISS even with question templates. A trustworthy FAISS-removal
+/ ML-promotion verdict needs REAL user queries (`--queries`) + a human spot-check of
+the LLM grades. Treat synthesized verdicts as directional only.
 """
 
 from __future__ import annotations
@@ -25,6 +35,7 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import json
+import os
 import sys
 from pathlib import Path
 from typing import List, Sequence, Tuple
@@ -127,8 +138,124 @@ def _cmd_score(args: argparse.Namespace) -> int:
     return 0
 
 
+def _load_dotenv(path: str = ".env") -> None:
+    p = Path(path)
+    if not p.is_file():
+        return
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            key, _, val = line.partition("=")
+            os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
+_TOPIC_TEMPLATES = [
+    "how does {x} affect markets",
+    "what are the risks of {x}",
+    "explain the debate around {x}",
+    "why does {x} matter for investors",
+]
+_ENTITY_TEMPLATES = [
+    "what is {x}'s view",
+    "what did experts say about {x}",
+    "how is {x} positioned",
+]
+
+
+def _synthesize_queries(corpus_dir: Path, n: int) -> List[str]:
+    """Bootstrap queries from corpus kg_entity/kg_topic surfaces (no live traffic).
+
+    Uses natural-question TEMPLATES rather than the bare surface label — a bare label
+    is a known-item gift to FAISS (it exact-matches its own kg node). This reduces, but
+    does not remove, the home-field bias: a truly fair eval uses REAL user queries via
+    ``--queries``. Treat synthesized verdicts as directional only.
+    """
+    store = FaissVectorStore.load(corpus_dir / "search")
+    people, topics = [], []
+    for meta in store.metadata_by_doc_id.values():
+        txt = (meta.get("text") or "").strip()
+        if not txt or len(txt) > 50:
+            continue
+        if meta.get("doc_type") == "kg_entity":
+            people.append(txt)
+        elif meta.get("doc_type") == "kg_topic":
+            topics.append(txt)
+    people = list(dict.fromkeys(people))
+    topics = list(dict.fromkeys(topics))
+    out: List[str] = []
+    for i in range(n):
+        if topics and (i % 2 == 0 or not people):
+            tmpl = _TOPIC_TEMPLATES[i % len(_TOPIC_TEMPLATES)]
+            out.append(tmpl.format(x=topics[i % len(topics)]))
+        elif people:
+            tmpl = _ENTITY_TEMPLATES[i % len(_ENTITY_TEMPLATES)]
+            out.append(tmpl.format(x=people[i % len(people)]))
+    return out[:n]
+
+
+def _openai_complete(model: str):
+    from openai import OpenAI
+
+    client = OpenAI()
+
+    def complete(prompt: str) -> str:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+        )
+        return resp.choices[0].message.content or ""
+
+    return complete
+
+
+def _cmd_auto(args: argparse.Namespace) -> int:
+    from podcast_scraper.search.llm_judge import grade_records
+
+    corpus = Path(args.corpus_dir)
+    if not lance_index_dir(corpus).exists():
+        print(f"No LanceDB index at {lance_index_dir(corpus)} — run `make index-two-tier` first.")
+        return 1
+    _load_dotenv()
+    if args.queries:
+        queries = [ln.strip() for ln in Path(args.queries).read_text().splitlines() if ln.strip()]
+    else:
+        queries = _synthesize_queries(corpus, args.synthesize)
+    print(f"Queries: {len(queries)} ({'file' if args.queries else 'synthesized'})")
+
+    records = build_judgment_template(
+        queries,
+        faiss_ranks=_faiss_ranks(corpus, args.k),
+        hybrid_ranks=_hybrid_ranks(corpus, args.k),
+        intent_of=classify_query,
+        k=args.k,
+    )
+    print(f"Grading {len(records)} records with {args.model} (LLM-as-judge) ...")
+    grade_records(records, _openai_complete(args.model))
+
+    with Path(args.out).open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(dataclasses.asdict(rec)) + "\n")
+
+    scores = score_from_judgments(records, k=args.k)
+    n = int(scores["_judged_count"]["n"])
+    print(f"\nGraded → {args.out}  (spot-check a sample to validate the judge)")
+    print(f"Judged with signal: {n}/{len(records)}")
+    print(f"\n  backend   nDCG@{args.k}   recall@{args.k}")
+    for b in ("faiss", "hybrid"):
+        print(f"  {b:7s}  {scores[b]['ndcg']:8.3f}  {scores[b]['recall']:8.3f}")
+    dn = scores["hybrid"]["ndcg"] - scores["faiss"]["ndcg"]
+    verdict = (
+        "PASS — hybrid >= FAISS (unblocks #858 + #860)"
+        if dn > 0.02 and n >= 30
+        else f"INCONCLUSIVE — Δ nDCG={dn:+.3f}, n={n} (want clear margin over >=30)"
+    )
+    print(f"\n  Δ nDCG = {dn:+.3f}\n  VERDICT: {verdict}")
+    return 0
+
+
 def main() -> int:
-    """Dispatch the template / score subcommand."""
+    """Dispatch the template / score / auto subcommand."""
     ap = argparse.ArgumentParser(description=__doc__)
     sub = ap.add_subparsers(dest="cmd", required=True)
     t = sub.add_parser("template", help="build a judgment template")
@@ -139,8 +266,19 @@ def main() -> int:
     s = sub.add_parser("score", help="score graded judgments")
     s.add_argument("--judged", required=True)
     s.add_argument("--k", type=int, default=10)
+    a = sub.add_parser("auto", help="synthesize queries, run both backends, LLM-grade, score")
+    a.add_argument("--corpus-dir", required=True)
+    a.add_argument("--queries", default=None, help="query file (else synthesize from corpus)")
+    a.add_argument("--synthesize", type=int, default=40, help="N queries when --queries absent")
+    a.add_argument("--model", default="gpt-4o-mini")
+    a.add_argument("--out", default="judged_auto.jsonl")
+    a.add_argument("--k", type=int, default=10)
     args = ap.parse_args()
-    return _cmd_template(args) if args.cmd == "template" else _cmd_score(args)
+    if args.cmd == "template":
+        return _cmd_template(args)
+    if args.cmd == "score":
+        return _cmd_score(args)
+    return _cmd_auto(args)
 
 
 if __name__ == "__main__":

--- a/src/podcast_scraper/search/backend.py
+++ b/src/podcast_scraper/search/backend.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Literal, Optional, Protocol, runtime_checkable
 
-Tier = Literal["segment", "insight", "all"]
+# segment = Tier 1 (transcript), insight = Tier 2 (GIL), aux = the other corpus
+# surfaces FAISS also indexes (kg_entity / kg_topic / quote / summary) so hybrid
+# doesn't lose coverage vs FAISS (RFC-090 full-coverage follow-up). "all" spans them.
+Tier = Literal["segment", "insight", "aux", "all"]
 
 
 @dataclass
@@ -48,6 +51,20 @@ class InsightDocument:
     speaker_id: Optional[str] = None
     source_segment_id: Optional[str] = None  # back-ref to grounding-quote segment
     source_tier: str = "insight"
+
+
+@dataclass
+class AuxDocument:
+    """A non-tiered corpus surface FAISS also indexes (kg_entity / kg_topic / quote /
+    summary) — kept so hybrid retrieval covers the same doc types as FAISS."""
+
+    id: str
+    text: str
+    show_id: str
+    episode_id: str
+    doc_type: str  # kg_entity | kg_topic | quote | summary
+    embedding: List[float] = field(default_factory=list)
+    source_tier: str = "aux"
 
 
 @dataclass
@@ -110,6 +127,10 @@ class SearchBackend(Protocol):
 
     def upsert_insight(self, doc: InsightDocument) -> None:
         """Insert or update a Tier-2 insight document."""
+        ...
+
+    def upsert_aux(self, doc: "AuxDocument") -> None:
+        """Insert or update an aux document (kg_entity / kg_topic / quote / summary)."""
         ...
 
     def delete(self, doc_id: str, tier: Tier) -> None:

--- a/src/podcast_scraper/search/backends/lancedb_backend.py
+++ b/src/podcast_scraper/search/backends/lancedb_backend.py
@@ -18,7 +18,14 @@ from ...utils.path_validation import (
     safe_relpath_under_corpus_root,
     safe_resolve_directory,
 )
-from ..backend import InsightDocument, ScoredResult, SearchQuery, SegmentDocument, Tier
+from ..backend import (
+    AuxDocument,
+    InsightDocument,
+    ScoredResult,
+    SearchQuery,
+    SegmentDocument,
+    Tier,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import pyarrow as pa
@@ -28,6 +35,7 @@ DEFAULT_EMBED_DIM = 384
 
 _SEGMENT_TABLE = "segments"
 _INSIGHT_TABLE = "insights"
+_AUX_TABLE = "aux"
 
 
 def _segment_schema(dim: int) -> "pa.Schema":
@@ -69,10 +77,26 @@ def _insight_schema(dim: int) -> "pa.Schema":
     )
 
 
-class LanceDBBackend:
-    """Embedded LanceDB backend (segments + insights), BM25 + vector per tier."""
+def _aux_schema(dim: int) -> "pa.Schema":
+    import pyarrow as pa
 
-    TABLES = {"segment": _SEGMENT_TABLE, "insight": _INSIGHT_TABLE}
+    return pa.schema(
+        [
+            ("id", pa.string()),
+            ("text", pa.string()),
+            ("embedding", pa.list_(pa.float32(), dim)),
+            ("show_id", pa.string()),
+            ("episode_id", pa.string()),
+            ("doc_type", pa.string()),  # kg_entity | kg_topic | quote | summary
+            ("source_tier", pa.string()),
+        ]
+    )
+
+
+class LanceDBBackend:
+    """Embedded LanceDB backend (segments + insights + aux), BM25 + vector per tier."""
+
+    TABLES = {"segment": _SEGMENT_TABLE, "insight": _INSIGHT_TABLE, "aux": _AUX_TABLE}
 
     INDEX_META_FILE = "index_meta.json"
 
@@ -151,23 +175,23 @@ class LanceDBBackend:
         self._tables[tier] = table
         return table
 
+    _SCHEMAS = {"segment": _segment_schema, "insight": _insight_schema, "aux": _aux_schema}
+
     def _ensure_table(self, tier: str):
         table = self._open_if_exists(tier)
         if table is not None:
             return table
-        schema = (
-            _segment_schema(self.embed_dim)
-            if tier == "segment"
-            else _insight_schema(self.embed_dim)
-        )
+        schema = self._SCHEMAS[tier](self.embed_dim)
         table = self.db.create_table(self.TABLES[tier], schema=schema)
         self._tables[tier] = table
         return table
 
     def create_indices(self) -> None:
-        """Create FTS (required for BM25) + vector indices on both tables."""
-        for tier in ("segment", "insight"):
-            table = self._ensure_table(tier)
+        """Create FTS (required for BM25) + vector indices on all tables that exist."""
+        for tier in ("segment", "insight", "aux"):
+            table = self._open_if_exists(tier)
+            if table is None:
+                continue  # tier never populated (e.g. a corpus with no kg/quote rows)
             table.create_fts_index("text", replace=True)
             try:
                 table.create_index(vector_column_name="embedding", replace=True)
@@ -176,7 +200,7 @@ class LanceDBBackend:
 
     def _tables_for_tier(self, tier: Tier) -> List[str]:
         if tier == "all":
-            return ["segment", "insight"]
+            return ["segment", "insight", "aux"]
         return [tier]
 
     # --- retrieval -------------------------------------------------------------
@@ -246,9 +270,13 @@ class LanceDBBackend:
         """Insert or update a Tier-2 insight document."""
         self._upsert("insight", dataclasses.asdict(doc))
 
+    def upsert_aux(self, doc: AuxDocument) -> None:
+        """Insert or update an aux document (kg_entity / kg_topic / quote / summary)."""
+        self._upsert("aux", dataclasses.asdict(doc))
+
     def delete(self, doc_id: str, tier: Tier) -> None:
-        """Delete a document by id; ``tier="all"`` removes from both tables."""
-        tiers = ("segment", "insight") if tier == "all" else (tier,)
+        """Delete a document by id; ``tier="all"`` removes from every table."""
+        tiers = ("segment", "insight", "aux") if tier == "all" else (tier,)
         for t in tiers:
             table = self._open_if_exists(t)
             if table is not None:
@@ -259,10 +287,12 @@ class LanceDBBackend:
         try:
             seg = self._open_if_exists("segment")
             ins = self._open_if_exists("insight")
+            aux = self._open_if_exists("aux")
             return {
                 "status": "ok",
                 "segments": seg.count_rows() if seg is not None else 0,
                 "insights": ins.count_rows() if ins is not None else 0,
+                "aux": aux.count_rows() if aux is not None else 0,
             }
         except Exception as exc:  # noqa: BLE001
             return {"status": "error", "error": str(exc)}

--- a/src/podcast_scraper/search/cli_handlers.py
+++ b/src/podcast_scraper/search/cli_handlers.py
@@ -1385,7 +1385,7 @@ def run_index_two_tier_cli(args: Namespace, logger: logging.Logger) -> int:
         allow_download=bool(getattr(args, "allow_download", False)),
     )
     print(
-        f"Two-tier index built at {lance_path}: "
-        f"episodes={stats.episodes} segments={stats.segments} insights={stats.insights}"
+        f"Two-tier index built at {lance_path}: episodes={stats.episodes} "
+        f"segments={stats.segments} insights={stats.insights} aux={stats.aux}"
     )
     return EXIT_SUCCESS

--- a/src/podcast_scraper/search/fusion.py
+++ b/src/podcast_scraper/search/fusion.py
@@ -14,7 +14,8 @@ from typing import Dict, List, Optional, Sequence
 from .backend import ScoredResult
 
 # Default tier weights: insights are grounded signal, slight boost is appropriate.
-TIER_WEIGHTS: Dict[str, float] = {"insight": 1.2, "segment": 1.0}
+# ``aux`` (kg/quote/summary) defaults to 1.0; unlisted tiers also fall back to 1.0.
+TIER_WEIGHTS: Dict[str, float] = {"insight": 1.2, "segment": 1.0, "aux": 1.0}
 
 
 def rrf_fuse(

--- a/src/podcast_scraper/search/hybrid_search.py
+++ b/src/podcast_scraper/search/hybrid_search.py
@@ -96,8 +96,11 @@ def lance_index_dir(output_dir: Path) -> Path:
     return Path(output_dir) / "search" / "lance_index"
 
 
+_AUX_DOC_TYPES = frozenset({"kg_entity", "kg_topic", "quote", "summary"})
+
+
 def _tier_for(doc_types: Optional[Sequence[str]]) -> Tier:
-    """Map requested doc types to a two-tier scope (insight | segment | all)."""
+    """Map requested doc types to a tier scope (insight | segment | aux | all)."""
     if not doc_types:
         return "all"
     wanted = {t.strip().lower() for t in doc_types if isinstance(t, str) and t.strip()}
@@ -105,18 +108,24 @@ def _tier_for(doc_types: Optional[Sequence[str]]) -> Tier:
         return "insight"
     if wanted <= {"transcript", "segment"}:
         return "segment"
+    if wanted <= _AUX_DOC_TYPES:
+        return "aux"
     return "all"
 
 
-def _doc_type_for_tier(source_tier: str) -> str:
-    # Segments are transcript chunks in the FAISS vocabulary the enrich/lift expects.
-    return "insight" if source_tier == "insight" else "transcript"
+def _doc_type_for_result(result: ScoredResult, payload: Dict) -> str:
+    # Segment = transcript in the FAISS vocab; aux rows carry their own doc_type.
+    if result.source_tier == "insight":
+        return "insight"
+    if result.source_tier == "aux":
+        return str(payload.get("doc_type") or "aux")
+    return "transcript"
 
 
 def _to_search_result(result: ScoredResult) -> SearchResult:
     payload = dict(result.payload or {})
     metadata = {
-        "doc_type": _doc_type_for_tier(result.source_tier),
+        "doc_type": _doc_type_for_result(result, payload),
         "text": payload.get("text", ""),
         "episode_id": payload.get("episode_id", ""),
         "feed_id": payload.get("show_id", ""),

--- a/src/podcast_scraper/search/llm_judge.py
+++ b/src/podcast_scraper/search/llm_judge.py
@@ -1,0 +1,83 @@
+"""LLM-as-judge relevance grading for the hybrid-vs-FAISS eval (RFC-057 / Step 2).
+
+Turns the human-grading bottleneck into a spot-check: an LLM grades each (query,
+candidate) for relevance (0 irrelevant / 1 related / 2 directly answers), filling a
+``JudgmentRecord.relevance`` so ``judged_eval.score_from_judgments`` can produce
+discriminating nDCG/recall per backend. A human then validates a small sample.
+
+The module is dependency-free and testable: the actual model call is injected as a
+``complete: Callable[[str], str]`` (prompt → response text), so unit tests use a fake
+and the script (``eval_hybrid_judged.py auto``) passes a real OpenAI-backed callable.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Callable, Dict, List, Sequence
+
+from .judged_eval import JudgmentRecord
+
+Complete = Callable[[str], str]
+
+_GRADE_RANGE = (0, 1, 2)
+
+
+def build_grading_prompt(record: JudgmentRecord) -> str:
+    """Build the grading prompt: query + numbered candidates → ask for a JSON map."""
+    lines = [
+        "You are grading podcast-corpus search results for relevance.",
+        f'Query: "{record.query}"',
+        "",
+        "Rate EACH result: 0 = irrelevant, 1 = related, 2 = directly answers the query.",
+        'Return ONLY a JSON object mapping doc_id to grade, e.g. {"a": 2, "b": 0}.',
+        "",
+        "Results:",
+    ]
+    for cand in record.candidates:
+        text = (cand.get("text") or "")[:400].replace("\n", " ")
+        lines.append(f'- id={cand.get("doc_id")}: {text}')
+    return "\n".join(lines)
+
+
+def parse_grades(response: str, candidate_ids: Sequence[str]) -> Dict[str, int]:
+    """Extract a ``{doc_id: grade}`` map from the model's response (robust to prose).
+
+    Only ids in *candidate_ids* are kept; grades are clamped to 0/1/2; unparseable →
+    empty (the record is then skipped as having no signal).
+    """
+    match = re.search(r"\{.*\}", response, re.DOTALL)
+    if not match:
+        return {}
+    try:
+        raw = json.loads(match.group(0))
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    valid = set(candidate_ids)
+    out: Dict[str, int] = {}
+    for doc_id, grade in raw.items():
+        if doc_id in valid:
+            try:
+                g = int(grade)
+            except (ValueError, TypeError):
+                continue
+            out[doc_id] = g if g in _GRADE_RANGE else max(0, min(2, g))
+    return out
+
+
+def grade_record(record: JudgmentRecord, complete: Complete) -> JudgmentRecord:
+    """Fill *record.relevance* by asking the model to grade its candidates."""
+    ids = [c.get("doc_id") for c in record.candidates]
+    try:
+        response = complete(build_grading_prompt(record))
+    except Exception:  # noqa: BLE001 - a failed grade leaves the record unjudged
+        return record
+    record.relevance = parse_grades(response, [i for i in ids if i])
+    return record
+
+
+def grade_records(records: Sequence[JudgmentRecord], complete: Complete) -> List[JudgmentRecord]:
+    """Grade every record in place; returns the list for convenience."""
+    return [grade_record(r, complete) for r in records]

--- a/src/podcast_scraper/search/llm_judge.py
+++ b/src/podcast_scraper/search/llm_judge.py
@@ -43,7 +43,7 @@ def build_grading_prompt(record: JudgmentRecord) -> str:
 def parse_grades(response: str, candidate_ids: Sequence[str]) -> Dict[str, int]:
     """Extract a ``{doc_id: grade}`` map from the model's response (robust to prose).
 
-    Only ids in *candidate_ids* are kept; grades are clamped to 0/1/2; unparseable →
+    Only ids in *candidate_ids* are kept; grades are clamped to 0/1/2; unparsable →
     empty (the record is then skipped as having no signal).
     """
     match = re.search(r"\{.*\}", response, re.DOTALL)

--- a/src/podcast_scraper/search/migration.py
+++ b/src/podcast_scraper/search/migration.py
@@ -30,9 +30,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
 
-from .backend import InsightDocument, SegmentDocument
+from .backend import AuxDocument, InsightDocument, SegmentDocument
 from .backends.lancedb_backend import LanceDBBackend
 from .faiss_store import FaissVectorStore
+
+# Non-tiered FAISS surfaces carried into the aux tier for full hybrid coverage.
+_AUX_DOC_TYPES = frozenset({"kg_entity", "kg_topic", "quote", "summary"})
 
 
 @dataclass
@@ -41,8 +44,20 @@ class MigrationStats:
 
     segments: int = 0
     insights: int = 0
+    aux: int = 0
     skipped: int = 0
     embed_dim: int = 0
+
+
+def _aux_from_faiss(doc_id: str, meta: Dict, embedding: list) -> AuxDocument:
+    return AuxDocument(
+        id=doc_id,
+        text=meta.get("text") or "",
+        show_id=meta.get("feed_id") or "",
+        episode_id=meta.get("episode_id") or "",
+        doc_type=str(meta.get("doc_type") or ""),
+        embedding=embedding,
+    )
 
 
 def _segment_from_faiss(doc_id: str, meta: Dict, embedding: list) -> SegmentDocument:
@@ -108,11 +123,16 @@ def migrate_faiss_to_lance(
                 continue
             backend.upsert_insight(_insight_from_faiss(doc_id, meta, emb))
             stats.insights += 1
+        elif doc_type in _AUX_DOC_TYPES:
+            if limit_per_tier is not None and stats.aux >= limit_per_tier:
+                continue
+            backend.upsert_aux(_aux_from_faiss(doc_id, meta, emb))
+            stats.aux += 1
         else:
             stats.skipped += 1
 
     # Record the model so the query path embeds in the same space (else silent mismatch).
     backend.write_index_meta(store.embedding_model)
-    if stats.segments or stats.insights:
+    if stats.segments or stats.insights or stats.aux:
         backend.create_indices()
     return stats

--- a/src/podcast_scraper/search/router.py
+++ b/src/podcast_scraper/search/router.py
@@ -50,12 +50,15 @@ SIGNAL_WEIGHTS: Dict[str, Dict[str, float]] = {
 }
 
 # Tier weights per query type (override the RRF defaults).
+# ``aux`` = kg_entity/kg_topic/quote/summary (RFC-090 full-coverage tier). It ranks
+# highest for entity_lookup (kg surfaces are the answer) and lowest for raw_evidence
+# (segments/quotes are). Unlisted tiers default to 1.0 in rrf_fuse.
 TIER_WEIGHTS_BY_QUERY: Dict[str, Dict[str, float]] = {
-    "entity_lookup": {"insight": 1.3, "segment": 0.9},
-    "raw_evidence": {"insight": 0.9, "segment": 1.3},
-    "temporal_tracking": {"insight": 1.2, "segment": 1.0},
-    "cross_show_synthesis": {"insight": 1.2, "segment": 1.0},
-    "semantic": {"insight": 1.2, "segment": 1.0},
+    "entity_lookup": {"insight": 1.3, "segment": 0.9, "aux": 1.3},
+    "raw_evidence": {"insight": 0.9, "segment": 1.3, "aux": 0.8},
+    "temporal_tracking": {"insight": 1.2, "segment": 1.0, "aux": 1.0},
+    "cross_show_synthesis": {"insight": 1.2, "segment": 1.0, "aux": 1.1},
+    "semantic": {"insight": 1.2, "segment": 1.0, "aux": 1.0},
 }
 
 

--- a/src/podcast_scraper/search/two_tier_indexer.py
+++ b/src/podcast_scraper/search/two_tier_indexer.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import cast, Dict, List, Optional, Tuple
 
 from ..providers.ml import embedding_loader
-from .backend import InsightDocument, SegmentDocument
+from .backend import AuxDocument, InsightDocument, SegmentDocument
 from .backends.lancedb_backend import LanceDBBackend
 from .corpus_scope import discover_metadata_files, episode_root_from_metadata_path
 from .indexer import _collect_docs_for_episode, _gi_path, _load_metadata_file
@@ -35,6 +35,9 @@ DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 DEFAULT_TARGET_TOKENS = 256
 DEFAULT_OVERLAP_TOKENS = 32
 
+# Non-tiered FAISS surfaces indexed into the aux tier for full coverage.
+_AUX_DOC_TYPES = frozenset({"kg_entity", "kg_topic", "quote", "summary"})
+
 
 @dataclass
 class TwoTierIndexStats:
@@ -43,6 +46,7 @@ class TwoTierIndexStats:
     episodes: int = 0
     segments: int = 0
     insights: int = 0
+    aux: int = 0
     linked: int = 0
 
 
@@ -138,6 +142,7 @@ def build_two_tier_index(
         # source_segment_id are populated (the compound-result path needs them).
         seg_docs: List[SegmentDocument] = []
         ins_docs: List[InsightDocument] = []
+        aux_docs: List[AuxDocument] = []
         node_id_by_insight: Dict[str, Optional[str]] = {}
         for doc_id, text, meta in rows:
             doc_type = meta.get("doc_type")
@@ -167,6 +172,17 @@ def build_two_tier_index(
                         embedding=_embed(text, model_id, allow_download=allow_download),
                     )
                 )
+            elif doc_type in _AUX_DOC_TYPES:
+                aux_docs.append(
+                    AuxDocument(
+                        id=doc_id,
+                        text=text,
+                        show_id=meta.get("feed_id") or "",
+                        episode_id=meta.get("episode_id") or "",
+                        doc_type=doc_type,
+                        embedding=_embed(text, model_id, allow_download=allow_download),
+                    )
+                )
 
         grounding = _insight_grounding_quotes(_gi_path(episode_root, meta_path, doc))
         insight_quotes = [
@@ -186,6 +202,9 @@ def build_two_tier_index(
         for ins in ins_docs:
             _ensure_backend(len(ins.embedding)).upsert_insight(ins)
             stats.insights += 1
+        for aux in aux_docs:
+            _ensure_backend(len(aux.embedding)).upsert_aux(aux)
+            stats.aux += 1
 
     if backend is not None:
         backend.write_index_meta(model_id)  # query path must embed in the same space

--- a/tests/integration/search/test_aux_tier.py
+++ b/tests/integration/search/test_aux_tier.py
@@ -1,0 +1,76 @@
+"""Aux-tier coverage: kg/quote/summary indexed + searchable (RFC-090 full coverage)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+pytest.importorskip("lancedb")
+
+from podcast_scraper.providers.ml import embedding_loader  # noqa: E402
+from podcast_scraper.search import two_tier_indexer as tti  # noqa: E402
+from podcast_scraper.search.backend import AuxDocument, SearchQuery  # noqa: E402
+from podcast_scraper.search.backends.lancedb_backend import LanceDBBackend  # noqa: E402
+
+_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def _emb(t):
+    return list(embedding_loader.encode(t, _MODEL, return_numpy=False, allow_download=True))
+
+
+def test_backend_upsert_search_delete_aux(tmp_path):
+    b = LanceDBBackend(str(tmp_path / "lance"), embed_dim=384)
+    b.upsert_aux(
+        AuxDocument(
+            id="kg_topic:1",
+            text="interest rates",
+            show_id="A",
+            episode_id="e1",
+            doc_type="kg_topic",
+            embedding=_emb("interest rates"),
+        )
+    )
+    b.create_indices()
+
+    assert b.health()["aux"] == 1
+    hits = b.search_bm25(SearchQuery(text="interest rates", embedding=[], tier="aux"))
+    assert any(h.doc_id == "kg_topic:1" and h.source_tier == "aux" for h in hits)
+    # "all" tier spans aux too.
+    assert any(
+        h.doc_id == "kg_topic:1"
+        for h in b.search_bm25(SearchQuery(text="interest rates", embedding=[], tier="all"))
+    )
+
+    b.delete("kg_topic:1", "all")  # all-tier delete must hit aux
+    assert b.health()["aux"] == 0
+
+
+def test_indexer_routes_aux_doc_types(tmp_path, monkeypatch):
+    rows = [
+        ("kg_topic:1", "oil markets", {"doc_type": "kg_topic", "episode_id": "e1", "feed_id": "s"}),
+        (
+            "quote:1",
+            "he said the dollar",
+            {"doc_type": "quote", "episode_id": "e1", "feed_id": "s"},
+        ),
+        ("summary:1", "episode recap", {"doc_type": "summary", "episode_id": "e1", "feed_id": "s"}),
+        (
+            "kg_entity:1",
+            "Jerome Powell",
+            {"doc_type": "kg_entity", "episode_id": "e1", "feed_id": "s"},
+        ),
+    ]
+    corpus = tmp_path / "corpus"
+    (corpus / "metadata").mkdir(parents=True)
+    monkeypatch.setattr(
+        tti, "discover_metadata_files", lambda root: [corpus / "metadata" / "e1.json"]
+    )
+    monkeypatch.setattr(tti, "_load_metadata_file", lambda p: {"episode": {"episode_id": "e1"}})
+    monkeypatch.setattr(tti, "episode_root_from_metadata_path", lambda p: corpus)
+    monkeypatch.setattr(tti, "_collect_docs_for_episode", lambda *a, **k: rows)
+
+    stats = tti.build_two_tier_index(corpus, corpus / "search" / "lance_index", allow_download=True)
+    assert stats.aux == 4 and stats.segments == 0 and stats.insights == 0
+    assert LanceDBBackend(str(corpus / "search" / "lance_index")).health()["aux"] == 4

--- a/tests/integration/search/test_lancedb_backend_edge.py
+++ b/tests/integration/search/test_lancedb_backend_edge.py
@@ -1,0 +1,41 @@
+"""Edge-branch coverage for LanceDBBackend (RFC-090 #855 + hardening)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+pytest.importorskip("lancedb")
+
+from podcast_scraper.search.backend import SearchQuery  # noqa: E402
+from podcast_scraper.search.backends.lancedb_backend import LanceDBBackend  # noqa: E402
+
+
+def test_search_on_empty_backend_returns_nothing(tmp_path):
+    # No tables created → read path skips missing tiers (no autocreate), returns [].
+    b = LanceDBBackend(str(tmp_path / "lance"), embed_dim=4)
+    assert b.search_bm25(SearchQuery(text="x", embedding=[], tier="all")) == []
+    assert b.search_vector(SearchQuery(text="x", embedding=[0.0] * 4, tier="all")) == []
+
+
+def test_health_on_empty_backend(tmp_path):
+    b = LanceDBBackend(str(tmp_path / "lance"), embed_dim=4)
+    h = b.health()
+    assert h["status"] == "ok" and h["segments"] == 0 and h["insights"] == 0
+
+
+def test_meta_rejects_unsafe_path(tmp_path):
+    # safe_resolve_directory rejects a '..' path → read returns None, write is a no-op.
+    b = LanceDBBackend(str(tmp_path / "lance"), embed_dim=4)
+    b.path = str(tmp_path / "a" / ".." / "b")  # contains '..' → sanitizer rejects
+    assert b.read_index_meta() is None
+    b.write_index_meta("some-model")  # must not raise
+
+
+def test_meta_round_trip(tmp_path):
+    b = LanceDBBackend(str(tmp_path / "lance"), embed_dim=4)
+    b.write_index_meta("sentence-transformers/all-MiniLM-L6-v2")
+    meta = b.read_index_meta()
+    assert meta is not None and meta["embedding_model"].endswith("MiniLM-L6-v2")
+    assert meta["embed_dim"] == 4

--- a/tests/integration/search/test_migration.py
+++ b/tests/integration/search/test_migration.py
@@ -55,17 +55,18 @@ def _build_faiss(tmp_path):
     return tmp_path / "faiss"
 
 
-def test_migration_maps_tiers_and_skips_others(tmp_path):
+def test_migration_maps_tiers_including_aux(tmp_path):
     faiss_dir = _build_faiss(tmp_path)
     stats = migrate_faiss_to_lance(faiss_dir, tmp_path / "lance")
     assert stats.insights == 1
     assert stats.segments == 1
-    assert stats.skipped == 1  # kg_entity skipped
+    assert stats.aux == 1  # kg_entity → aux tier (full coverage), not skipped
+    assert stats.skipped == 0
     assert stats.embed_dim == 4
 
     backend = LanceDBBackend(str(tmp_path / "lance"), embed_dim=4)
     health = backend.health()
-    assert health["insights"] == 1 and health["segments"] == 1
+    assert health["insights"] == 1 and health["segments"] == 1 and health["aux"] == 1
 
     # Migration records the FAISS index's model so the query path matches it.
     meta = backend.read_index_meta()

--- a/tests/integration/upgrade/test_migration_verify.py
+++ b/tests/integration/upgrade/test_migration_verify.py
@@ -1,0 +1,36 @@
+"""Verify-branch coverage for migrations 0001/0002 (empty-index path; #862)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+pytest.importorskip("lancedb")
+
+from podcast_scraper.search.faiss_store import VECTORS_FILE  # noqa: E402
+from podcast_scraper.upgrade.migration import MigrationContext  # noqa: E402
+from podcast_scraper.upgrade.migrations.m0001_faiss_to_lance import (  # noqa: E402
+    FaissToLanceMigration,
+)
+from podcast_scraper.upgrade.migrations.m0002_two_tier_native_reindex import (  # noqa: E402
+    TwoTierNativeReindexMigration,
+)
+
+
+def _ctx(tmp_path):
+    return MigrationContext(corpus_root=tmp_path)
+
+
+def test_m0001_verify_fails_on_present_but_empty_index(tmp_path):
+    (tmp_path / "search").mkdir()
+    (tmp_path / "search" / VECTORS_FILE).write_text("", encoding="utf-8")  # FAISS present
+    (tmp_path / "search" / "lance_index").mkdir()  # lance dir exists but has no tables
+    ok, msg = FaissToLanceMigration().verify(_ctx(tmp_path))
+    assert not ok and "no rows" in msg
+
+
+def test_m0002_verify_fails_on_present_but_empty_index(tmp_path):
+    (tmp_path / "search" / "lance_index").mkdir(parents=True)  # exists but empty
+    ok, msg = TwoTierNativeReindexMigration().verify(_ctx(tmp_path))
+    assert not ok and "empty" in msg

--- a/tests/unit/search/test_backend.py
+++ b/tests/unit/search/test_backend.py
@@ -59,6 +59,7 @@ class _FakeBackend:
     def __init__(self) -> None:
         self.segments: Dict[str, SegmentDocument] = {}
         self.insights: Dict[str, InsightDocument] = {}
+        self.aux: Dict[str, object] = {}
 
     def search_bm25(self, query: SearchQuery) -> List[ScoredResult]:
         return []
@@ -71,6 +72,9 @@ class _FakeBackend:
 
     def upsert_insight(self, doc: InsightDocument) -> None:
         self.insights[doc.id] = doc
+
+    def upsert_aux(self, doc) -> None:
+        self.aux[doc.id] = doc
 
     def delete(self, doc_id: str, tier) -> None:
         self.segments.pop(doc_id, None)

--- a/tests/unit/search/test_corpus_search_branches.py
+++ b/tests/unit/search/test_corpus_search_branches.py
@@ -1,0 +1,18 @@
+"""Coverage for run_corpus_search early-return branches (RFC-090 Phase 2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.corpus_search import run_corpus_search
+
+pytestmark = pytest.mark.unit
+
+
+def test_empty_query_returns_error(tmp_path):
+    assert run_corpus_search(tmp_path, "   ").error == "empty_query"
+
+
+def test_no_index_returns_error(tmp_path):
+    # Hybrid disabled (default) + no FAISS index → no_index.
+    assert run_corpus_search(tmp_path, "a real query").error == "no_index"

--- a/tests/unit/search/test_hybrid_fallbacks.py
+++ b/tests/unit/search/test_hybrid_fallbacks.py
@@ -89,3 +89,10 @@ def test_tier_for_mixed_doc_types_is_all():
     assert hs._tier_for(None) == "all"
     assert hs._tier_for(["insight"]) == "insight"
     assert hs._tier_for(["transcript"]) == "segment"
+
+
+def test_unsafe_output_dir_falls_back(tmp_path, monkeypatch):
+    _patch_backend(monkeypatch)
+    # A path containing '..' is rejected by safe_resolve_directory → None (FAISS fallback).
+    unsafe = str(tmp_path / "a" / ".." / "b")
+    assert hs.hybrid_candidates(unsafe, "q", top_k=5) is None

--- a/tests/unit/search/test_hybrid_helpers.py
+++ b/tests/unit/search/test_hybrid_helpers.py
@@ -1,0 +1,60 @@
+"""Unit coverage for hybrid_search pure helpers (RFC-090 Phase 2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search import hybrid_search as hs
+from podcast_scraper.search.backend import CompoundResult, ScoredResult
+
+pytestmark = pytest.mark.unit
+
+
+def test_lance_index_dir():
+    assert str(hs.lance_index_dir("/c")).endswith("/c/search/lance_index")
+
+
+def test_load_search_config_present_and_invalid(tmp_path, monkeypatch):
+    cfg = tmp_path / "search.yaml"
+    monkeypatch.setenv("PODCAST_SEARCH_CONFIG", str(cfg))
+    cfg.write_text("serving:\n  hybrid_enabled: true\nrouter:\n  mode: rules\n", encoding="utf-8")
+    doc = hs._load_search_config()
+    assert doc["serving"]["hybrid_enabled"] is True and doc["router"]["mode"] == "rules"
+
+    cfg.write_text(": : not yaml : :", encoding="utf-8")
+    assert hs._load_search_config() == {}  # parse error → {}
+
+    cfg.write_text("- a list not a dict", encoding="utf-8")
+    assert hs._load_search_config() == {}  # non-dict → {}
+
+
+def test_to_search_result_segment_carries_timestamps_and_speaker():
+    seg = ScoredResult(
+        "chunk:1",
+        0.7,
+        1,
+        {
+            "text": "t",
+            "episode_id": "e1",
+            "show_id": "A",
+            "start_time": 2.0,
+            "end_time": 5.0,
+            "speaker_id": "spk",
+        },
+        "bm25",
+        "segment",
+    )
+    out = hs._to_search_result(seg)
+    assert out.metadata["doc_type"] == "transcript"
+    assert out.metadata["timestamp_start_ms"] == 2000 and out.metadata["timestamp_end_ms"] == 5000
+    assert out.metadata["speaker_id"] == "spk"
+    assert out.metadata["feed_id"] == "A"
+
+
+def test_flatten_handles_all_result_types():
+    seg = ScoredResult("s1", 0.8, 1, {}, "bm25", "segment")
+    ins = ScoredResult("i1", 0.9, 1, {}, "vector", "insight")
+    comp = CompoundResult(doc_id="s1", score=0.9, rank=1, segment=seg, insight=ins)
+    assert hs._flatten(comp) == [ins, seg]  # compound → both
+    assert hs._flatten(ins) == [ins]  # scored → itself
+    assert hs._flatten("not a result") == []  # unknown → empty

--- a/tests/unit/search/test_hybrid_helpers.py
+++ b/tests/unit/search/test_hybrid_helpers.py
@@ -58,3 +58,22 @@ def test_flatten_handles_all_result_types():
     assert hs._flatten(comp) == [ins, seg]  # compound → both
     assert hs._flatten(ins) == [ins]  # scored → itself
     assert hs._flatten("not a result") == []  # unknown → empty
+
+
+def test_tier_for_aux_doc_types():
+    assert hs._tier_for(["kg_topic"]) == "aux"
+    assert hs._tier_for(["kg_entity", "quote"]) == "aux"
+    assert hs._tier_for(["insight", "kg_topic"]) == "all"  # mixed → all
+
+
+def test_to_search_result_aux_uses_payload_doc_type():
+    aux = ScoredResult(
+        "kg_topic:1",
+        0.5,
+        1,
+        {"text": "x", "episode_id": "e1", "show_id": "A", "doc_type": "kg_topic"},
+        "bm25",
+        "aux",
+    )
+    out = hs._to_search_result(aux)
+    assert out.metadata["doc_type"] == "kg_topic"  # aux carries its real doc_type

--- a/tests/unit/search/test_llm_judge.py
+++ b/tests/unit/search/test_llm_judge.py
@@ -64,3 +64,8 @@ def test_grade_record_survives_model_error():
 def test_grade_records_batch():
     recs = grade_records([_rec(), _rec()], lambda p: '{"a": 1, "b": 1}')
     assert all(r.relevance == {"a": 1, "b": 1} for r in recs)
+
+
+def test_parse_grades_skips_non_int_grade_for_valid_id():
+    # A valid candidate id with a non-integer grade is skipped (not crashed).
+    assert parse_grades('{"a": "high", "b": 1}', ["a", "b"]) == {"b": 1}

--- a/tests/unit/search/test_llm_judge.py
+++ b/tests/unit/search/test_llm_judge.py
@@ -1,0 +1,66 @@
+"""Unit tests for the LLM-as-judge grader (RFC-057 / Step 2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.search.judged_eval import JudgmentRecord
+from podcast_scraper.search.llm_judge import (
+    build_grading_prompt,
+    grade_record,
+    grade_records,
+    parse_grades,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _rec():
+    return JudgmentRecord(
+        query="oil prices",
+        intent="semantic",
+        candidates=[
+            {"doc_id": "a", "text": "crude oil rallied"},
+            {"doc_id": "b", "text": "unrelated cooking show"},
+        ],
+        faiss_ranking=["a", "b"],
+        hybrid_ranking=["b", "a"],
+    )
+
+
+def test_build_prompt_lists_query_and_candidates():
+    p = build_grading_prompt(_rec())
+    assert 'Query: "oil prices"' in p
+    assert "id=a:" in p and "id=b:" in p
+
+
+def test_parse_grades_extracts_clamps_and_filters():
+    resp = 'Sure! Here you go: {"a": 2, "b": 0, "c": 5, "x": "nope"}'
+    grades = parse_grades(resp, ["a", "b", "c"])
+    assert grades["a"] == 2 and grades["b"] == 0
+    assert grades["c"] == 2  # 5 clamped to 2
+    assert "x" not in grades  # not a candidate id / unparseable
+
+
+def test_parse_grades_handles_garbage():
+    assert parse_grades("no json here", ["a"]) == {}
+    assert parse_grades("{not valid json", ["a"]) == {}
+    assert parse_grades("[1,2,3]", ["a"]) == {}  # not a dict
+
+
+def test_grade_record_fills_relevance():
+    rec = grade_record(_rec(), lambda prompt: '{"a": 2, "b": 0}')
+    assert rec.relevance == {"a": 2, "b": 0}
+
+
+def test_grade_record_survives_model_error():
+    def _boom(prompt):
+        raise RuntimeError("api down")
+
+    rec = grade_record(_rec(), _boom)
+    assert rec.relevance == {}  # failed grade → unjudged, not a crash
+
+
+def test_grade_records_batch():
+    recs = grade_records([_rec(), _rec()], lambda p: '{"a": 1, "b": 1}')
+    assert all(r.relevance == {"a": 1, "b": 1} for r in recs)

--- a/tests/unit/upgrade/test_cli_handlers.py
+++ b/tests/unit/upgrade/test_cli_handlers.py
@@ -66,3 +66,40 @@ def test_run_up_to_date_is_noop(tmp_path, monkeypatch, capsys):
     args = parse_upgrade_argv(["run", "--corpus-dir", str(tmp_path), "--yes"])
     assert run_upgrade_cli(args, log) == 0
     assert "Up to date" in capsys.readouterr().out
+
+
+def test_run_yes_json_on_empty_corpus(tmp_path, capsys):
+    # No FAISS, no metadata → 0001 no-ops, 0002 native build finds nothing; --json prints.
+    import json as _json
+
+    rc = _run(tmp_path, "run", "--yes", "--json")
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out)
+    assert {r["id"] for r in payload} == {"0001_faiss_to_lance", "0002_two_tier_native_reindex"}
+
+
+def test_unknown_subcommand_errors(tmp_path):
+    from argparse import Namespace
+
+    from podcast_scraper.upgrade.cli_handlers import run_upgrade_cli
+
+    args = Namespace(
+        command="upgrade", upgrade_subcommand="bogus", corpus_dir=str(tmp_path), json=False
+    )
+    assert run_upgrade_cli(args, log) == 1
+
+
+def test_confirm_prompt_tty(monkeypatch):
+    from podcast_scraper.upgrade import cli_handlers as ch
+
+    status = type("St", (), {"pending": [type("M", (), {"id": "0001_x"})()]})()
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda *_a: "y")
+    assert ch._confirm(status, log) is True
+    monkeypatch.setattr("builtins.input", lambda *_a: "n")
+    assert ch._confirm(status, log) is False
+
+
+def test_verify_text_mode_no_applied(tmp_path, capsys):
+    assert _run(tmp_path, "verify") == 0  # text mode (no --json)
+    assert "No applied migrations" in capsys.readouterr().out

--- a/tests/unit/upgrade/test_migration_base.py
+++ b/tests/unit/upgrade/test_migration_base.py
@@ -1,0 +1,26 @@
+"""Coverage for the base Migration default verify/plan (#862)."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.upgrade.migration import Migration, MigrationContext, MigrationResult
+
+pytestmark = pytest.mark.unit
+
+
+class _Bare(Migration):
+    id = "0000_bare"
+    to_version = "2.7.0"
+    description = "bare step"
+
+    def apply(self, ctx):
+        return MigrationResult(self.id, applied=True)
+
+
+def test_base_verify_and_plan_defaults(tmp_path):
+    m = _Bare()
+    ctx = MigrationContext(corpus_root=tmp_path)
+    ok, msg = m.verify(ctx)
+    assert ok and "no verification" in msg  # default verify
+    assert m.plan(ctx) == "bare step"  # default plan = description


### PR DESCRIPTION
## Summary

Continues the RFC-090 hybrid work after #865 merged. Three things, one branch:

1. **Step 0 — coverage** (the #865 codecov/patch gap): raised the new-code modules to ~93–99% (hybrid_search, two_tier_indexer, lancedb_backend, upgrade CLI/migrations, corpus_search branches).
2. **Step 3 — full-coverage `aux` tier**: hybrid now indexes the doc types FAISS does (kg_entity / kg_topic / quote / summary), so it no longer loses on coverage.
3. **Step 2 — LLM-as-judge eval**: an auto-grading harness + the first discriminating finding.

## Why this order (Step 1 changed the plan)

Activating hybrid on the real corpus (Step 1) and diffing vs FAISS showed hybrid was **blind to half the corpus** — for entity/topic queries FAISS returns `kg_topic`/`kg_entity`, which hybrid didn't index. An eval then would have shown "hybrid loses" for the wrong reason (coverage, not ranking). So Step 3 (coverage) had to come before Step 2 (eval). After Step 3, hybrid returns `kg_topic` at the top, matching FAISS coverage (index now: 336 segments + 240 insights + **957 aux**).

## Step 2 finding (honest, not a "hybrid wins")

The LLM-judge harness works and is **discriminating** — its first run surfaced two genuine issues, which is its whole point:
- **Synthesis bias**: corpus-derived queries home-field-favor FAISS (it exact-matches its own kg nodes). Mitigated with question templates; documented as *directional only* — a binding FAISS-removal verdict needs **real user queries** (`--queries`) + your spot-check of the grades (the approved flow).
- **A real hybrid weakness**: RRF buries precise `aux` (kg_entity/kg_topic) matches under BM25 hits on common terms — so hybrid under-ranks the exact entity/topic FAISS finds. That's a **fusion/weight-tuning** follow-up, not a reason to pick a winner.

I deliberately did **not** chase a number to make hybrid look good — the harness + finding are the deliverable.

## New surfaces
- `aux` tier across backend / LanceDB / indexer / migration / router+fusion weights / hybrid mapping.
- `search/llm_judge.py` (injectable `complete` → unit-testable without API calls) + `eval_hybrid_judged.py auto`.

## Tests / gates
- Proactive coverage for every new branch (aux CRUD+search, indexer routing, migration aux, hybrid mapping, llm_judge parse/grade/error paths). `make ci-fast` green (incl. 100% docstrings, spelling).

## Follow-ups (queued, your calls)
- Real-query eval + your grade spot-check → binding #858/#860 verdict.
- RRF/weight tuning so precise aux matches aren't diluted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
