### PR TITLE
fix(viewer): cap digest topic-bands height (fixes Stack test firefox click race)

### DIFF
--- a/web/gi-kg-viewer/src/components/digest/DigestView.vue
+++ b/web/gi-kg-viewer/src/components/digest/DigestView.vue
@@ -850,7 +850,7 @@ onBeforeUnmount(() => {
 
       <div
         v-if="digest.topics.length"
-        class="min-w-0 overflow-x-hidden"
+        class="min-w-0 max-h-[40vh] overflow-x-hidden overflow-y-auto"
         role="region"
         aria-label="Topic bands"
       >


### PR DESCRIPTION
## Problem
Stack test has been red since the regression window 2026-05-30→06-08: `stack-jobs-flow` "configure mock feeds, run pipeline job, wait, evaluate" hangs 15 min on `digestRows.first().click()`.

## Root cause (bisected to #890)
#890 (PRD-033) added ~175 lines to the digest **topic-bands** (cross-show toggles/rows, feed + topic links), making that section tall enough to push the **Recent** rows below the fold. The Recent list is a nested `overflow-y-auto` inside the already-scrollable digest; in **firefox**, Playwright's scroll-into-view + hit-test races firefox's async scroll on the nested scroller, so the click never lands. Chromium settles synchronously → firefox-only. The element is genuinely actionable (real users click fine) — it's a Playwright-firefox artifact #890 exposed.

## Fix
Bound the topic-bands region to `max-h-[40vh]` with its own `overflow-y-auto`. All #890 functionality stays (bands scroll internally), the Recent rows stay above the fold, no outer scroll is needed, and the race never triggers.

## Verified
Desktop-Firefox Playwright repro against a real corpus: first Recent row click now succeeds in **~55 ms** (was 15-min timeout), opens the episode rail; 3 topic bands + cross-show toggle still render; `vue-tsc` strict build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)