### PR TITLE
ML model manifest: single source + drift guard + CI de-dup (#917)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -110,106 +110,20 @@ jobs:
     - name: Validate ML model cache
       id: validate-cache
       run: |
-        echo "🔍 Validating ML model cache..."
-        MISSING_MODELS=""
-        MODELS_COMPLETE=true
-
-        # Check Whisper models
-        echo "📦 Whisper models:"
-        for model in "tiny.en" "base.en"; do
-          WHISPER_PATH="$HOME/.cache/whisper/${model}.pt"
-          if [ -f "$WHISPER_PATH" ] && [ -s "$WHISPER_PATH" ]; then
-            SIZE=$(du -h "$WHISPER_PATH" | cut -f1)
-            echo "  ✅ $model ($SIZE)"
-          else
-            echo "  ❌ $model - MISSING or empty"
-            MISSING_MODELS="$MISSING_MODELS whisper:$model"
-            MODELS_COMPLETE=false
-          fi
-        done
-
-        # Check Hugging Face models
-        echo ""
-        echo "📦 Hugging Face models:"
-        HF_CACHE="$HOME/.cache/huggingface/hub"
-        # Test models: facebook/bart-base, allenai/led-base-16384
-        # Production models: facebook/bart-base (MAP), llama3.2:3b via Ollama (REDUCE)
-        # Note: allenai/led-base-16384 retained as pure-ML fallback reduce model
-        for model in "facebook/bart-base" "allenai/led-base-16384" "google/long-t5-tglobal-base" "google/flan-t5-base"; do
-          MODEL_DIR="models--${model//\//--}"
-          MODEL_PATH="$HF_CACHE/$MODEL_DIR"
-          if [ -d "$MODEL_PATH/snapshots" ] && [ "$(find "$MODEL_PATH/snapshots" -type f 2>/dev/null | head -1)" ]; then
-            SIZE=$(du -sh "$MODEL_PATH" | cut -f1)
-            echo "  ✅ $model ($SIZE)"
-          else
-            echo "  ❌ $model - MISSING or incomplete"
-            MISSING_MODELS="$MISSING_MODELS hf:$model"
-            MODELS_COMPLETE=false
-          fi
-        done
-
-        # Gated diarization models: only required when HF_TOKEN is provisioned (a
-        # terms-accepted token can fetch them). Forces the preload to run on the
-        # first cached-but-tokenless → tokenful transition so they get added.
-        if [ -n "$HF_TOKEN" ]; then
-          echo ""
-          echo "📦 Diarization models (gated, HF_TOKEN present):"
-          DIAR_PATH="$HF_CACHE/models--pyannote--speaker-diarization-3.1"
-          if [ -d "$DIAR_PATH/snapshots" ] && [ "$(find "$DIAR_PATH/snapshots" -type f 2>/dev/null | head -1)" ]; then
-            echo "  ✅ pyannote/speaker-diarization-3.1"
-          else
-            echo "  ❌ pyannote/speaker-diarization-3.1 - MISSING"
-            MISSING_MODELS="$MISSING_MODELS hf:pyannote/speaker-diarization-3.1"
-            MODELS_COMPLETE=false
-          fi
-        fi
-
-        echo ""
-        if [ "$MODELS_COMPLETE" = true ]; then
-          echo "✅ All required ML models are cached!"
+        # Single manifest (#917): verify_required_models.py reads
+        # model_manifest.ci_artifact_model_ids() -- no duplicated bash arrays.
+        if python scripts/cache/verify_required_models.py; then
           echo "models_complete=true" >> "$GITHUB_OUTPUT"
         else
-          echo "⚠️  Some models are missing. Will run preload..."
           echo "models_complete=false" >> "$GITHUB_OUTPUT"
+          exit 1
         fi
-
     - name: Preload production ML models (if incomplete)
       if: steps.validate-cache.outputs.models_complete != 'true'
       run: make preload-ml-models-production
 
     - name: Final cache validation
-      run: |
-        echo "🔍 Final validation..."
-        CACHE_VALID=true
-
-        for model in "tiny.en" "base.en"; do
-          if [ ! -f "$HOME/.cache/whisper/${model}.pt" ]; then
-            echo "❌ Whisper $model still missing!"
-            CACHE_VALID=false
-          fi
-        done
-
-        HF_CACHE="$HOME/.cache/huggingface/hub"
-        # Test models: facebook/bart-base, allenai/led-base-16384
-        # Production models: facebook/bart-base (MAP), llama3.2:3b via Ollama (REDUCE)
-        # Note: allenai/led-base-16384 retained as pure-ML fallback reduce model
-        for model in "facebook/bart-base" "allenai/led-base-16384" "google/long-t5-tglobal-base" "google/flan-t5-base"; do
-          MODEL_DIR="models--${model//\//--}"
-          if [ ! -d "$HF_CACHE/$MODEL_DIR/snapshots" ]; then
-            echo "❌ HF $model still missing!"
-            CACHE_VALID=false
-          fi
-        done
-
-        if [ "$CACHE_VALID" = true ]; then
-          echo "✅ All models validated successfully!"
-          TOTAL_SIZE=$(du -sh "$HOME/.cache" 2>/dev/null | cut -f1 || echo "unknown")
-          echo "📊 Total cache size: $TOTAL_SIZE"
-        else
-          echo "❌ FATAL: Models still missing after preload!"
-          exit 1
-        fi
-
+      run: python scripts/cache/verify_required_models.py
     - name: Upload ML models artifact (for dependent test jobs in same run)
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -596,56 +596,10 @@ jobs:
     - name: Verify models were downloaded (only if cache miss)
       if: (needs.detect-changes.outputs.docs-only != 'true' || needs.detect-changes.outputs.code == 'true') && steps.cache-models.outputs.cache-hit != 'true'
       run: |
-        echo "🔍 Verifying models were downloaded..."
-        MISSING=""
-        # Check Whisper models (preload-production downloads both tiny.en and base.en)
-        for model in "tiny.en" "base.en"; do
-          if [ ! -f "$HOME/.cache/whisper/${model}.pt" ]; then
-            MISSING="$MISSING whisper:$model"
-          fi
-        done
-        # Check Hugging Face models (preload-production downloads all: bart-base, led-base-16384, bart-large-cnn, led-large-16384)
-        HF_CACHE="$HOME/.cache/huggingface/hub"
-        echo "🔍 Debug: Checking HuggingFace cache structure..."
-        echo "  HF_CACHE: $HF_CACHE"
-        echo "  HF_CACHE exists: $([ -d "$HF_CACHE" ] && echo 'yes' || echo 'no')"
-        if [ -d "$HF_CACHE" ]; then
-          echo "  Contents of HF_CACHE:"
-          find "$HF_CACHE" -maxdepth 1 -printf '%M %u %s %TF %TR %f\n' | head -20
-        fi
-        for model in "facebook/bart-base" "allenai/led-base-16384" "google/long-t5-tglobal-base" "google/flan-t5-base"; do
-          MODEL_DIR="models--${model//\//--}"
-          MODEL_PATH="$HF_CACHE/$MODEL_DIR"
-          echo "  Checking $model:"
-          echo "    MODEL_PATH: $MODEL_PATH"
-          echo "    MODEL_PATH exists: $([ -d "$MODEL_PATH" ] && echo 'yes' || echo 'no')"
-          if [ -d "$MODEL_PATH" ]; then
-            echo "    Contents of MODEL_PATH:"
-            find "$MODEL_PATH" -maxdepth 1 -printf '%M %u %s %TF %TR %f\n' | head -10
-            if [ -d "$MODEL_PATH/snapshots" ]; then
-              echo "    snapshots/ exists, contents:"
-              find "$MODEL_PATH/snapshots" -maxdepth 1 -printf '%M %u %s %TF %TR %f\n' | head -5
-            else
-              echo "    snapshots/ does NOT exist"
-            fi
-            if [ -d "$MODEL_PATH/blobs" ]; then
-              echo "    blobs/ exists, file count: $(find "$MODEL_PATH/blobs" -type f 2>/dev/null | wc -l)"
-            fi
-            TOTAL_FILES=$(find "$MODEL_PATH" -type f 2>/dev/null | wc -l)
-            echo "    Total files in MODEL_PATH: $TOTAL_FILES"
-          fi
-          # Model is valid if it has files (in snapshots, blobs, or anywhere in the directory)
-          if [ ! -d "$MODEL_PATH" ] || [ "$(find "$MODEL_PATH" -type f 2>/dev/null | head -1)" = "" ]; then
-            MISSING="$MISSING hf:$model"
-          fi
-        done
-        if [ -n "$MISSING" ]; then
-          echo "❌ ERROR: Models not downloaded: $MISSING"
-          exit 1
-        fi
-        echo "✅ All required models downloaded successfully"
-        echo "📦 Cache will be saved at end of job for test jobs to use"
-        echo "🔍 Debug: Cache sizes before save:"
+        # Single manifest (#917): verify_required_models.py reads
+        # model_manifest.ci_artifact_model_ids() -- no duplicated bash arrays.
+        python scripts/cache/verify_required_models.py
+        echo "Cache will be saved at end of job for test jobs to use"
         du -sh "$HOME/.cache/whisper" 2>/dev/null || echo "  Whisper cache not found"
         du -sh "$HOME/.cache/huggingface" 2>/dev/null || echo "  HuggingFace cache not found"
     - name: Upload ML models artifact (for dependent test jobs in same run)
@@ -696,50 +650,11 @@ jobs:
     - name: Validate ML model cache
       id: validate-cache
       run: |
-        echo "🔍 Validating ML model cache..."
-        MISSING_MODELS=""
-        MODELS_COMPLETE=true
-
-        # Check Whisper models
-        echo "📦 Whisper models:"
-        for model in "tiny.en" "base.en"; do
-          WHISPER_PATH="$HOME/.cache/whisper/${model}.pt"
-          if [ -f "$WHISPER_PATH" ] && [ -s "$WHISPER_PATH" ]; then
-            SIZE=$(du -h "$WHISPER_PATH" | cut -f1)
-            echo "  ✅ $model ($SIZE)"
-          else
-            echo "  ❌ $model - MISSING or empty"
-            MISSING_MODELS="$MISSING_MODELS whisper:$model"
-            MODELS_COMPLETE=false
-          fi
-        done
-
-        # Check Hugging Face models
-        echo ""
-        echo "📦 Hugging Face models:"
-        HF_CACHE="$HOME/.cache/huggingface/hub"
-        for model in "facebook/bart-base" "allenai/led-base-16384" "google/long-t5-tglobal-base" "google/flan-t5-base"; do
-          MODEL_DIR="models--${model//\//--}"
-          MODEL_PATH="$HF_CACHE/$MODEL_DIR"
-          # Check if model has files anywhere (blobs, snapshots, or root)
-          # HuggingFace cache structure: files in blobs/, symlinks in snapshots/
-          TOTAL_FILES=$(find "$MODEL_PATH" -type f 2>/dev/null | wc -l)
-          if [ -d "$MODEL_PATH" ] && [ "$TOTAL_FILES" -gt 0 ]; then
-            SIZE=$(du -sh "$MODEL_PATH" | cut -f1)
-            echo "  ✅ $model ($SIZE, $TOTAL_FILES files)"
-          else
-            echo "  ❌ $model - MISSING or incomplete (0 files found)"
-            MISSING_MODELS="$MISSING_MODELS hf:$model"
-            MODELS_COMPLETE=false
-          fi
-        done
-
-        echo ""
-        if [ "$MODELS_COMPLETE" = true ]; then
-          echo "✅ All required ML models are cached!"
+        # Single manifest (#917): verify_required_models.py reads
+        # model_manifest.ci_artifact_model_ids() -- no duplicated bash arrays.
+        if python scripts/cache/verify_required_models.py; then
           echo "models_complete=true" >> "$GITHUB_OUTPUT"
         else
-          echo "⚠️  Some models are missing: $MISSING_MODELS"
           echo "models_complete=false" >> "$GITHUB_OUTPUT"
           exit 1
         fi
@@ -863,84 +778,11 @@ jobs:
     - name: Validate ML model cache
       id: validate-cache
       run: |
-        echo "🔍 Validating ML model cache..."
-        MISSING_MODELS=""
-        MODELS_COMPLETE=true
-
-        # Check Whisper models
-        echo "📦 Whisper models:"
-        for model in "tiny.en"; do
-          WHISPER_PATH="$HOME/.cache/whisper/${model}.pt"
-          if [ -f "$WHISPER_PATH" ] && [ -s "$WHISPER_PATH" ]; then
-            SIZE=$(du -h "$WHISPER_PATH" | cut -f1)
-            echo "  ✅ $model ($SIZE)"
-          else
-            echo "  ❌ $model - MISSING or empty"
-            MISSING_MODELS="$MISSING_MODELS whisper:$model"
-            MODELS_COMPLETE=false
-          fi
-        done
-
-        # Check Hugging Face models
-        echo ""
-        echo "📦 Hugging Face models:"
-        HF_CACHE="$HOME/.cache/huggingface/hub"
-        echo "🔍 Debug: Checking HuggingFace cache after restore..."
-        echo "  HF_CACHE: $HF_CACHE"
-        echo "  HF_CACHE exists: $([ -d "$HF_CACHE" ] && echo 'yes' || echo 'no')"
-        if [ -d "$HF_CACHE" ]; then
-          echo "  Contents of HF_CACHE:"
-          find "$HF_CACHE" -maxdepth 1 -printf '%M %u %s %TF %TR %f\n' | head -20
-          echo "  Total size: $(du -sh "$HF_CACHE" 2>/dev/null | cut -f1)"
-        fi
-        for model in "facebook/bart-base" "allenai/led-base-16384" "google/long-t5-tglobal-base" "google/flan-t5-base"; do
-          MODEL_DIR="models--${model//\//--}"
-          MODEL_PATH="$HF_CACHE/$MODEL_DIR"
-          echo "  Checking $model:"
-          echo "    MODEL_PATH: $MODEL_PATH"
-          echo "    MODEL_PATH exists: $([ -d "$MODEL_PATH" ] && echo 'yes' || echo 'no')"
-          if [ -d "$MODEL_PATH" ]; then
-            echo "    Contents of MODEL_PATH:"
-            find "$MODEL_PATH" -maxdepth 1 -printf '%M %u %s %TF %TR %f\n' | head -10
-          if [ -d "$MODEL_PATH/snapshots" ]; then
-            echo "    snapshots/ exists, contents:"
-            find "$MODEL_PATH/snapshots" -maxdepth 1 -printf '%M %u %s %TF %TR %f\n' | head -5
-            FILE_COUNT_SNAPSHOTS=$(find "$MODEL_PATH/snapshots" -type f -o -type l 2>/dev/null | wc -l)
-            echo "    File/symlink count in snapshots/: $FILE_COUNT_SNAPSHOTS"
-          else
-            echo "    snapshots/ does NOT exist"
-          fi
-          if [ -d "$MODEL_PATH/blobs" ]; then
-            echo "    blobs/ exists, contents:"
-            find "$MODEL_PATH/blobs" -maxdepth 1 -printf '%M %u %s %TF %TR %f\n' | head -5
-            FILE_COUNT_BLOBS=$(find "$MODEL_PATH/blobs" -type f 2>/dev/null | wc -l)
-            echo "    File count in blobs/: $FILE_COUNT_BLOBS"
-          else
-            echo "    blobs/ does NOT exist"
-          fi
-          # Check if model is complete: either files in snapshots (following symlinks) or files in blobs
-          TOTAL_FILES=$(find "$MODEL_PATH" -type f 2>/dev/null | wc -l)
-          echo "    Total files in MODEL_PATH: $TOTAL_FILES"
-        fi
-        # Model is valid if it has files anywhere (blobs, snapshots, or root)
-        # HuggingFace cache structure: files in blobs/, symlinks in snapshots/
-        TOTAL_FILES=$(find "$MODEL_PATH" -type f 2>/dev/null | wc -l)
-        if [ -d "$MODEL_PATH" ] && [ "$TOTAL_FILES" -gt 0 ]; then
-          SIZE=$(du -sh "$MODEL_PATH" | cut -f1)
-          echo "  ✅ $model ($SIZE, $TOTAL_FILES files)"
-        else
-          echo "  ❌ $model - MISSING or incomplete (0 files found)"
-          MISSING_MODELS="$MISSING_MODELS hf:$model"
-          MODELS_COMPLETE=false
-        fi
-        done
-
-        echo ""
-        if [ "$MODELS_COMPLETE" = true ]; then
-          echo "✅ All required ML models are cached!"
+        # Single manifest (#917): verify_required_models.py reads
+        # model_manifest.ci_artifact_model_ids() -- no duplicated bash arrays.
+        if python scripts/cache/verify_required_models.py; then
           echo "models_complete=true" >> "$GITHUB_OUTPUT"
         else
-          echo "⚠️  Some models are missing: $MISSING_MODELS"
           echo "models_complete=false" >> "$GITHUB_OUTPUT"
           exit 1
         fi
@@ -1056,50 +898,11 @@ jobs:
     - name: Validate ML model cache
       id: validate-cache
       run: |
-        echo "🔍 Validating ML model cache..."
-        MISSING_MODELS=""
-        MODELS_COMPLETE=true
-
-        # Check Whisper models
-        echo "📦 Whisper models:"
-        for model in "tiny.en" "base.en"; do
-          WHISPER_PATH="$HOME/.cache/whisper/${model}.pt"
-          if [ -f "$WHISPER_PATH" ] && [ -s "$WHISPER_PATH" ]; then
-            SIZE=$(du -h "$WHISPER_PATH" | cut -f1)
-            echo "  ✅ $model ($SIZE)"
-          else
-            echo "  ❌ $model - MISSING or empty"
-            MISSING_MODELS="$MISSING_MODELS whisper:$model"
-            MODELS_COMPLETE=false
-          fi
-        done
-
-        # Check Hugging Face models
-        echo ""
-        echo "📦 Hugging Face models:"
-        HF_CACHE="$HOME/.cache/huggingface/hub"
-        for model in "facebook/bart-base" "allenai/led-base-16384" "google/long-t5-tglobal-base" "google/flan-t5-base"; do
-          MODEL_DIR="models--${model//\//--}"
-          MODEL_PATH="$HF_CACHE/$MODEL_DIR"
-          # Check if model has files anywhere (blobs, snapshots, or root)
-          # HuggingFace cache structure: files in blobs/, symlinks in snapshots/
-          TOTAL_FILES=$(find "$MODEL_PATH" -type f 2>/dev/null | wc -l)
-          if [ -d "$MODEL_PATH" ] && [ "$TOTAL_FILES" -gt 0 ]; then
-            SIZE=$(du -sh "$MODEL_PATH" | cut -f1)
-            echo "  ✅ $model ($SIZE, $TOTAL_FILES files)"
-          else
-            echo "  ❌ $model - MISSING or incomplete (0 files found)"
-            MISSING_MODELS="$MISSING_MODELS hf:$model"
-            MODELS_COMPLETE=false
-          fi
-        done
-
-        echo ""
-        if [ "$MODELS_COMPLETE" = true ]; then
-          echo "✅ All required ML models are cached!"
+        # Single manifest (#917): verify_required_models.py reads
+        # model_manifest.ci_artifact_model_ids() -- no duplicated bash arrays.
+        if python scripts/cache/verify_required_models.py; then
           echo "models_complete=true" >> "$GITHUB_OUTPUT"
         else
-          echo "⚠️  Some models are missing: $MISSING_MODELS"
           echo "models_complete=false" >> "$GITHUB_OUTPUT"
           exit 1
         fi
@@ -1222,48 +1025,11 @@ jobs:
     - name: Validate ML model cache
       id: validate-cache
       run: |
-        echo "🔍 Validating ML model cache..."
-        MISSING_MODELS=""
-        MODELS_COMPLETE=true
-
-        # Check Whisper models
-        echo "📦 Whisper models:"
-        for model in "tiny.en" "base.en"; do
-          WHISPER_PATH="$HOME/.cache/whisper/${model}.pt"
-          if [ -f "$WHISPER_PATH" ] && [ -s "$WHISPER_PATH" ]; then
-            SIZE=$(du -h "$WHISPER_PATH" | cut -f1)
-            echo "  ✅ $model ($SIZE)"
-          else
-            echo "  ❌ $model - MISSING or empty"
-            MISSING_MODELS="$MISSING_MODELS whisper:$model"
-            MODELS_COMPLETE=false
-          fi
-        done
-
-        # Check Hugging Face models
-        echo ""
-        echo "📦 Hugging Face models:"
-        HF_CACHE="$HOME/.cache/huggingface/hub"
-        for model in "facebook/bart-base" "allenai/led-base-16384" "google/long-t5-tglobal-base" "google/flan-t5-base"; do
-          MODEL_DIR="models--${model//\//--}"
-          MODEL_PATH="$HF_CACHE/$MODEL_DIR"
-          TOTAL_FILES=$(find "$MODEL_PATH" -type f 2>/dev/null | wc -l)
-          if [ -d "$MODEL_PATH" ] && [ "$TOTAL_FILES" -gt 0 ]; then
-            SIZE=$(du -sh "$MODEL_PATH" | cut -f1)
-            echo "  ✅ $model ($SIZE, $TOTAL_FILES files)"
-          else
-            echo "  ❌ $model - MISSING or incomplete (0 files found)"
-            MISSING_MODELS="$MISSING_MODELS hf:$model"
-            MODELS_COMPLETE=false
-          fi
-        done
-
-        echo ""
-        if [ "$MODELS_COMPLETE" = true ]; then
-          echo "✅ All required ML models are cached!"
+        # Single manifest (#917): verify_required_models.py reads
+        # model_manifest.ci_artifact_model_ids() -- no duplicated bash arrays.
+        if python scripts/cache/verify_required_models.py; then
           echo "models_complete=true" >> "$GITHUB_OUTPUT"
         else
-          echo "⚠️  Some models are missing: $MISSING_MODELS"
           echo "models_complete=false" >> "$GITHUB_OUTPUT"
           exit 1
         fi
@@ -1385,16 +1151,7 @@ jobs:
         name: ml-models
         path: /home/runner/.cache
     - name: Validate ML model cache (same checks as E2E)
-      run: |
-        for model in tiny.en base.en; do
-          test -s "$HOME/.cache/whisper/${model}.pt" || { echo "missing whisper $model"; exit 1; }
-        done
-        HF_CACHE="$HOME/.cache/huggingface/hub"
-        for model in facebook/bart-base allenai/led-base-16384 google/long-t5-tglobal-base google/flan-t5-base; do
-          MODEL_DIR="models--${model//\//--}"
-          test -d "$HF_CACHE/$MODEL_DIR" || { echo "missing hf $model"; exit 1; }
-          test "$(find "$HF_CACHE/$MODEL_DIR" -type f 2>/dev/null | head -1)" || { echo "empty hf $model"; exit 1; }
-        done
+      run: python scripts/cache/verify_required_models.py
     - name: Install dependencies (ML + LLM for full pipeline acceptance)
       run: |
         python -m pip install --upgrade pip

--- a/scripts/cache/verify_required_models.py
+++ b/scripts/cache/verify_required_models.py
@@ -1,0 +1,79 @@
+"""Verify the CI ml-models artifact carries every model the test jobs need (#917).
+
+Reads the single manifest (``model_manifest.ci_artifact_model_ids``) and checks
+each is present in the local caches. This replaces the hand-maintained,
+~4x-duplicated bash arrays in ``.github/workflows/python-app.yml`` -- the drift
+that let MiniLM go missing from CI and break the offline search tests (#897).
+
+Usage (CI cache-validation step):
+    python scripts/cache/verify_required_models.py
+
+Exits non-zero and prints the missing models if any required model is absent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _ensure_src_on_path() -> None:
+    root = Path(__file__).resolve().parents[2]
+    src = root / "src"
+    if src.is_dir() and str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+
+def _whisper_cached(name: str) -> bool:
+    return (Path.home() / ".cache" / "whisper" / f"{name}.pt").is_file()
+
+
+def _spacy_cached(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
+
+
+def _hf_cached(model_id: str) -> bool:
+    """True if the HF hub cache has a non-empty dir for ``model_id``."""
+    from podcast_scraper.cache.directories import get_transformers_cache_dir
+
+    cache_dir = get_transformers_cache_dir()
+    model_dir = cache_dir / f"models--{model_id.replace('/', '--')}"
+    if not model_dir.is_dir():
+        return False
+    return any(p.is_file() for p in model_dir.rglob("*"))
+
+
+def main() -> int:
+    _ensure_src_on_path()
+    from podcast_scraper.providers.ml import model_manifest as mm
+
+    checks = {
+        "whisper": _whisper_cached,
+        "spacy": _spacy_cached,
+        "summary": _hf_cached,
+        "embedding": _hf_cached,
+        "qa": _hf_cached,
+        "nli": _hf_cached,
+    }
+
+    missing: list[str] = []
+    print("Verifying CI artifact models (from model_manifest):")
+    for spec in mm.models_for_tier("ci_artifact"):
+        check = checks.get(spec.kind)
+        if check is None:  # diarization etc. are not ci_artifact, but be safe
+            continue
+        ok = check(spec.model_id)
+        print(f"  [{'OK ' if ok else 'MISS'}] {spec.kind:9} {spec.model_id}")
+        if not ok:
+            missing.append(f"{spec.kind}:{spec.model_id}")
+
+    if missing:
+        print(f"\nERROR: required models not cached: {', '.join(missing)}")
+        return 1
+    print("\nAll required ml-models-artifact models are cached.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/podcast_scraper/providers/ml/model_manifest.py
+++ b/src/podcast_scraper/providers/ml/model_manifest.py
@@ -1,0 +1,102 @@
+"""ML preload manifest (#917): *which* models to preload and *where*.
+
+This is the single source of truth for the **preload policy** — which models the
+pipeline downloads and into which tier (dev/test, CI artifact, nightly
+production, gated). It deliberately does NOT restate things that already live in
+a central place:
+
+- **summary + evidence** model ids are the central ``ModelRegistry`` keys
+  (autoresearch-fed via ``scripts/registry/promote_baseline.py`` ->
+  ``ModeConfiguration``); their params/capabilities stay in the registry.
+- **whisper / spaCy** defaults come from ``config_constants``.
+- **pinned revisions** come from ``config_constants.get_pinned_revision_for_model``.
+
+So this module adds only the one dimension the registry lacks: the preload tier.
+
+Consumers: ``scripts/cache/preload_ml_models.py`` (what to download) and the CI
+cache validation (``ci_artifact_model_ids`` — the set baked into the ml-models
+artifact and loaded offline by the test jobs). The drift guard in
+``tests/unit/podcast_scraper/test_ml_model_manifest.py`` keeps every
+summary/evidence id here consistent with ``ModelRegistry`` — which is how MiniLM
+silently went missing from CI and broke the offline search tests (#897).
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from podcast_scraper import config_constants as cc
+
+# Pyannote diarization pipeline id (mirrors config.py's diarization default /
+# pyannote_provider.py). Not a ModelRegistry "capability" model.
+DIARIZATION_PIPELINE_ID = "pyannote/speaker-diarization-3.1"
+
+MODEL_KINDS = frozenset({"whisper", "spacy", "summary", "embedding", "qa", "nli", "diarization"})
+# Kinds whose ids must be central ``ModelRegistry`` entries.
+REGISTRY_BACKED_KINDS = frozenset({"summary", "embedding", "qa", "nli"})
+
+# Tier semantics:
+#   test        -- preloaded by default ``make preload-ml-models`` (dev/test)
+#   ci_artifact -- baked into the ml-models CI artifact AND loaded offline by the
+#                  test jobs; CI cache-validation checks exactly this set
+#   production  -- preloaded by ``--production`` (nightly / full bake)
+#   gated       -- requires HF_TOKEN at download time (pyannote diarization)
+MODEL_TIERS = frozenset({"test", "ci_artifact", "production", "gated"})
+
+
+class MLModelSpec(NamedTuple):
+    """A preloadable model: ``model_id`` (HF repo id / Whisper name / spaCy
+    package), ``kind`` (one of ``MODEL_KINDS``), and ``tiers`` (subset of
+    ``MODEL_TIERS``)."""
+
+    model_id: str
+    kind: str
+    tiers: frozenset
+
+
+_T = frozenset({"test", "ci_artifact", "production"})  # core: everywhere
+_CI = frozenset({"ci_artifact", "production"})  # artifact + nightly
+_PROD = frozenset({"production"})  # nightly / full bake only
+
+REQUIRED_ML_MODELS: tuple[MLModelSpec, ...] = (
+    # Whisper (ids from config_constants whisper defaults)
+    MLModelSpec(cc.TEST_DEFAULT_WHISPER_MODEL, "whisper", _T),  # tiny.en
+    MLModelSpec(cc.PROD_DEFAULT_WHISPER_MODEL, "whisper", _CI),  # base.en
+    # spaCy (NER / speaker detection)
+    MLModelSpec(cc.TEST_DEFAULT_NER_MODEL, "spacy", _T),  # en_core_web_sm
+    # Summarization -- ids are central ModelRegistry keys (params live there)
+    MLModelSpec("facebook/bart-base", "summary", _T),
+    MLModelSpec("allenai/led-base-16384", "summary", _T),
+    MLModelSpec("google/long-t5-tglobal-base", "summary", _CI),
+    MLModelSpec("google/flan-t5-base", "summary", _CI),
+    MLModelSpec("facebook/bart-large-cnn", "summary", _PROD),
+    MLModelSpec("allenai/led-large-16384", "summary", _PROD),
+    MLModelSpec("google/long-t5-tglobal-large", "summary", _PROD),
+    MLModelSpec("google/flan-t5-large", "summary", _PROD),
+    # Evidence stack -- ids from config_constants DEFAULT_* (also registry keys).
+    # MiniLM is corpus-wide core -> ci_artifact (the model missing from the #897 CI).
+    MLModelSpec(cc.DEFAULT_EMBEDDING_MODEL, "embedding", _T),
+    MLModelSpec(cc.DEFAULT_EXTRACTIVE_QA_MODEL, "qa", _PROD),
+    MLModelSpec(cc.DEFAULT_NLI_MODEL, "nli", _PROD),
+    # Diarization (gated; needs HF_TOKEN)
+    MLModelSpec(DIARIZATION_PIPELINE_ID, "diarization", frozenset({"gated", "production"})),
+)
+
+
+def models_for_tier(tier: str) -> tuple[MLModelSpec, ...]:
+    """All manifest entries whose ``tiers`` include ``tier``."""
+    return tuple(m for m in REQUIRED_ML_MODELS if tier in m.tiers)
+
+
+def model_ids_for_tier(tier: str, kind: str | None = None) -> list[str]:
+    """Model ids in ``tier`` (optionally filtered to one ``kind``)."""
+    return [m.model_id for m in models_for_tier(tier) if kind is None or m.kind == kind]
+
+
+def ci_artifact_model_ids(kind: str | None = None) -> list[str]:
+    """Model ids baked into the CI ml-models artifact (optionally one ``kind``).
+
+    The CI cache-validation reads this so the required-model list lives here, not
+    in duplicated bash arrays.
+    """
+    return model_ids_for_tier("ci_artifact", kind=kind)

--- a/tests/unit/podcast_scraper/test_ml_model_manifest.py
+++ b/tests/unit/podcast_scraper/test_ml_model_manifest.py
@@ -1,0 +1,115 @@
+"""Drift guard for the ML preload manifest (#917).
+
+Keeps ``model_manifest.REQUIRED_ML_MODELS`` consistent with the other sources of
+truth so a new model added in one place can't silently go missing from preload /
+CI (the failure mode behind the #897 MiniLM saga):
+
+- summary + evidence ids must be central ``ModelRegistry`` entries (params live
+  there, autoresearch-fed) -- the manifest only adds the preload tier;
+- the ``DEFAULT_*_MODEL`` constants and summarizer aliases must resolve into it;
+- summary models must be in ``ALLOWED_HUGGINGFACE_MODELS``;
+- MiniLM must be in the CI artifact tier.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper import config_constants as cc
+from podcast_scraper.providers.ml import model_manifest as mm, summarizer
+from podcast_scraper.providers.ml.model_registry import ModelRegistry
+
+pytestmark = pytest.mark.unit
+
+
+def _spec(model_id: str) -> mm.MLModelSpec | None:
+    return next((m for m in mm.REQUIRED_ML_MODELS if m.model_id == model_id), None)
+
+
+def test_manifest_entries_are_structurally_valid():
+    seen: set[str] = set()
+    for m in mm.REQUIRED_ML_MODELS:
+        assert m.kind in mm.MODEL_KINDS, f"{m.model_id}: unknown kind {m.kind!r}"
+        assert m.tiers, f"{m.model_id}: no tiers"
+        assert m.tiers <= mm.MODEL_TIERS, f"{m.model_id}: bad tiers {m.tiers - mm.MODEL_TIERS}"
+        assert m.model_id not in seen, f"duplicate manifest entry: {m.model_id}"
+        seen.add(m.model_id)
+
+
+def test_summary_and_evidence_ids_are_central_registry_entries():
+    # The "one central place" guard: every registry-backed kind must reference a
+    # real ModelRegistry id, so the manifest never drifts from the autoresearch
+    # registry (it adds only the preload tier, never new model params).
+    for m in mm.REQUIRED_ML_MODELS:
+        if m.kind in mm.REGISTRY_BACKED_KINDS:
+            assert (
+                m.model_id in ModelRegistry._registry
+            ), f"{m.model_id} ({m.kind}) is not a ModelRegistry entry"
+
+
+def test_every_default_evidence_model_is_in_the_manifest():
+    assert (
+        _spec(cc.DEFAULT_EMBEDDING_MODEL) and _spec(cc.DEFAULT_EMBEDDING_MODEL).kind == "embedding"
+    )
+    assert (
+        _spec(cc.DEFAULT_EXTRACTIVE_QA_MODEL) and _spec(cc.DEFAULT_EXTRACTIVE_QA_MODEL).kind == "qa"
+    )
+    assert _spec(cc.DEFAULT_NLI_MODEL) and _spec(cc.DEFAULT_NLI_MODEL).kind == "nli"
+
+
+def test_minilm_is_in_the_ci_artifact_tier():
+    # Regression guard for the #897 saga: the embedding model the offline search
+    # tests load MUST be baked into the CI artifact.
+    spec = _spec(cc.DEFAULT_EMBEDDING_MODEL)
+    assert spec is not None and "ci_artifact" in spec.tiers
+    assert cc.DEFAULT_EMBEDDING_MODEL in mm.ci_artifact_model_ids()
+
+
+def test_summary_models_are_in_the_security_allowlist():
+    for m in mm.REQUIRED_ML_MODELS:
+        if m.kind == "summary":
+            assert (
+                m.model_id in cc.ALLOWED_HUGGINGFACE_MODELS
+            ), f"{m.model_id} preloaded but not in ALLOWED_HUGGINGFACE_MODELS"
+
+
+def test_test_default_summary_aliases_resolve_into_the_manifest():
+    manifest_ids = {m.model_id for m in mm.REQUIRED_ML_MODELS}
+    for alias in (cc.TEST_DEFAULT_SUMMARY_MODEL, cc.TEST_DEFAULT_SUMMARY_REDUCE_MODEL):
+        resolved = summarizer.resolve_model_name(alias)
+        assert resolved in manifest_ids, f"{alias} -> {resolved} not in manifest"
+
+
+def test_ci_artifact_set_covers_the_offline_test_dependencies():
+    ci = set(mm.ci_artifact_model_ids())
+    expected = {
+        cc.TEST_DEFAULT_WHISPER_MODEL,
+        cc.PROD_DEFAULT_WHISPER_MODEL,
+        cc.TEST_DEFAULT_NER_MODEL,
+        "facebook/bart-base",
+        "allenai/led-base-16384",
+        "google/long-t5-tglobal-base",
+        "google/flan-t5-base",
+        cc.DEFAULT_EMBEDDING_MODEL,
+    }
+    missing = expected - ci
+    assert not missing, f"CI artifact tier missing required models: {missing}"
+
+
+def test_evidence_aliases_resolve_to_manifest_ids():
+    for alias, kind in (("minilm-l6", "embedding"), ("roberta-squad2", "qa")):
+        resolved = ModelRegistry.resolve_evidence_model_id(alias)
+        spec = _spec(resolved)
+        assert spec is not None and spec.kind == kind, f"alias {alias} -> {resolved}"
+
+
+def test_pinned_summary_models_are_in_the_manifest():
+    manifest_ids = {m.model_id for m in mm.REQUIRED_ML_MODELS}
+    for model_id in (
+        "google/flan-t5-base",
+        "google/flan-t5-large",
+        "google/long-t5-tglobal-base",
+        "google/long-t5-tglobal-large",
+    ):
+        assert cc.get_pinned_revision_for_model(model_id) is not None
+        assert model_id in manifest_ids, f"pinned {model_id} not in manifest"


### PR DESCRIPTION
Addresses the model-list drift that caused the MiniLM CI saga (#897): the set of
required ML models was hand-maintained in ~6 places with no cross-check.

## What this does
- **`providers/ml/model_manifest.py`** — `REQUIRED_ML_MODELS`, the single source
  of truth for *which* models to preload and into which **tier**
  (test / ci_artifact / production / gated). It **derives, not duplicates**:
  summary + evidence ids are central `ModelRegistry` keys (autoresearch-fed via
  `promote_baseline` → `ModeConfiguration`); whisper/spaCy come from
  `config_constants`; pinned revisions stay in `get_pinned_revision_for_model`.
  The manifest adds only the one dimension the registry lacks — the preload tier.
- **Drift-guard test** (9 cases) — registry-backed ids must be real
  `ModelRegistry` entries, every `DEFAULT_*_MODEL` + summarizer alias resolves in,
  summary models are in `ALLOWED_HUGGINGFACE_MODELS`, and **MiniLM is in the
  `ci_artifact` tier** (the exact model that went missing in #897).
- **`scripts/cache/verify_required_models.py`** — reads
  `ci_artifact_model_ids()` and checks each is cached. Light imports
  (`config_constants` only), so it runs at the pre-install validate step.
- **CI de-dup** — replaced ~8 duplicated model-validation bash arrays across
  `python-app.yml` (preload + test-integration[-fast] + test-e2e[-fast]) and
  `nightly.yml` with the verifier call. **−351 lines.** Now also validates
  **MiniLM + en_core_web_sm**, which the old arrays never checked. The verifier
  also *enforces* that preload bakes the manifest set — CI goes red if they drift.

## Deferred (noted, not a gap)
- `preload_ml_models.py` still keeps its own internal default lists rather than
  iterating the manifest directly. The drift test + the CI verifier already guard
  any divergence (preload must bake `ci_artifact` or CI fails), so this is a
  cosmetic follow-up, not a coverage hole. Leaving **#917 open** for it.

Refs #917