### PR TITLE
feat(cli): enrich-edges — activate relational edges (HAS_EPISODE/MENTIONS/SPOKEN_BY) into the corpus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,7 @@ validate-kg-schema:
 	fi
 
 # GI/KG viewer v2 (#489): FastAPI + Vite. ``make init`` includes FastAPI via ``[dev]``; cd $(WEB_VIEWER_DIR) && npm install
-.PHONY: serve serve-api serve-ui serve-e2e-mock stack-build stack-build-llm stack-compose-validate stack-up stack-down stack-logs verify-stack-profiles stack-test-build stack-test-build-cloud stack-test-up stack-test-down stack-test-seed stack-test-playwright stack-test-export stack-test-ml stack-test-cloud-thin stack-test-ml-ci deploy-codespace restore-corpus restore-corpus-prod reprocess-corpus-from-transcripts corpus-compat-check index-two-tier upgrade-status upgrade-check upgrade-dry-run upgrade-corpus upgrade-verify smoke-prod corpus-snapshot-manifest-validate corpus-snapshot-select-tag corpus-snapshot-select-tag-prod corpus-snapshot-selftest corpus-snapshot-integration
+.PHONY: serve serve-api serve-ui serve-e2e-mock stack-build stack-build-llm stack-compose-validate stack-up stack-down stack-logs verify-stack-profiles stack-test-build stack-test-build-cloud stack-test-up stack-test-down stack-test-seed stack-test-playwright stack-test-export stack-test-ml stack-test-cloud-thin stack-test-ml-ci deploy-codespace restore-corpus restore-corpus-prod reprocess-corpus-from-transcripts corpus-compat-check index-two-tier enrich-relational-edges upgrade-status upgrade-check upgrade-dry-run upgrade-corpus upgrade-verify smoke-prod corpus-snapshot-manifest-validate corpus-snapshot-select-tag corpus-snapshot-select-tag-prod corpus-snapshot-selftest corpus-snapshot-integration
 SERVE_OUTPUT_DIR ?= ./output
 # Optional corpus-editing + jobs routes (health shows green when on). Override with SERVE_ARGS= to disable.
 SERVE_ARGS ?= --enable-feeds-api --enable-operator-config-api --enable-jobs-api
@@ -1022,6 +1022,13 @@ corpus-compat-check:
 index-two-tier:
 	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
 	$(PYTHON) -m podcast_scraper.cli index-two-tier --output-dir "$${CORPUS_DIR}"
+
+# Derive relational edges into each gi.json (#874): Podcast->HAS_EPISODE->Episode,
+# Insight->MENTIONS->Entity, and Quote->SPOKEN_BY->Person (diarized episodes only).
+# Idempotent cross-layer pass; re-run after new diarization (#876) to fill SPOKEN_BY.
+enrich-relational-edges:
+	@test -n "$${CORPUS_DIR:-}" || (echo "CORPUS_DIR required (corpus parent path)"; exit 1); \
+	$(PYTHON) -m podcast_scraper.cli enrich-edges --output-dir "$${CORPUS_DIR}"
 
 # Corpus upgrade-path framework (#862). Managed, idempotent migrations for moving a
 # deployed corpus across releases (2.6 → 2.7 FAISS→LanceDB is step 0001). CORPUS_DIR

--- a/src/podcast_scraper/cli.py
+++ b/src/podcast_scraper/cli.py
@@ -3459,6 +3459,12 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         tt_argv = list(argv[1:]) if len(argv) > 1 else []
         return parse_index_two_tier_argv(tt_argv)
 
+    if argv and len(argv) > 0 and argv[0] == "enrich-edges":
+        from .search.cli_handlers import parse_enrich_edges_argv
+
+        ee_argv = list(argv[1:]) if len(argv) > 1 else []
+        return parse_enrich_edges_argv(ee_argv)
+
     if argv and len(argv) > 0 and argv[0] == "topic-clusters":
         from .search.cli_handlers import parse_topic_clusters_argv
 
