### PR TITLE
fix(viewer): close DateChip popover on preset select (unblocks stack-test)

### DIFF
--- a/web/gi-kg-viewer/src/components/shared/DateChip.vue
+++ b/web/gi-kg-viewer/src/components/shared/DateChip.vue
@@ -73,18 +73,26 @@ watch(
   },
 )
 
+// Selecting a preset commits the value AND dismisses the popover. Without the
+// close(), the open panel keeps overlaying the content below the chip and
+// intercepts the next click (e.g. a digest recent row) — useFilterChipPopover
+// only auto-closes on outside-pointerdown/Escape, which a hit-tested click never
+// reaches, so the UI deadlocks (stack-jobs-flow "wait, evaluate" hung 15m on it).
 function setAll(): void {
   emit('update:modelValue', '')
+  close()
 }
 
 function setPreset(days: 7 | 30 | 90): void {
   emit('update:modelValue', localYmdDaysAgo(days))
+  close()
 }
 
 function commitCustom(): void {
   const v = customInput.value.trim()
   if (!/^\d{4}-\d{2}-\d{2}$/.test(v) && v !== '') return
   emit('update:modelValue', v)
+  close()
 }
 
 function presetButtonClass(active: boolean): string {


### PR DESCRIPTION
## Problem

The **Stack test** has been failing on `main` (`stack-jobs-flow.spec.ts:578` → `validateCorpusDataLoadedAfterJob`): after picking **All time** in the Digest date chip, clicking the first digest recent row hangs for the full 15-min test budget. Confirmed not a flake — failed identically on a re-run, and stack-test runs on cloud runners (no DGX/contention involved).

## Root cause

`DateChip`'s preset handlers (`setAll` / `setPreset` / `commitCustom`) emit the new value but never **close** the popover. `useFilterChipPopover` only auto-closes on outside-pointerdown / Escape. So the open panel keeps overlaying the content below the chip; Playwright's click hit-test sees the digest row occluded by the popover and waits for it to clear — but it only clears on a click the test won't issue until the row is unoccluded. Deadlock → timeout.

## Fix

Call `close()` after each preset commit so the popover dismisses on selection (standard chip-popover UX), unblocking interaction with the content below.

## Validation

- `npm run build` (vue-tsc strict + vite) green locally.
- The Stack test exercises this exact flow end-to-end; this PR should turn it green.

Isolated single-file change, intentionally separate from in-flight feature work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)