@@ -4540,6 +4546,11 @@ def main(  # noqa: C901 - main function handles multiple command paths
         from .search.cli_handlers import run_index_two_tier_cli
 
         return run_index_two_tier_cli(args, log)
+
+    if hasattr(args, "command") and args.command == "enrich-edges":
+        from .search.cli_handlers import run_enrich_edges_cli
+
+        return run_enrich_edges_cli(args, log)
 
     if hasattr(args, "command") and args.command == "topic-clusters":
         from .search.cli_handlers import run_topic_clusters_cli

--- a/src/podcast_scraper/search/cli_handlers.py
+++ b/src/podcast_scraper/search/cli_handlers.py
@@ -1389,3 +1389,88 @@ def run_index_two_tier_cli(args: Namespace, logger: logging.Logger) -> int:
         f"segments={stats.segments} insights={stats.insights} aux={stats.aux}"
     )
     return EXIT_SUCCESS
+
+
+def parse_enrich_edges_argv(argv: Sequence[str]) -> Namespace:
+    """Parse ``enrich-edges`` args (#874: derive relational edges into each gi.json)."""
+    parser = argparse.ArgumentParser(prog="podcast_scraper enrich-edges")
+    parser.add_argument("--output-dir", required=True, help="Corpus root (parent of feeds/).")
+    parser.add_argument(
+        "--no-speaker",
+        action="store_true",
+        help="Skip SPOKEN_BY (diarization-dependent); emit only show + entity edges.",
+    )
+    args = parser.parse_args(list(argv))
+    args.command = "enrich-edges"
+    return args
+
+
+def run_enrich_edges_cli(args: Namespace, logger: logging.Logger) -> int:
+    """Derive relational edges into each gi.json (#874): Podcast→HAS_EPISODE→Episode,
+    Insight→MENTIONS→Entity, and (unless --no-speaker) Quote→SPOKEN_BY→Person.
+
+    A cross-layer, idempotent corpus pass — re-runnable any time; reprocess after the
+    new diarization (#876) lands to fill SPOKEN_BY corpus-wide.
+    """
+    output_dir = getattr(args, "output_dir", None)
+    if not output_dir:
+        logger.error("enrich-edges: --output-dir is required")
+        return EXIT_INVALID_ARGS
+
+    from podcast_scraper.gi.io import write_artifact
+    from podcast_scraper.gi.relational_edges import (
+        add_episode_show_edges,
+        add_insight_entity_edges,
+        kg_entity_names,
+    )
+    from podcast_scraper.gi.speakers import add_spoken_by_edges
+    from podcast_scraper.search.corpus_scope import episode_root_from_metadata_path
+    from podcast_scraper.search.indexer import _gi_path, _load_metadata_file, _transcript_path
+
+    corpus = Path(output_dir)
+    include_speaker = not bool(getattr(args, "no_speaker", False))
+    totals = {"episodes": 0, "has_episode": 0, "mentions": 0, "spoken_by": 0}
+    for meta_path in discover_metadata_files(corpus):
+        doc = _load_metadata_file(meta_path)
+        if not doc:
+            continue
+        episode_root = episode_root_from_metadata_path(meta_path)
+        gi_path = _gi_path(episode_root, meta_path, doc)
+        if not (gi_path and gi_path.is_file()):
+            continue
+        try:
+            artifact = json.loads(gi_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            logger.warning("enrich-edges: skip %s (%s)", gi_path, format_exception_for_log(exc))
+            continue
+        show_title = (doc.get("feed") or {}).get("title") or ""
+        totals["has_episode"] += add_episode_show_edges(artifact, show_title)
+        kg_path = Path(str(gi_path).replace(".gi.json", ".kg.json"))
+        if kg_path.is_file():
+            try:
+                kg_artifact = json.loads(kg_path.read_text(encoding="utf-8"))
+                totals["mentions"] += add_insight_entity_edges(
+                    artifact, kg_entity_names(kg_artifact)
+                )
+            except (OSError, ValueError):
+                pass
+        if include_speaker:
+            transcript_path = _transcript_path(episode_root, doc)
+            if transcript_path and transcript_path.is_file():
+                content = doc.get("content") or {}
+                totals["spoken_by"] += add_spoken_by_edges(
+                    artifact,
+                    transcript_path.read_text(encoding="utf-8", errors="replace"),
+                    hosts=content.get("detected_hosts") or [],
+                    guests=content.get("detected_guests") or [],
+                )
+        write_artifact(gi_path, artifact, validate=True)
+        totals["episodes"] += 1
+
+    msg = (
+        f"enrich-edges: episodes={totals['episodes']} HAS_EPISODE={totals['has_episode']} "
+        f"MENTIONS={totals['mentions']} SPOKEN_BY={totals['spoken_by']}"
+    )
+    logger.info(msg)
+    print(msg)
+    return EXIT_SUCCESS

--- a/tests/unit/search/test_enrich_edges_cli.py
+++ b/tests/unit/search/test_enrich_edges_cli.py
@@ -1,0 +1,146 @@
+"""Unit tests for the enrich-edges CLI (parse + walker) — #874 activation."""
+
+from __future__ import annotations
+
+import json
+import logging
+from argparse import Namespace
+
+import pytest
+
+from podcast_scraper.search.cli_handlers import parse_enrich_edges_argv, run_enrich_edges_cli
+
+pytestmark = pytest.mark.unit
+
+_LOG = logging.getLogger("test-enrich-edges")
+
+
+def test_parse_sets_command_and_output_dir():
+    args = parse_enrich_edges_argv(["--output-dir", "/tmp/corpus"])
+    assert args.command == "enrich-edges"
+    assert args.output_dir == "/tmp/corpus"
+    assert args.no_speaker is False
+
+
+def test_parse_no_speaker_flag():
+    args = parse_enrich_edges_argv(["--output-dir", "/tmp/corpus", "--no-speaker"])
+    assert args.no_speaker is True
+
+
+def test_parse_requires_output_dir():
+    with pytest.raises(SystemExit):
+        parse_enrich_edges_argv([])
+
+
+def test_run_requires_output_dir():
+    assert run_enrich_edges_cli(Namespace(), _LOG) == 2  # EXIT_INVALID_ARGS
+
+
+def _build_corpus(tmp_path):
+    """Minimal one-episode corpus: metadata + gi.json + kg.json + diarized transcript."""
+    (tmp_path / "metadata").mkdir()
+    (tmp_path / "metadata" / "ep1.metadata.json").write_text(
+        json.dumps(
+            {
+                "feed": {"title": "Test Show"},
+                "episode": {"episode_id": "ep1"},
+                "content": {
+                    "transcript_file_path": "transcript.txt",
+                    "detected_hosts": [],
+                    "detected_guests": ["Elon Musk"],
+                },
+                "grounded_insights": {"artifact_path": "ep1.gi.json"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "ep1.gi.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "2.0",
+                "model_version": "t",
+                "prompt_version": "t",
+                "episode_id": "ep1",
+                "nodes": [
+                    {"id": "episode:ep1", "type": "Episode", "properties": {}},
+                    {
+                        "id": "insight:1",
+                        "type": "Insight",
+                        "properties": {"text": "Elon Musk plans to list SpaceX."},
+                    },
+                ],
+                "edges": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "ep1.kg.json").write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": "person:elon-musk",
+                        "type": "Entity",
+                        "properties": {"name": "Elon Musk", "kind": "person"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "transcript.txt").write_text(
+        "Speaker 1: Hello. Speaker 2: Elon Musk.", encoding="utf-8"
+    )
+
+
+def test_run_persists_relational_edges(tmp_path):
+    _build_corpus(tmp_path)
+    rc = run_enrich_edges_cli(parse_enrich_edges_argv(["--output-dir", str(tmp_path)]), _LOG)
+    assert rc == 0
+    art = json.loads((tmp_path / "ep1.gi.json").read_text())
+    edge_types = {e["type"] for e in art["edges"]}
+    assert "HAS_EPISODE" in edge_types  # Podcast→Episode (from feed title)
+    assert "MENTIONS" in edge_types  # Insight→Entity (Elon Musk matched)
+    assert any(n["id"] == "podcast:test-show" and n["type"] == "Podcast" for n in art["nodes"])
+    # idempotent: a second pass adds nothing new
+    rc2 = run_enrich_edges_cli(parse_enrich_edges_argv(["--output-dir", str(tmp_path)]), _LOG)
+    art2 = json.loads((tmp_path / "ep1.gi.json").read_text())
+    assert rc2 == 0 and len(art2["edges"]) == len(art["edges"])
+
+
+def test_run_no_speaker_skips_transcript(tmp_path):
+    _build_corpus(tmp_path)
+    rc = run_enrich_edges_cli(
+        parse_enrich_edges_argv(["--output-dir", str(tmp_path), "--no-speaker"]), _LOG
+    )
+    assert rc == 0
+    art = json.loads((tmp_path / "ep1.gi.json").read_text())
+    # show + entity edges still emitted; SPOKEN_BY path skipped
+    assert {"HAS_EPISODE", "MENTIONS"} <= {e["type"] for e in art["edges"]}
+
+
+def test_run_skips_unreadable_gi(tmp_path):
+    _build_corpus(tmp_path)
+    (tmp_path / "ep1.gi.json").write_text("{ not valid json", encoding="utf-8")
+    # malformed gi.json is skipped gracefully, run still succeeds
+    assert run_enrich_edges_cli(parse_enrich_edges_argv(["--output-dir", str(tmp_path)]), _LOG) == 0
+
+
+def test_run_handles_unreadable_kg(tmp_path):
+    _build_corpus(tmp_path)
+    (tmp_path / "ep1.kg.json").write_text("{ bad", encoding="utf-8")
+    rc = run_enrich_edges_cli(parse_enrich_edges_argv(["--output-dir", str(tmp_path)]), _LOG)
+    assert rc == 0
+    # MENTIONS skipped (kg unreadable) but HAS_EPISODE still added
+    art = json.loads((tmp_path / "ep1.gi.json").read_text())
+    assert "HAS_EPISODE" in {e["type"] for e in art["edges"]}
+
+
+def test_run_without_kg_or_transcript(tmp_path):
+    _build_corpus(tmp_path)
+    (tmp_path / "ep1.kg.json").unlink()  # no kg → MENTIONS branch skipped
+    (tmp_path / "transcript.txt").unlink()  # no transcript → SPOKEN_BY branch skipped
+    rc = run_enrich_edges_cli(parse_enrich_edges_argv(["--output-dir", str(tmp_path)]), _LOG)
+    assert rc == 0
+    edge_types = {e["type"] for e in json.loads((tmp_path / "ep1.gi.json").read_text())["edges"]}
+    assert "HAS_EPISODE" in edge_types and "MENTIONS" not in edge_types


### PR DESCRIPTION
## What this lands — activate the relational edges into the corpus

#874 and #879 built the relational edge *capability* (tested derivations) but nothing called them, so the corpus didn't carry the edges. This wires them in: a **cross-layer, idempotent corpus pass** that derives and **persists** the edges into each `gi.json`.

### `enrich-edges` CLI + `make enrich-relational-edges`
For every episode (mirrors the `index-two-tier` dispatch):
- `Podcast ─HAS_EPISODE→ Episode` (from the feed title)
- `Insight ─MENTIONS→ Entity` (from the episode's KG entities)
- `Quote ─SPOKEN_BY→ Person` (from the diarized transcript; skip with `--no-speaker`)

Re-runnable any time; **reprocess after the new diarization (#876)** lands to fill `SPOKEN_BY` corpus-wide. The two diarization-independent edges activate **immediately**.

### Validated on the v2 prod corpus
```
enrich-edges: episodes=100 HAS_EPISODE=100 MENTIONS=530 SPOKEN_BY=0(*)
```
(*0 new because the proof run already added the 55.) Every gi.json **schema-validated and persisted**. Corpus now carries:
`HAS_INSIGHT 1318 · ABOUT 2516 · SUPPORTED_BY 2725` **+ `SPOKEN_BY 55 · HAS_EPISODE 100 · MENTIONS 530`**.

## Dependency / stacking

**Stacks on #879** — persisting `MENTIONS` requires the `MENTIONS` edge added to the GIL schema there. The diff shows #879's commit until it merges; I'll rebase onto main once #879 lands (dropping the merged commit, leaving only the activation).

## Validation
- Pre-commit (black/isort/flake8/mypy) green; new test `tests/unit/search/test_enrich_edges_cli.py` (3).
- End-to-end CLI run on v2 persisted 630 new relational edges with passing schema validation.

Refs #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
