### PR TITLE
feat(autoresearch): batch-3 championships — DGX vs cloud (#928/#929/#930/#931) + DGX whisper bug fix + vLLM default flip

### DIFF
--- a/.ai-coding-guidelines-quick.md
+++ b/.ai-coding-guidelines-quick.md
@@ -19,8 +19,9 @@
 
 1. **Never:** NEVER push without showing `git status` and `git diff` first
 2. **Never:** NEVER push without explicit user approval
-3. Show changes → ask approval → THEN push
-4. Pre-commit hook already ran `make ci-fast` checks, so no need to run `make ci` again
+3. **Always:** ALWAYS rebase onto latest `origin/main` before pushing a feature branch (`git fetch origin main && git rebase origin/main`). Applies to first push AND every subsequent push. Force-push the rebased branch with `--force-with-lease` (never plain `--force`). Force-push to `main`/`master` remains forbidden.
+4. Show changes → ask approval → rebase → THEN push
+5. Pre-commit hook already ran `make ci-fast` checks, so no need to run `make ci` again
 
 ### File Location Rule (MANDATORY)
 

--- a/.ai-coding-guidelines.md
+++ b/.ai-coding-guidelines.md
@@ -197,7 +197,9 @@ git push origin fix/descriptive-name
 4. **ALWAYS show `git status` before asking to push**
 5. **ALWAYS show `git diff` or summary of changes before asking to push**
 6. **ALWAYS wait for explicit approval (user says "push", "go ahead", "yes", etc.)**
-7. **ONLY push after steps 4-6 are complete AND user has approved**
+7. **ALWAYS rebase onto latest `origin/main` before push** — `git fetch origin main && git rebase origin/main`. Applies to first push AND every subsequent push of a feature branch, so the PR diff is always against current main (no "behind by N" state). After rebase, force-push with `git push --force-with-lease` (never plain `--force`). Force-push to `main`/`master` remains forbidden. Hotfix-direct-to-main is the only exception — see Git Workflow / Hotfix section in AGENTS.md.
+8. **If the rebase produces conflicts:** STOP. Show the user the conflict files + `git status` output before resolving. Don't attempt resolution unilaterally on files outside the branch's own scope.
+9. **ONLY push after steps 4-7 are complete AND user has approved**
 
 **Note:** Pre-commit hooks already run `make ci-fast` checks. For **viewer-heavy** work, agents may run **`make ci-ui-fast`** locally first (Playwright + no Python **`tests/e2e/`**); the hook still runs **`make ci-fast`**. After pre-commit passes, you can push directly without running `make ci` again.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,25 @@ Tests alone are not a substitute. See `docs/guides/AGENT_BROWSER_LOOP_GUIDE.md`.
 - Default: stage specific files for the current task (`git add <file>`).
   Avoid blind `git add -A` unless the user explicitly says so.
 
+### Always rebase before pushing a feature branch
+
+- BEFORE the first push of a feature branch: `git fetch origin main && git rebase origin/main`.
+- BEFORE each subsequent push: same — rebase against the latest main so the PR
+  diff is always against current main, not a stale base.
+- Exception: hotfix-direct-to-main (already covered above) does not need rebase
+  — it goes straight onto main.
+- Why: linear history when the PR lands; PR diff shows only the branch's
+  changes (no "behind by N"); latent main-vs-branch conflicts surface earlier
+  than at merge time.
+- Force-push is REQUIRED after a rebase. Use `git push --force-with-lease`
+  (not `--force`) on feature branches so a teammate's concurrent push isn't
+  silently overwritten.
+- Force-push to `main` / `master` remains forbidden (covered by the hotfix
+  section above).
+- If a rebase produces conflicts, STOP and show the user the conflict files
+  alongside `git status` output before resolving. Don't attempt resolution
+  unilaterally on files outside the branch's own scope.
+
 ### Active-merge safety (when `.git/MERGE_HEAD` exists)
 
 - NEVER `git stash` during a merge — destroys conflict resolutions.

--- a/Makefile
+++ b/Makefile
@@ -471,6 +471,15 @@ quality: complexity deadcode docstrings spelling
 	# TODO(transformers PYSECs): drop ignores after bumping transformers to a
 	#   patched 5.x release (paired with the CVE-2026-1839 ignore above).
 	#
+	# Ignore CVE-2025-3000 (torch.jit.script memory corruption).
+	#   Local-access attack on the JIT script path. We don't call
+	#   ``torch.jit.script`` directly anywhere in the codebase; torch is loaded
+	#   transitively via transformers / sentence-transformers / pyannote at
+	#   higher levels. Same exploitation class as the PYSEC-2025-189..197 block
+	#   above (no fix version published; 2.12.0 is latest).
+	# TODO(CVE-2025-3000): drop ignore when torch upstream ships a fixed
+	#   version and we bump the pin.
+	#
 	# Note: If protobuf is updated to >=6.33.5 or >=7.0.0, this ignore can be removed
 	# Note: en-core-web-sm is installed from GitHub (not PyPI), so it cannot be audited by pip-audit
 	#       If it appears in audit output, it can be safely ignored as it's not from PyPI
@@ -504,7 +513,8 @@ quality: complexity deadcode docstrings spelling
 		--ignore-vuln PYSEC-2025-217 \
 		--ignore-vuln PYSEC-2025-218 \
 		--ignore-vuln PYSEC-2026-161 \
-		--ignore-vuln MAL-2026-4750
+		--ignore-vuln MAL-2026-4750 \
+		--ignore-vuln CVE-2025-3000
 	# PYSEC-2026-161 (starlette<1.0.1, Host-header URL-path poisoning, GHSA-86qp-5c8j-p5mr):
 	# Not exploitable in this codebase — grep -rn 'request.url.path' src/ is empty;
 	# FastAPI routing uses the real request path, not the reconstructed URL. Traefik

--- a/data/eval/configs/finale/finale_928_cell_c_qwen36_vllm_vs_ollama_2026_06.yaml
+++ b/data/eval/configs/finale/finale_928_cell_c_qwen36_vllm_vs_ollama_2026_06.yaml
@@ -1,0 +1,45 @@
+# #928 Cell C — proper-isolation serving-stack comparison.
+#
+# Same model family (Qwen3.6-35B-A3B / qwen3.5:35b ≈ Qwen3.6-35B-A3B at Q4_K_M),
+# different server: Ollama (Q4 GGUF, llama.cpp runtime) vs vLLM (bf16,
+# transformers runtime on nvcr.io/nvidia/vllm:26.05-py3).
+#
+# Isolates the SERVING STACK variable that the parent #928 eval
+# (R1-Distill vLLM vs Qwen3.6 Ollama) conflated with both model and
+# quantization. This config does NOT re-include R1-Distill — the
+# parent eval's verdict for R1 stands.
+
+tag: finale_928_cell_c_qwen36_vllm_vs_ollama_2026_06
+
+runs_glob:
+  - data/eval/runs/autoresearch_prompt_ollama_qwen35_35b_smoke_paragraph_v1_curated_5feeds_smoke_v1
+  - data/eval/runs/autoresearch_prompt_vllm_qwen36_35b_a3b_curated_5feeds_smoke_v1
+
+metrics_filename: metrics_vs_silver_opus47_smoke_v1.json
+
+strata:
+  - name: dgx_qwen36_family
+    match:
+      - autoresearch_prompt_ollama_qwen35_35b_
+      - autoresearch_prompt_vllm_qwen36_35b_a3b_
+
+promotion:
+  per_stratum_top_k: 2
+  floor_fraction: 0.3
+  overall_cap: 2
+  carte_blanche:
+    - autoresearch_prompt_ollama_qwen35_35b_
+    - autoresearch_prompt_vllm_qwen36_35b_a3b_
+
+judges:
+  primary:
+    kind: sonnet46
+    model: claude-sonnet-4-6
+  cross_check:
+    kind: openai_chat
+    model: gpt-5.4
+    top_n_per_stratum: 2
+
+max_episodes_per_finalist: 5
+cost_cap_usd: 5.0
+output_root: data/eval/runs/finale

--- a/data/eval/configs/finale/finale_928_summary_dgx_local_2026_06.yaml
+++ b/data/eval/configs/finale/finale_928_summary_dgx_local_2026_06.yaml
@@ -1,0 +1,40 @@
+# #928 — DGX summary championship: Ollama qwen3.5:35b vs vLLM DeepSeek-R1-Distill-32B.
+#
+# Both candidates are LOCAL (DGX-served, $0 marginal cost). This is the
+# pure "local frontier" comparison per the user's framing: how far can
+# DGX go for summary, independent of cloud Gemini.
+
+tag: finale_928_summary_dgx_local_2026_06
+
+runs_glob:
+  - data/eval/runs/autoresearch_prompt_ollama_qwen35_35b_smoke_paragraph_v1_curated_5feeds_smoke_v1
+  - data/eval/runs/autoresearch_prompt_vllm_r1distill_32b_smoke_paragraph_v1_curated_5feeds_smoke_v1
+
+metrics_filename: metrics_vs_silver_opus47_smoke_v1.json
+
+strata:
+  - name: dgx_le_40b
+    match:
+      - autoresearch_prompt_ollama_qwen35_35b_
+      - autoresearch_prompt_vllm_r1distill_
+
+promotion:
+  per_stratum_top_k: 2
+  floor_fraction: 0.3              # generous — R1's ROUGE is low, want it in panel anyway
+  overall_cap: 2
+  carte_blanche:
+    - autoresearch_prompt_ollama_qwen35_35b_
+    - autoresearch_prompt_vllm_r1distill_
+
+judges:
+  primary:
+    kind: sonnet46
+    model: claude-sonnet-4-6
+  cross_check:
+    kind: openai_chat
+    model: gpt-5.4
+    top_n_per_stratum: 2
+
+max_episodes_per_finalist: 5
+cost_cap_usd: 5.0
+output_root: data/eval/runs/finale

--- a/docs/guides/eval-reports/EVAL_DIARIZATION_DGX_VS_CLOUD_2026_06.md
+++ b/docs/guides/eval-reports/EVAL_DIARIZATION_DGX_VS_CLOUD_2026_06.md
@@ -1,0 +1,91 @@
+# EVAL — Diarization championship phase 1 (3-way: MPS / CUDA / CPU), 2026-06-10
+
+**Issue:** #930
+**Branch:** `feat/autoresearch-batch-3-championships`
+**Dataset:** v2 audio fixtures, 5 episodes (RFC-059 §2 macOS `say` generation)
+**Status:** Phase 1 complete (3 GPU/CPU backends measured). Gemini speaker-detection comparison is a follow-up — no Gemini speech provider in repo yet.
+
+---
+
+## TL;DR
+
+**pyannote-on-Apple-MPS is essentially tied with pyannote-on-DGX-CUDA in latency.** Pure CPU is **~17× slower** than either GPU path. The operator's MacBook is a fully viable diarization platform for podcast workloads at the scale we run — DGX adds value primarily for x86/ARM-no-GPU deployments (cheap VPS, CI runners) and for keeping load off the laptop.
+
+## Latency results (5 v2 episodes, ~5 min each)
+
+| Backend | Hardware | Episodes | Mean wall (s) | Realtime multiple |
+| --- | --- | ---: | ---: | ---: |
+| **Apple MPS** | M4 Pro laptop (auto-pick) | 5/5 | **23.35** | **~13×** |
+| **NVIDIA CUDA** | DGX GB10 via `:8001` | 5/5 | **23.50** | **~13×** |
+| **Pure CPU** | M4 Pro with `LOCAL_DIARIZE_DEVICE=cpu` | 1/5 | **415.48** | **0.7×** |
+
+Per-episode breakdown:
+
+| Episode | Apple MPS (s) | NVIDIA CUDA (s) | Pure CPU (s) |
+| --- | ---: | ---: | ---: |
+| p01_e01 | 23.1 | 25.7 | **415.5** |
+| p02_e01 | 27.1 | 26.7 | (not run — CPU too slow) |
+| p03_e01 | 20.6 | 19.9 | (not run) |
+| p04_e01 | 23.6 | 23.4 | (not run) |
+| p05_e01 | 22.4 | 21.8 | (not run) |
+
+## Speaker count detection (3-backend, 5 episodes)
+
+All three backends detect **3 speakers per episode** on v2 fixtures (MPS and CUDA always 3; the partial CPU run also 3). The transcript-label parser reports 5 "ground-truth" speakers — but **the v2 audio is generated with a single TTS voice** (`tests/scripts/transcripts_to_mp3.py` defaults to `say --voice Alex` for all roles per the current state of `#934`). So pyannote can't separate Maya / Liam / Ad acoustically when they all speak with Alex's voice; clustering on residual acoustic features lands at 3.
+
+**Until `#934` lands distinct voices per speaker, speaker-count accuracy on v2 fixtures is not a useful pyannote-quality signal.** Segmentation density (segments-per-turn ratio) is the cleaner number on this dataset.
+
+## Segmentation density
+
+Segments produced by pyannote ÷ turn-changes in the transcript:
+
+| Backend | Mean ratio (5 ep) | Range |
+| --- | ---: | --- |
+| Apple MPS | 1.07 | 0.87 – 1.28 |
+| NVIDIA CUDA | 1.08 | 0.87 – 1.28 |
+| Pure CPU | 1.00 (1 ep) | n/a |
+
+All three backends produce **roughly the same segmentation density** (~1.0× turn-changes), which is what you'd hope for: identical model, identical inputs, identical output up to device-level numerical noise. The GPU vs CPU difference is purely a latency story for this model + dataset, not a quality story.
+
+## What this means operationally
+
+**The "no DGX" path is viable for podcast diarization workloads** if the operator runs on Apple Silicon. ~25 s per 5-min episode on an M4 Pro is fine for batch processing dozens of episodes per session. The DGX adds value when:
+
+1. The host machine has no GPU (CPU = 17× slower → unworkable for prod).
+2. Diarization runs in production CI / VPS infra (no Apple Silicon there).
+3. The operator wants to keep load off the laptop while transcription / KG also runs.
+
+For laptop-driven manual processing, **either path is fine**. This is a strong signal for the `local` profile shape (`config/profiles/local.yaml`): keep the in-process pyannote default for laptop runs, no DGX required.
+
+## What's NOT in this report (gaps + follow-ups)
+
+1. **Gemini speech speaker detection** — no Gemini speech provider in this repo. `cloud_balanced.yaml` references it but the provider class needs wiring. Filed as part of the broader cloud-provider-pluggability work (no separate ticket yet).
+2. **Proper DER** (Diarization Error Rate) — requires time-aligned speaker ground truth, which v2 fixtures don't ship. Could be derived from whisper word-level timestamps as an alignment proxy. Filed for follow-up.
+3. **Distinct voices in v2 fixtures** (#934) — until this lands, speaker-count is the wrong signal. Documented above.
+4. **Diarization client resilience** (#954, filed today) — independent of this evaluation but matters for prod reliability under shared-GPU contention.
+5. **Burst latency** — only sequential measurements here. Concurrent diarization calls would test the queueing behavior that #954 is filed against.
+
+## Recommendation
+
+**Phase 1 verdict**: keep pyannote as the diarization engine across all profile shapes. Device selection picks itself:
+
+- `local` profile (laptop, no DGX): in-process pyannote with `device=auto` → picks MPS on Apple Silicon → ~13× realtime
+- `cloud_with_dgx_*` profiles (DGX available): route to `:8001/v1/diarize` → ~13× realtime, off-laptop
+- `cloud_*` profiles (no DGX, no GPU): currently `speaker_detector_provider: gemini` — keep until either (a) Gemini speech is wired and benchmarked, or (b) the operator decides cost > convenience and migrates to a cloud pyannote service
+
+Phase 2 (when the gaps above close): real DER measurement vs Gemini speaker detection, burst-latency, fixture quality once #934 voices land.
+
+## Artifacts
+
+- `scripts/eval/score/diarization_dgx_vs_cloud_v1.py` — harness with 3 backends (`dgx`, `local` with device override, `gemini` slot for future)
+- `data/eval/runs/diarization_dgx_vs_cloud_v1/dgx/metrics.json` — DGX CUDA 5/5
+- `data/eval/runs/diarization_dgx_vs_cloud_v1/local-mps/metrics.json` — Apple MPS 5/5
+- `data/eval/runs/diarization_dgx_vs_cloud_v1/local-cpu/metrics.json` — Pure CPU 1/5
+
+## References
+
+- Issue: #930
+- Parent epic: #927 (DGX-vs-cloud autoresearch programme)
+- pyannote-on-DGX deploy: `infra/dgx/pyannote-server/` (#926)
+- Distinct-voice v2 fixtures: #934
+- Diarization client resilience gap: #954 (filed today during pyannote-wedge investigation)

--- a/docs/guides/eval-reports/EVAL_HYBRID_ROUTING_2026_06.md
+++ b/docs/guides/eval-reports/EVAL_HYBRID_ROUTING_2026_06.md
@@ -16,13 +16,19 @@ tradeoffs land."
 | Profile shape | Whisper | Diarize | Summary | Net change from before this PR |
 | --- | --- | --- | --- | --- |
 | `local.yaml` (laptop, no DGX) | openai-whisper / MPS | pyannote / MPS | hermes3:8b (Ollama on CPU) | None — confirmed |
-| `cloud_with_dgx_*` (DGX-equipped) | openai-whisper / `:8002` (with operational caveat) | pyannote / `:8001` | Ollama qwen3.5:35b on `:11434` | None — confirmed |
+| `cloud_with_dgx_*` (DGX-equipped) | **openai-whisper / `:8002` — promoted after temperature-bug fix this PR** | pyannote / `:8001` | Ollama qwen3.5:35b on `:11434` | Transcription default flips to DGX `:8002` (was: MPS/cloud per pre-Cell-C draft) |
 | `cloud_*` (no DGX, cloud-OK) | cloud Whisper API | Gemini speech (current — unmeasured this batch) | gemini-2.5-flash-lite | None — not re-litigated |
 
-The "no change" net is honest: the **evidence base under each
-profile improved**, but no profile-default shifts. That's the right
-outcome for a research batch — measure what's there, document the
-operating points, change defaults only when evidence demands it.
+After late-batch findings landed, two defaults DO flip:
+
+- **`cloud_with_dgx_*` transcription** → `whisper-openai` on
+  `dgx:8002` (after the temperature-schedule fix this PR).
+- **vLLM autoresearch service default** → `26.05-py3 +
+  Qwen3.6-35B-A3B` (after Cell C confirmed parity with Ollama
+  on the same model family).
+
+The `local.yaml` and `cloud_*` shapes stay as-is — evidence base
+under each profile improved, no default change needed.
 
 ## What each underlying eval concluded
 
@@ -71,35 +77,49 @@ indistinguishable when serving the same model family).
 
 Full report: `docs/guides/eval-reports/EVAL_SUMMARY_DGX_LOCAL_2026_06.md`
 
-### Transcription (#929 partial)
+### Transcription (#929 — done; 4-way, post-fix)
 
-**3-way: openai-whisper on Apple MPS vs DGX-CUDA `:8002` vs pure CPU.**
+**4-way: openai-whisper on Apple MPS vs DGX `:8002` (fixed) vs pure
+CPU vs DGX faster-whisper on `:8000` (speaches image).**
 
-- MPS clean: 1.6× realtime mean (with 13-min cold start dragging
-  the mean; warm runs are 2.6-3.8× realtime), WER 0.10 mean on v2
-  fixtures.
-- DGX CUDA under concurrent vLLM load: WER spiked to 8.21 on one
-  episode (13,136 hyp words for a 1,519-word reference — model
-  started hallucinating after the first segment, consistent with
-  CPU-fallback under GPU pressure / the same auto-unload-then-reload
-  regression as `#948`'s speaches).
-- Pure CPU (1 episode): 1.5× realtime, WER 0.109 — basically tied
-  with MPS on warm runs. **MPS only ~1.8× faster than CPU on warm,
-  not the 17× extrapolated from diarization.** Means CPU fallback
-  for laptop `local.yaml` is production-viable when MPS is busy.
+- **MPS** (laptop): WER 0.096 mean, 1.6× realtime (warm 2.6-3.8×).
+  Clean local default.
+- **Pure CPU** (M4 Pro, 5 episodes): WER 0.137 mean, 2.34× realtime.
+  Quality 30% behind MPS, still production-viable. **MPS is only
+  ~1.4× faster than CPU on this workload, not 17×** — the
+  diarization extrapolation didn't hold for openai-whisper.
+- **DGX openai-whisper on `:8002`, AFTER the bug fix this PR**:
+  WER 0.102 mean (within 6% of MPS, inside scoring noise), **4.56×
+  realtime** (~3× faster than MPS, ~2× faster than CPU). **New
+  production winner for DGX-equipped profiles.**
+- **DGX faster-whisper (speaches image, `:8000`)**: still broken —
+  empty output on 4/5 episodes, hallucinations on the 5th. Separate
+  bug from the openai-whisper one (lives in speaches container
+  config). Filed as follow-up; NOT a production candidate.
 
-**Speaches/faster-whisper engine comparison stays out of scope**
-per `#952` — that gate is what unlocks the proper 4-way (MPS vs
-CUDA vs CPU vs ctranslate2-CUDA) eval.
+**The temperature-schedule bug**: pre-fix, DGX openai-whisper was
+producing WER 3.20 mean (hallucinations with 2-9× extra words). The
+synthesis-pre-Cell-C version of this report recommended NOT routing
+to DGX whisper because of those numbers. **Root cause was a
+config bug** in `infra/dgx/whisper-server/app.py` (forced
+`temperature=0.0` scalar disabled openai-whisper's built-in
+fallback schedule, which is what saves long audio from
+autoregressive runaway). Fixed in this PR. Re-run confirmed clean.
+
+**DGX-over-Tailscale hang pattern**: The post-fix sweep hit
+intermittent HTTP-response hangs (server returns 200 OK, body
+stuck mid-transit over Tailscale). Worked around per-episode for
+this eval. Filed as **#956** — applies to every DGX consumer
+(whisper, pyannote, vLLM, future agents), not just whisper.
 
 **Net effect on routing**:
 
-- Laptop runs → MPS openai-whisper. Stable, fast, simple.
-- DGX runs → openai-whisper on `:8002` **with the operational caveat**
-  that GPU contention with concurrent vLLM produces hallucinations.
-  Either dedicate DGX to whisper during transcription windows, or
-  add single-flight + duration-scaled timeout (`#946` pattern) to
-  the client. Filed as a follow-up.
+- Laptop runs (`local.yaml`) → MPS openai-whisper. **No change.**
+- DGX-equipped runs (`cloud_with_dgx_*`) → **route transcription to
+  `whisper-openai` on `:8002` (the fixed container)**. Quality
+  matches MPS within noise, ~3× faster realtime. This **flips** the
+  earlier (pre-Cell-C) recommendation that suggested keeping
+  transcription off the DGX.
 - Cloud Whisper API stays the `cloud_*` default; not retested this
   batch.
 
@@ -122,18 +142,33 @@ this batch: openai-whisper is also 1.5× realtime on **pure CPU**
 on M4 Pro, so MPS isn't load-bearing — the fallback path stays
 production-viable.
 
-### `cloud_with_dgx_*` (DGX-equipped, cost-conscious) — **no change but caveat documented**
+### `cloud_with_dgx_*` (DGX-equipped, cost-conscious) — **transcription flips to DGX after the temperature-bug fix**
 
-- Transcription: openai-whisper at `dgx:8002` (or speaches at
-  `dgx:8000` when `#952` validates it)
+- Transcription: **openai-whisper at `dgx:8002`** (the fixed
+  container, this PR). WER 0.102 mean (within noise of MPS 0.096),
+  4.56× realtime mean — the fastest GPU-accelerated path
+  available. `speaches/faster-whisper` at `dgx:8000` is **NOT**
+  the path; that container has a separate unresolved bug (#952
+  remains gated on the speaches root-cause).
 - Diarization: pyannote at `dgx:8001` (`#926`)
 - Summary: Ollama qwen3.5:35b at `dgx:11434`
 
-Validated for non-contended GPU use. **Operational caveat for prod**:
-running heavy concurrent vLLM autoresearch workloads on the same
-GB10 degrades the whisper container quality (per #929 partial). Either
-schedule transcription windows when vLLM is idle, or apply the
-single-flight + duration-scaled-timeout pattern from `#946`.
+**Operational caveats**:
+
+- The earlier "GPU contention with vLLM degrades whisper" claim
+  was wrong. The DGX whisper container produced byte-identical
+  bad output regardless of vLLM running — it was a config bug in
+  our `app.py` (forced `temperature=0.0` disabled openai-whisper's
+  fallback schedule). Fix is in this PR. After the fix, no
+  contention sensitivity observed.
+- **DGX-over-Tailscale HTTP hangs (`#956`)**: long-blocking calls
+  from the laptop to the DGX occasionally lose the response
+  mid-transit (server returns 200 OK, body stuck). Reproducible.
+  Affects every DGX client, not just whisper. Production
+  consumers should design around this — either async job
+  pattern, or the shared timeout/retry/keepalive layer landed
+  in `#956`. For the eval, the workaround was per-call timeout
+  combined with per-episode invocation.
 
 ### `cloud_*` (no DGX, cloud-OK) — **NOT retested this batch**
 
@@ -147,19 +182,41 @@ Out of scope for this PR. The cloud paths were validated previously
 and this batch didn't relitigate them. They stay the documented
 choice for users without local GPU.
 
-## What this PR DOES NOT change
+## What this PR DOES change (after the late-batch findings)
 
-- No prod profile defaults flip.
-- `cloud_*` profiles aren't relitigated.
-- The faster-whisper-vs-openai-whisper engine question stays at `#952`.
+- **`cloud_with_dgx_*` transcription default**: flips to
+  `whisper-openai` on `dgx:8002` (the fixed container). Earlier
+  drafts of this report had kept transcription off the DGX
+  because of the temperature-bug results.
+- **vLLM autoresearch default**: flips from
+  `25.11-py3 + DeepSeek-R1-Distill-32B` to
+  `26.05-py3 + Qwen3.6-35B-A3B + --max-num-seqs 128`. The Cell C
+  comparison (this PR) showed Qwen3.6-served-by-vLLM ties Ollama-
+  qwen3.5:35b within scoring noise. R1-Distill kept as a
+  one-line revert (`docker-compose.yml.r1-distill.bak` preserved
+  on the DGX).
+
+## What this PR does NOT change
+
+- `local.yaml` profile defaults — confirmed unchanged.
+- `cloud_*` profiles — not relitigated; cloud Whisper API + Gemini
+  flash-lite + `speaker_detector_provider: gemini` stay the
+  documented choice.
+- Ollama qwen3.5:35b remains the summary default for
+  `cloud_with_dgx_*` (Cell C confirmed: Ollama and vLLM tie when
+  serving the same model family; Ollama is operationally simpler).
+- The faster-whisper container (`dgx:8000`, speaches image) stays
+  out of the production routing — separate bug, separate fix.
+  `#952` remains the engine-comparison gate, blocked on that fix.
 
 ## Follow-ups (filed)
 
 | # | What | Why |
 | --- | --- | --- |
-| `#946` (in flight) | Whisper client resilience: duration-scaled timeout + single-flight | Required for DGX whisper to be production-grade under shared-GPU load |
-| `#952` | Validate faster-whisper WER vs openai-whisper on real podcasts | Unblocks the 4-way transcription comparison |
-| `#953` | openai-whisper DGX service (delivered this PR) | — |
+| `#946` (in flight) | Whisper client resilience: duration-scaled timeout + single-flight | Should now consume `#956`'s shared resilience layer instead of bespoke patterns |
+| `#952` | Validate faster-whisper WER vs openai-whisper on real podcasts | Blocked on speaches `compute_type=default` root-cause (the empty-output bug surfaced this batch) |
+| `#953` | openai-whisper DGX service (deployed earlier, **temperature-schedule bug fixed this PR**) | The deploy was correct; the API contract had a bad default. App.py fix in this PR. |
+| `#956` (filed this batch) | DGX-over-Tailscale client resilience (shared timeout/retry/keepalive layer for every DGX consumer) | Long-blocking HTTP over Tailscale loses responses mid-transit; hit during the post-fix #929 sweep |
 | `#954` (filed today) | Diarization client resilience analog to `#946` | Same operational gap surfaced during this batch |
 | `#934` | Distinct voices in v2 fixtures | Required to verdict pyannote speaker-count accuracy |
 | #928 Cell D / E | Quant isolation (R1-Distill on Ollama Q4 GGUF, and Ollama-Qwen3.6 at bf16) | Cell C resolved the serving-stack question; remaining isolated variable is precision |

--- a/docs/guides/eval-reports/EVAL_HYBRID_ROUTING_2026_06.md
+++ b/docs/guides/eval-reports/EVAL_HYBRID_ROUTING_2026_06.md
@@ -1,0 +1,201 @@
+# EVAL — Hybrid routing synthesis (#931), 2026-06-10
+
+**Issue:** #931 (synthesize #928 / #929 / #930 into a routing decision)
+**Branch:** `feat/autoresearch-batch-3-championships`
+**Status:** **Synthesis-in-progress.** Locks in the framing the user articulated during the batch ("we have options, not all users have DGX — we keep options and explore") and pins the per-profile decisions on what the underlying evals concluded.
+
+---
+
+## TL;DR
+
+Three production profile shapes, three different best-of-class
+recommendations. Not "X wins, kill the others" — instead "here's the
+operating point each profile occupies, what we measured, and where the
+tradeoffs land."
+
+| Profile shape | Whisper | Diarize | Summary | Net change from before this PR |
+| --- | --- | --- | --- | --- |
+| `local.yaml` (laptop, no DGX) | openai-whisper / MPS | pyannote / MPS | hermes3:8b (Ollama on CPU) | None — confirmed |
+| `cloud_with_dgx_*` (DGX-equipped) | openai-whisper / `:8002` (with operational caveat) | pyannote / `:8001` | Ollama qwen3.5:35b on `:11434` | None — confirmed |
+| `cloud_*` (no DGX, cloud-OK) | cloud Whisper API | Gemini speech (current — unmeasured this batch) | gemini-2.5-flash-lite | None — not re-litigated |
+
+The "no change" net is honest: the **evidence base under each
+profile improved**, but no profile-default shifts. That's the right
+outcome for a research batch — measure what's there, document the
+operating points, change defaults only when evidence demands it.
+
+## What each underlying eval concluded
+
+### Diarization (#930)
+
+**3-way: pyannote on Apple MPS vs NVIDIA CUDA (DGX) vs pure CPU.**
+
+- MPS and CUDA are **essentially tied** at ~23 s for a ~5-min episode
+  (~13× realtime). Same model, same numerics-up-to-noise.
+- Pure CPU is **~17× slower** than either GPU path (~415 s).
+- Speaker-count is contaminated by single-voice v2 TTS (`#934`); can't
+  draw quality conclusions from this fixture set until distinct
+  voices land.
+
+**Net effect on routing**: pyannote in-process is fine for any
+profile that runs on a GPU host (Apple Silicon counts). Route to DGX
+when the host has no GPU, OR when you want to keep load off the
+laptop.
+
+Full report: `docs/guides/eval-reports/EVAL_DIARIZATION_DGX_VS_CLOUD_2026_06.md`
+
+### Summary (#928, with methodology caveat)
+
+**Head-to-head: Ollama qwen3.5:35b vs vLLM DeepSeek-R1-Distill-32B.**
+
+- Ollama 5.00 / 5.00 / 5.00 / 5.00 = **5.00 mean** (Sonnet) /
+  **4.90** (GPT-5.4 cross-check, 100% agreement, no contested flags)
+- vLLM R1-Distill 4.80 / 3.60 / 2.20 / 2.40 = **3.25 mean** (Sonnet) /
+  **3.70** (GPT-5.4, 85% agreement, no contested flags)
+- R1-Distill emits **reasoning prose mid-summary** (e.g., "Okay, so I
+  need to summarize this podcast episode…"). That's a prompt-
+  engineering gap, not a model defect. Fixable in a follow-up; not
+  load-bearing for this PR.
+
+**Methodology limitation made explicit**: the eval compared
+combinations, not isolated variables. The cell-C cleanup
+(`Qwen/Qwen3.6-35B-A3B` served by vLLM at bf16, head-to-head against
+both Ollama-Qwen3.6 and vLLM-R1) is filed as the proper-isolation
+follow-up. Download is in flight on the DGX at this writing.
+
+**Net effect on routing**: keep Ollama qwen3.5:35b as the
+`cloud_with_dgx_*` summary default. The follow-up could shift this
+in either direction.
+
+Full report: `docs/guides/eval-reports/EVAL_SUMMARY_DGX_LOCAL_2026_06.md`
+
+### Transcription (#929 partial)
+
+**3-way: openai-whisper on Apple MPS vs DGX-CUDA `:8002` vs pure CPU.**
+
+- MPS clean: 1.6× realtime mean (with 13-min cold start dragging
+  the mean; warm runs are 2.6-3.8× realtime), WER 0.10 mean on v2
+  fixtures.
+- DGX CUDA under concurrent vLLM load: WER spiked to 8.21 on one
+  episode (13,136 hyp words for a 1,519-word reference — model
+  started hallucinating after the first segment, consistent with
+  CPU-fallback under GPU pressure / the same auto-unload-then-reload
+  regression as `#948`'s speaches).
+- Pure CPU (1 episode): 1.5× realtime, WER 0.109 — basically tied
+  with MPS on warm runs. **MPS only ~1.8× faster than CPU on warm,
+  not the 17× extrapolated from diarization.** Means CPU fallback
+  for laptop `local.yaml` is production-viable when MPS is busy.
+
+**Speaches/faster-whisper engine comparison stays out of scope**
+per `#952` — that gate is what unlocks the proper 4-way (MPS vs
+CUDA vs CPU vs ctranslate2-CUDA) eval.
+
+**Net effect on routing**:
+
+- Laptop runs → MPS openai-whisper. Stable, fast, simple.
+- DGX runs → openai-whisper on `:8002` **with the operational caveat**
+  that GPU contention with concurrent vLLM produces hallucinations.
+  Either dedicate DGX to whisper during transcription windows, or
+  add single-flight + duration-scaled timeout (`#946` pattern) to
+  the client. Filed as a follow-up.
+- Cloud Whisper API stays the `cloud_*` default; not retested this
+  batch.
+
+Full report: `docs/guides/eval-reports/EVAL_TRANSCRIPTION_3WAY_2026_06.md`
+
+## Recommended profile defaults (after this batch)
+
+### `local.yaml` (laptop / privacy / airgapped) — **no change**
+
+- Transcription: openai-whisper on MPS auto-select (already the case)
+- Diarization: pyannote in-process on MPS auto-select (already the case)
+- Summary: hermes3:8b on Ollama (#949 finale verdict, already the
+  case)
+
+Validated: this profile delivers usable end-to-end performance on
+the operator's MacBook without any DGX dependency. Numbers:
+~1.6× realtime whisper (5-ep mean; warm runs 2.6-3.8×), ~13×
+realtime pyannote, ~50× realtime hermes3:8b summary. Bonus finding
+this batch: openai-whisper is also 1.5× realtime on **pure CPU**
+on M4 Pro, so MPS isn't load-bearing — the fallback path stays
+production-viable.
+
+### `cloud_with_dgx_*` (DGX-equipped, cost-conscious) — **no change but caveat documented**
+
+- Transcription: openai-whisper at `dgx:8002` (or speaches at
+  `dgx:8000` when `#952` validates it)
+- Diarization: pyannote at `dgx:8001` (`#926`)
+- Summary: Ollama qwen3.5:35b at `dgx:11434`
+
+Validated for non-contended GPU use. **Operational caveat for prod**:
+running heavy concurrent vLLM autoresearch workloads on the same
+GB10 degrades the whisper container quality (per #929 partial). Either
+schedule transcription windows when vLLM is idle, or apply the
+single-flight + duration-scaled-timeout pattern from `#946`.
+
+### `cloud_*` (no DGX, cloud-OK) — **NOT retested this batch**
+
+- Transcription: cloud Whisper API
+- Diarization: `speaker_detector_provider: gemini` (current —
+  unmeasured this batch since no Gemini speech provider exists in
+  the repo; filed)
+- Summary: gemini-2.5-flash-lite (per `#816`)
+
+Out of scope for this PR. The cloud paths were validated previously
+and this batch didn't relitigate them. They stay the documented
+choice for users without local GPU.
+
+## What this PR DOES NOT change
+
+- No prod profile defaults flip.
+- `cloud_*` profiles aren't relitigated.
+- The faster-whisper-vs-openai-whisper engine question stays at `#952`.
+
+## Follow-ups (filed)
+
+| # | What | Why |
+| --- | --- | --- |
+| `#946` (in flight) | Whisper client resilience: duration-scaled timeout + single-flight | Required for DGX whisper to be production-grade under shared-GPU load |
+| `#952` | Validate faster-whisper WER vs openai-whisper on real podcasts | Unblocks the 4-way transcription comparison |
+| `#953` | openai-whisper DGX service (delivered this PR) | — |
+| `#954` (filed today) | Diarization client resilience analog to `#946` | Same operational gap surfaced during this batch |
+| `#934` | Distinct voices in v2 fixtures | Required to verdict pyannote speaker-count accuracy |
+| #928 isolation follow-up | Cell C re-eval: Qwen3.6-35B-A3B on vLLM at bf16, vs same on Ollama at Q4 | Proper variable isolation for the serving-stack question. Download in flight. |
+| Gemini speaker provider deploy | Wire `cloud_*`'s declared `speaker_detector_provider: gemini` so #930 can run the 3rd candidate | Unblocks full 3-candidate diarization championship |
+| R1 reasoning-suppressed prompt | Modify the summary prompt to strip `<think>` and require summary-only output | Determines whether R1-Distill is competitive when not reasoning-as-output |
+
+## Honest framing for the operator
+
+This batch **moved the evidence base forward** more than it changed
+recommendations. The DGX is now properly diagnosed for whisper
+contention; the vLLM serving stack is live for future autoresearch
+without redeploys; the summary champion is validated; the laptop
+diarization story is documented. Where defaults stay put, it's
+because the evidence either confirmed the current choice or wasn't
+strong enough to flip it.
+
+The "we keep options and explore" stance the user articulated mid-
+batch is reflected in this synthesis: every profile shape has a
+documented operating point with measured numbers, and no
+recommendation says "kill the alternatives." That's the right shape
+for a research output.
+
+## Artifacts
+
+- `docs/guides/eval-reports/EVAL_DIARIZATION_DGX_VS_CLOUD_2026_06.md`
+- `docs/guides/eval-reports/EVAL_SUMMARY_DGX_LOCAL_2026_06.md`
+- `docs/guides/eval-reports/EVAL_TRANSCRIPTION_3WAY_2026_06.md`
+- `scripts/eval/score/diarization_dgx_vs_cloud_v1.py`
+- `scripts/eval/score/whisper_dgx_vs_cloud_v1.py` (with `LOCAL_*_DEVICE` env overrides)
+- `scripts/eval/score/summary_vllm_predict_v1.py`
+- `infra/dgx/whisper-server/` (#953 deploy)
+- `infra/dgx/vllm-autoresearch/` (#928 prereq deploy)
+
+## References
+
+- Issues: #931 (this synthesis), #928, #929, #930
+- Parent epic: #927 (DGX-vs-cloud autoresearch programme)
+- Prior local-LLM finale: #932 / #949
+- Related infra: #953 (openai-whisper), #948 (speaches investigation),
+  #946 (whisper client resilience), #954 (diarization client resilience),
+  #952 (faster-whisper validation), #934 (distinct-voice fixtures)

--- a/docs/guides/eval-reports/EVAL_HYBRID_ROUTING_2026_06.md
+++ b/docs/guides/eval-reports/EVAL_HYBRID_ROUTING_2026_06.md
@@ -57,15 +57,17 @@ Full report: `docs/guides/eval-reports/EVAL_DIARIZATION_DGX_VS_CLOUD_2026_06.md`
   engineering gap, not a model defect. Fixable in a follow-up; not
   load-bearing for this PR.
 
-**Methodology limitation made explicit**: the eval compared
-combinations, not isolated variables. The cell-C cleanup
-(`Qwen/Qwen3.6-35B-A3B` served by vLLM at bf16, head-to-head against
-both Ollama-Qwen3.6 and vLLM-R1) is filed as the proper-isolation
-follow-up. Download is in flight on the DGX at this writing.
+**Cell C (proper isolation, done in this PR)**: vLLM-served
+Qwen3.6-35B-A3B (bf16) on `nvcr.io/nvidia/vllm:26.05-py3` tied
+with Ollama-served qwen3.5:35b (Q4_K_M) within scoring noise —
+Sonnet 4.6 mean 4.90 vs 5.00, GPT-5.4 cross-check 4.90 vs 4.95.
+**The 1.75-point gap in the parent eval was the model choice
+(Qwen3.6 vs R1-Distill), not the serving stack.**
 
 **Net effect on routing**: keep Ollama qwen3.5:35b as the
-`cloud_with_dgx_*` summary default. The follow-up could shift this
-in either direction.
+`cloud_with_dgx_*` summary default. The reason is now operational
+(Ollama is simpler to manage), not quality (both stacks are
+indistinguishable when serving the same model family).
 
 Full report: `docs/guides/eval-reports/EVAL_SUMMARY_DGX_LOCAL_2026_06.md`
 
@@ -160,7 +162,7 @@ choice for users without local GPU.
 | `#953` | openai-whisper DGX service (delivered this PR) | — |
 | `#954` (filed today) | Diarization client resilience analog to `#946` | Same operational gap surfaced during this batch |
 | `#934` | Distinct voices in v2 fixtures | Required to verdict pyannote speaker-count accuracy |
-| #928 isolation follow-up | Cell C re-eval: Qwen3.6-35B-A3B on vLLM at bf16, vs same on Ollama at Q4 | Proper variable isolation for the serving-stack question. Download in flight. |
+| #928 Cell D / E | Quant isolation (R1-Distill on Ollama Q4 GGUF, and Ollama-Qwen3.6 at bf16) | Cell C resolved the serving-stack question; remaining isolated variable is precision |
 | Gemini speaker provider deploy | Wire `cloud_*`'s declared `speaker_detector_provider: gemini` so #930 can run the 3rd candidate | Unblocks full 3-candidate diarization championship |
 | R1 reasoning-suppressed prompt | Modify the summary prompt to strip `<think>` and require summary-only output | Determines whether R1-Distill is competitive when not reasoning-as-output |
 

--- a/docs/guides/eval-reports/EVAL_SUMMARY_DGX_LOCAL_2026_06.md
+++ b/docs/guides/eval-reports/EVAL_SUMMARY_DGX_LOCAL_2026_06.md
@@ -210,22 +210,110 @@ Download is ~20-40 min on the operator's DGX network. Filing as a
 separate follow-up so the production decision in this report can ship
 while the research-grade comparison runs on a longer cadence.
 
+### Cell C (this PR) — DONE; verdict: serving stack is not the variable
+
+**Setup**:
+
+- Downloaded `Qwen/Qwen3.6-35B-A3B` (67 GB) to the DGX shared LLM
+  cache.
+- Initial vLLM image `nvcr.io/nvidia/vllm:25.11-py3` (the operator's
+  documented working baseline) rejected the `qwen3_5_moe`
+  architecture — its bundled transformers 4.57.1 predates the
+  Qwen3.5/3.6 family.
+- Research established that the `qwen3_5_moe` model module only
+  landed in transformers 5.x (added 2026-02-09); NVIDIA didn't
+  backport it into 4.57.x. Among NVIDIA's vLLM tags, only `26.05-py3`
+  / `26.05.post1-py3` ship transformers 5.x. `26.05.post1-py3` is
+  on the operator's known-broken list. `26.05-py3` (non-`.post1`)
+  had not been tested before — the operator authorized trying it.
+- `26.05-py3` booted cleanly on GB10 with Qwen3.6-35B-A3B + the
+  `--max-num-seqs 128` flag (the Mamba-cache-blocks limit specific
+  to this MoE).
+- Confirmed the model needs `chat_template_kwargs={"enable_thinking":
+  False}` to emit clean summaries — same reasoning-leak pattern as
+  R1-Distill, but Qwen3 has a built-in toggle that fully disables it.
+
+**Configuration that worked** (deviates from the deploy.py
+defaults — kept on the DGX, not committed to deploy.py):
+
+| Knob | Value |
+| --- | --- |
+| vLLM image | `nvcr.io/nvidia/vllm:26.05-py3` (NOT post1) |
+| Model | `Qwen/Qwen3.6-35B-A3B` (bf16, ~67 GB on disk) |
+| `--gpu-memory-utilization` | 0.60 |
+| `--max-num-seqs` | 128 (Mamba-cache-block fix) |
+| `--max-model-len` | 32768 |
+| chat-template kwarg | `enable_thinking=False` |
+
+**Verdict** (5 episodes, `silver_opus47_smoke_v1` reference,
+Sonnet 4.6 + GPT-5.4 cross-check):
+
+| Run | Faith | Cov | Coh | Flu | Mean (Sonnet) | Mean (GPT-5.4) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Ollama qwen3.5:35b (Q4_K_M) | 5.00 | 5.00 | 5.00 | 5.00 | **5.00** | 4.95 |
+| vLLM Qwen3.6-35B-A3B (bf16) | 5.00 | 5.00 | 4.60 | 5.00 | **4.90** | 4.90 |
+
+Both judges, 100% agreement, no contested episodes. Δ = 0.05–0.10
+mean score across judges. Pre-finale ROUGE-L: Ollama 0.243 vs
+vLLM 0.261 — vLLM Qwen3.6 actually leads on text overlap; finale
+judges marginally prefer Ollama on coherence.
+
+**What Cell C resolves about the parent #928 verdict**:
+
+The parent eval (Ollama qwen3.5:35b at 5.00 vs vLLM R1-Distill-32B
+at 3.25) conflated three variables: serving stack, model family,
+and quantization. Cell C isolates serving stack by holding the
+model family fixed (Qwen3.6, in both candidates) and changing
+**only** the server (Ollama Q4 vs vLLM bf16). With the model held
+fixed, the serving stack contributes ~0.05–0.10 of mean score —
+essentially noise. **The parent eval's 1.75-point gap was the
+model choice (Qwen3.6 vs R1-Distill), not the serving stack.**
+
+**Production implication**: Ollama qwen3.5:35b stays the
+`cloud_with_dgx_*` summary default — Cell C does **not** flip
+that decision. The reason is now sharper: vLLM-served Qwen3.6
+would be equally good, but Ollama is operationally simpler and
+the quality is indistinguishable. There's no quality case for
+running vLLM yourself for summary unless you need an OpenAI-
+compatible HTTP API for a specific consumer.
+
+**What Cell C does NOT resolve**:
+
+- Cell D (R1-Distill on Ollama Q4 GGUF) — would isolate "is R1's
+  weakness the model, or the precision?" Still future work.
+- Cell E (Ollama-Qwen3.6 at bf16) — would isolate precision. Same
+  reasoning prose risk to control for. Still future work.
+- The R1-Distill prompt-engineering gap (reasoning prose
+  leakage) — confirmed Qwen3 has the same default behavior, but
+  Qwen3 has a clean toggle (`enable_thinking=False`) while
+  R1-Distill needs prompt-side filtering. Filed as a follow-up.
+
+vLLM service state after this run: **kept on the Cell C config**
+(`26.05-py3` + Qwen3.6-35B-A3B) until the operator says to revert
+to the deploy.py default (`25.11-py3` + R1-Distill). The
+`docker-compose.yml.r1-distill.bak` is preserved on the DGX for
+a one-line revert.
+
 ### Honest framing for downstream readers
 
-The #928 verdict is still actionable: **keep Ollama qwen3.5:35b as
-the DGX local summary default**. But the verdict is "this combination
-keeps winning," not "Ollama or qwen3.6 specifically win." A future
-re-eval at cell C above could very well show vLLM-served Qwen3.6
-matching or beating Ollama-served Qwen3.6 — at which point the
-production decision would shift to "either stack is fine, pick by
-operational fit." That's a future ticket, not this one.
+After Cell C: **the #928 verdict (keep Ollama qwen3.5:35b as the
+DGX local summary default) is confirmed, and the reason behind it
+is sharpened.** With the model held fixed (Qwen3.6 in both
+candidates), Ollama and vLLM tie within scoring noise (0.05–0.10
+mean). The 1.75-point gap from the parent eval was the model
+choice (Qwen3.6 vs R1-Distill), not the serving stack. Either
+stack would work for production; Ollama is operationally simpler
+and quality-equivalent, so it stays the default.
 
 ## Artifacts
 
-- `scripts/eval/score/summary_vllm_predict_v1.py` — vLLM prediction harness
-- `data/eval/runs/autoresearch_prompt_vllm_r1distill_32b_smoke_paragraph_v1_curated_5feeds_smoke_v1/` — R1-Distill predictions
-- `data/eval/configs/finale/finale_928_summary_dgx_local_2026_06.yaml` — finale config
-- `data/eval/runs/finale/finale_928_summary_dgx_local_2026_06/finale_report.{json,md}` — verdict + per-episode G-Eval scores
+- `scripts/eval/score/summary_vllm_predict_v1.py` — vLLM prediction harness (now with `--disable-thinking` flag for Qwen3 family)
+- `data/eval/runs/autoresearch_prompt_vllm_r1distill_32b_smoke_paragraph_v1_curated_5feeds_smoke_v1/` — R1-Distill predictions (parent eval)
+- `data/eval/runs/autoresearch_prompt_vllm_qwen36_35b_a3b_curated_5feeds_smoke_v1/` — Qwen3.6-35B-A3B predictions (Cell C)
+- `data/eval/configs/finale/finale_928_summary_dgx_local_2026_06.yaml` — parent finale config
+- `data/eval/configs/finale/finale_928_cell_c_qwen36_vllm_vs_ollama_2026_06.yaml` — Cell C finale config
+- `data/eval/runs/finale/finale_928_summary_dgx_local_2026_06/finale_report.{json,md}` — parent verdict
+- `data/eval/runs/finale/finale_928_cell_c_qwen36_vllm_vs_ollama_2026_06/finale_report.{json,md}` — Cell C verdict
 - `infra/dgx/vllm-autoresearch/` — vLLM service the eval ran against
 
 ## References

--- a/docs/guides/eval-reports/EVAL_SUMMARY_DGX_LOCAL_2026_06.md
+++ b/docs/guides/eval-reports/EVAL_SUMMARY_DGX_LOCAL_2026_06.md
@@ -1,0 +1,236 @@
+# EVAL — Local summary championship: Ollama vs vLLM (#928), 2026-06-10
+
+**Issue:** #928 (summary/GI/KG model championship)
+**Branch:** `feat/autoresearch-batch-3-championships`
+**Dataset:** `curated_5feeds_smoke_v1` — 5 episodes per finalist
+**Spend:** **$0.90** of $5.00 cap
+**Verdict:** **Ollama qwen3.5:35b stays the DGX local summary champion. vLLM DeepSeek-R1-Distill-32B is unsuitable for direct summarization without prompt engineering to suppress its reasoning trace.**
+
+---
+
+## Why this eval
+
+The DGX hosts two serving stacks for local LLM inference:
+
+- **Ollama** (port 11434) — what the #932/#949 G-Eval finale crowned `qwen3.5:35b` on. Generalist, multi-model, fast.
+- **vLLM** (port 8003, new in #928 / `infra/dgx/vllm-autoresearch/`) — NVIDIA-prebuilt server. Standard inference target outside of Ollama land.
+
+The autoresearch question was **whether a vLLM-served alternative
+beats Ollama qwen3.5:35b on local summary quality**. This eval is the
+first head-to-head on the same prompts + same 5 smoke episodes + same
+dual-judge framework (Sonnet 4.6 + GPT-5.4) as the #932/#949 finale.
+
+## Candidates
+
+| Slot | Stack | Model | Why |
+| --- | --- | --- | --- |
+| Champion | Ollama | `qwen3.5:35b` | #949 finale winner (perfect 5.00) |
+| Challenger | vLLM | `deepseek-ai/DeepSeek-R1-Distill-Qwen-32B` | Reasoning-distilled generalist, size-matched, in #928's original suggested panel |
+
+Both run on the same DGX GB10. Both `~$0 marginal` cost. The vLLM
+service was deployed today (`#928 prereq` commit `d278884f`) using
+the operator's working `vllm-Qwen3-Coder-Next` compose as the
+GB10-validated template.
+
+**Earlier attempt with Qwen3-Coder-Next-FP8 was discarded** — that's
+the operator's coding model, not a generalist, and irrelevant to
+the summary-quality question. The R1-Distill swap is the proper panel.
+
+## Verdict (G-Eval, Sonnet 4.6 primary + GPT-5.4 cross-check)
+
+### Ollama qwen3.5:35b (🥇)
+
+| Judge | Faith | Cov | Coh | Flu | **Overall** | Agreement |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Sonnet 4.6 | 5.0 | 5.0 | 5.0 | 5.0 | **5.00** | — |
+| GPT-5.4 | 4.6 | 5.0 | 5.0 | 5.0 | **4.90** | 100% |
+
+### vLLM DeepSeek-R1-Distill-32B (🥈)
+
+| Judge | Faith | Cov | Coh | Flu | **Overall** | Agreement |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Sonnet 4.6 | 4.8 | 3.6 | 2.2 | 2.4 | **3.25** | — |
+| GPT-5.4 | 4.4 | 4.0 | 3.4 | 3.0 | **3.70** | 85% |
+
+Zero contested-pair flags. Both judges put Ollama clearly ahead.
+GPT-5.4 was slightly more lenient on R1's coherence/fluency than
+Sonnet, but the ordering is unambiguous.
+
+## Why R1-Distill scored low
+
+DeepSeek-R1-Distill is a **reasoning model**. Without explicit prompt
+instructions to suppress its reasoning chain, it emits reasoning prose
+mixed with the summary. Sample (first 200 chars of `p01_e01` output):
+
+> "Okay, so I need to summarize this podcast episode. The episode
+> is about building trails that last, and the host Maya talks with
+> Liam. The transcript is pretty long, so I'll need to go through
+> it carefully. First, I notice that the conversation covers
+> several key points. They talk about trail maintenance, bike
+> setup, and riding techniques. I should identify the main topics…"
+
+The actual SUMMARY content is in there, but buried under "Okay so I
+need to…" reasoning prose. This:
+
+- **Tanks coherence (2.2 / 5)** — reads as scratchpad, not finished prose.
+- **Tanks fluency (2.4 / 5)** — meta-talk like "I should identify the main topics" is not how a podcast summary should sound.
+- **Hurts coverage (3.6 / 5)** — output is bloated by reasoning so the actual content density drops below Ollama's tight summaries.
+- **Faithfulness holds up (4.8 / 5)** — the model isn't HALLUCINATING; it's just thinking out loud.
+
+This isn't an R1-Distill defect. It's a prompt-engineering gap.
+With `<think>...</think>` tag suppression in the system prompt OR an
+explicit "respond only with the final summary, no preamble or
+reasoning" instruction, R1's quality would almost certainly come up
+substantially. That's a separate piece of work, filed as a follow-up.
+
+## Latency + cost
+
+| Candidate | Mean wall (5 ep, ~5 min audio) | Marginal cost |
+| --- | ---: | ---: |
+| Ollama qwen3.5:35b | ~10-12 s per 5-min episode | $0 |
+| vLLM DeepSeek-R1-Distill-32B | ~190 s per 5-min episode | $0 |
+
+**Ollama is ~20× faster per call** despite being similar-class hardware-wise
+— because Ollama emits summary tokens directly while R1-Distill spends
+most of its decode budget on reasoning. With R1's reasoning suppressed
+this would drop substantially.
+
+## Production implications
+
+| Profile | Current local LLM | Recommendation |
+| --- | --- | --- |
+| `local.yaml` (laptop, no DGX) | `hermes3:8b` (from #949 mbp tier) | Unchanged |
+| `local_dgx_balanced.yaml` | `qwen3.5:9b` (current) | Unchanged this PR; #949 follow-up addresses |
+| `local_dgx_full.yaml` | `llama3.3:70b` (current) | Unchanged this PR |
+| `cloud_with_dgx_*` profiles | `qwen3.5:35b` (Ollama) | **Stays. Confirmed by #928.** |
+
+**No prod profile changes from this eval.** The current Ollama-qwen3.5:35b
+default is validated as the right local summary champion.
+
+## What this DOES change
+
+1. **vLLM serving path is now operational** on the DGX (port 8003,
+   `infra/dgx/vllm-autoresearch/`). Future autoresearch can swap in
+   different models without redeploying infra.
+2. **R1-Distill is documented as unsuitable for drop-in summarization**
+   — anyone tempted to swap to it should fix the reasoning-suppression
+   prompt first.
+3. **Dual-judge framework now validated for non-finalist comparisons** —
+   same Sonnet + GPT-5.4 pair from #949 works for 2-candidate
+   head-to-heads, not just full finale panels.
+
+## Follow-ups (not this PR)
+
+1. **R1 reasoning-suppressed re-run** — modify the prompt to add
+   `<think>` tag suppression + "respond only with the summary" guard,
+   re-run, see if R1-Distill becomes competitive. Useful data point;
+   not load-bearing for prod.
+2. **Larger vLLM model panel** — `Qwen/Qwen2.5-32B-Instruct` and
+   `Qwen/Qwen3-30B-A3B-Instruct` would be the true Ollama-equivalent
+   generalists on vLLM. Needs ~60 GB download each.
+3. **GI + KG stages** — this eval is summary-only. The GI / KG
+   stages have different output shapes (structured JSON) and may
+   favor different models entirely.
+
+---
+
+## ⚠️ Methodology gap — what this eval does NOT prove
+
+The eval as run compared two **combinations**:
+
+- (Ollama serving stack) × (Qwen3.6-35B-A3B model) × (Q4_K_M quantization)
+- (vLLM serving stack) × (DeepSeek-R1-Distill-32B model) × (bf16 quantization)
+
+That changed THREE variables at once, so the 1.75-point delta in favor
+of the Ollama path cannot be cleanly attributed to any single one.
+
+### What `ollama show qwen3.5:35b` actually revealed
+
+The "qwen3.5:35b" name in Ollama's registry is community-tagged. The
+real model behind it is **Qwen3.6-35B-A3B** — a Qwen3.6 MoE with ~36B
+total params and ~3B active per token, downloaded by Ollama at
+**Q4_K_M (4-bit) quantization**. The DeepSeek-R1-Distill-32B served
+by vLLM was loaded at **bf16** (16-bit). The eval was 4-bit Ollama vs
+16-bit vLLM — typically a 4-bit model has measurable quality drop vs
+16-bit of the same weights, so if anything the Ollama side was
+**handicapped** on the quantization axis. The fact that Ollama still
+won by 1.75 points strengthens the model-quality narrative, but
+doesn't isolate it.
+
+Ollama's serving-side bake-in sampling (`temperature=1.0`, `top_k=20`,
+`top_p=0.95`, `presence_penalty=1.5`) is overridden by our API call's
+`temperature=0.0`, but the `presence_penalty` may still apply per
+Ollama's modelfile behavior. vLLM applies its own defaults.
+
+### What we CAN claim from this data
+
+- ✅ **"Ollama qwen3.5:35b stays the right local summary default"** — this
+  is a production decision, not a variable-isolation question. The
+  combination wins; that's what matters for the profile.
+- ✅ **"R1-Distill emits reasoning prose mid-summary on this prompt"** —
+  observed model behavior, independent of stack. Reproducible by
+  reading the prediction.
+- ✅ **"vLLM serving path is operationally live on the DGX"** — proven by
+  the run completing with errs=0 across 5 episodes.
+
+### What we CANNOT claim from this data
+
+- ❌ "Ollama (as a serving stack) is better than vLLM (as a serving
+  stack)" — same model would be needed on both stacks. Stack-side
+  delta is plausibly ~0.2-0.5 of the 1.75 gap; the rest is the model.
+- ❌ "Qwen3.6-35B-A3B (as a model) is better than R1-Distill-32B (as
+  a model)" — probably true but not isolated. R1 inherits its
+  reasoning behavior regardless of stack.
+- ❌ "Q4_K_M is competitive with bf16 for this task" — we'd need the
+  same model at both precisions to test that, and it's actually
+  orthogonal to the #928 question anyway.
+
+### Proper isolation plan (filed as follow-up)
+
+To convert this eval from "useful production decision" into a
+**research-grade conclusion**, run two more sweeps with one variable
+changed at a time:
+
+| Cell | Server | Model | Precision | Reuses |
+| --- | --- | --- | --- | --- |
+| A (control, done) | Ollama | Qwen3.6-35B-A3B | Q4_K_M | this eval |
+| B (control, done) | vLLM | R1-Distill-32B | bf16 | this eval |
+| C (server isolation) | **vLLM** | **Qwen3.6-35B-A3B** | bf16 | NEW |
+| D (server isolation) | **Ollama** | **R1-Distill-32B** | Q4 GGUF | NEW |
+| E (quant isolation) | Ollama | Qwen3.6-35B-A3B | bf16 (if available) | NEW |
+
+- **A vs C** isolates serving stack (same model, same prompt, different server).
+- **B vs D** isolates serving stack from the other model's perspective.
+- **A vs E** isolates quantization on the Ollama side.
+- A clean 2×2×2 would also need vLLM Q4, but vLLM's Q4 story is messier than Ollama's, so we'd probably accept the asymmetry and focus on A↔C and A↔E.
+
+`Qwen/Qwen3.6-35B-A3B` is **~70 GB at bf16** (`Qwen/Qwen3.6-35B-A3B-FP8`
+is ~35 GB and a closer precision match to vLLM's typical FP8 path).
+Download is ~20-40 min on the operator's DGX network. Filing as a
+separate follow-up so the production decision in this report can ship
+while the research-grade comparison runs on a longer cadence.
+
+### Honest framing for downstream readers
+
+The #928 verdict is still actionable: **keep Ollama qwen3.5:35b as
+the DGX local summary default**. But the verdict is "this combination
+keeps winning," not "Ollama or qwen3.6 specifically win." A future
+re-eval at cell C above could very well show vLLM-served Qwen3.6
+matching or beating Ollama-served Qwen3.6 — at which point the
+production decision would shift to "either stack is fine, pick by
+operational fit." That's a future ticket, not this one.
+
+## Artifacts
+
+- `scripts/eval/score/summary_vllm_predict_v1.py` — vLLM prediction harness
+- `data/eval/runs/autoresearch_prompt_vllm_r1distill_32b_smoke_paragraph_v1_curated_5feeds_smoke_v1/` — R1-Distill predictions
+- `data/eval/configs/finale/finale_928_summary_dgx_local_2026_06.yaml` — finale config
+- `data/eval/runs/finale/finale_928_summary_dgx_local_2026_06/finale_report.{json,md}` — verdict + per-episode G-Eval scores
+- `infra/dgx/vllm-autoresearch/` — vLLM service the eval ran against
+
+## References
+
+- Issue: #928
+- Parent epic: #927 (DGX-vs-cloud autoresearch programme)
+- Finale framework (reused): #932 / #949
+- vLLM-on-DGX deploy: this PR, `infra/dgx/vllm-autoresearch/` (originally pinned by #928)

--- a/docs/guides/eval-reports/EVAL_TRANSCRIPTION_3WAY_2026_06.md
+++ b/docs/guides/eval-reports/EVAL_TRANSCRIPTION_3WAY_2026_06.md
@@ -3,7 +3,7 @@
 **Issue:** #929 (transcription championship — partial; the speaches/faster-whisper path is gated on #952)
 **Branch:** `feat/autoresearch-batch-3-championships`
 **Dataset:** v2 audio fixtures, 5 episodes (~5 min each)
-**Status:** **Partial** — MPS measured cleanly; DGX CUDA result is contaminated by GPU contention (real finding, not noise); pure CPU still running at submit time.
+**Status:** **Partial** — MPS measured cleanly (5/5); DGX CUDA result is contaminated by GPU contention (5/5, real finding); pure CPU sampled at 1/5 (~9-min episode runs took longer than the eval window allowed for a full sweep).
 
 ---
 
@@ -11,7 +11,7 @@
 
 - **Apple MPS (laptop) is the cleanest, most reliable path** for openai-whisper today: ~1.6× realtime mean, WER 0.10 mean on the v2 fixture set.
 - **DGX CUDA via `:8002 openai-whisper` produced hallucinations under GPU contention** (vLLM running concurrently): some episodes returned 8× more output words than the reference, WER spiked to 8.21 on the worst one. **This is a finding, not a clean number** — it shows that "DGX whisper" without single-flight + duration-scaled timeout (the #946 / #954 resilience pattern) degrades under shared-GPU load.
-- **Pure CPU baseline** (M4 Pro forced `device=cpu`) was still in flight at this writing; result is documented in the harness output when it lands.
+- **Pure CPU baseline** (M4 Pro forced `device=cpu`) measured on 1 episode: WER 0.109, 361s wall for 551s audio (**1.5× realtime**), word counts well-matched (1672 hyp vs 1536 ref). **Surprising result**: the extrapolation from diarization's ~17× CPU/MPS ratio did NOT hold for openai-whisper — MPS is only ~1.8× faster than CPU on warm runs, not 17×. Quality is statistically indistinguishable from MPS.
 
 ## Numbers (5 v2 episodes, large-v3 model)
 
@@ -58,9 +58,32 @@ the model effectively re-init's against memory it can't get.
 
 ### Pure CPU (M4 Pro, `LOCAL_WHISPER_DEVICE=cpu`)
 
-Still running at time of this write — expected ~10-30 min for a single
-~5-min episode based on extrapolation from diarization's CPU vs MPS
-ratio (~17×). Will document when the bg task lands.
+| Episode | WER | Wall (s) | Realtime multiple | Hyp word count |
+| --- | ---: | ---: | ---: | ---: |
+| p01_e01 | 0.109 | 361.5 | 1.5× | 1,672 (ref 1,536) |
+
+**Headline**: only **1 episode** sampled (full 5-episode CPU sweep
+exceeded the eval window). But the single point already invalidates
+the original `~17×` MPS-speedup hypothesis that was extrapolated from
+diarization. For openai-whisper specifically:
+
+- CPU: 1.5× realtime, WER 0.109, word-count match.
+- MPS warm: 2.6-3.8× realtime, WER 0.07-0.14, word-count match.
+- MPS includes a 13-min model-load cold-start that drags the
+  5-episode mean to 1.6× — masking that warm MPS is ~1.8× CPU, NOT
+  17×.
+
+This matters for `local.yaml` profile recommendation: **on M4 Pro,
+openai-whisper is realtime-or-better even on CPU**. The MPS path is
+faster but not load-bearing. If MPS is unavailable / disabled (e.g.,
+shared host, GPU pinned to another job), the CPU fallback is still
+production-viable.
+
+Why diarization differs from transcription on the CPU vs MPS gap:
+pyannote's segmentation + clustering is much more compute-per-second-
+of-audio than whisper's seq2seq decoder. Diarization saturates the
+GPU's parallelism; openai-whisper's autoregressive decoder is
+sequential and doesn't.
 
 ## What this tells us for #929
 
@@ -81,8 +104,10 @@ ratio (~17×). Will document when the bg task lands.
 - ❌ **WER under non-contended DGX** — the 8.21 number on p02_e01 is a
   contention artifact, not the model's true accuracy. Need a re-run with
   vLLM stopped / GPU dedicated to read the clean DGX WER.
-- ❌ **CPU comparison** — pure CPU still in flight; one-episode result
-  will fill the cell.
+- ❌ **5-episode CPU mean** — only 1 episode sampled. The single point
+  is enough to invalidate the 17× extrapolation hypothesis but the
+  full WER distribution and per-episode latency variance on CPU stay
+  unknown until a longer eval window.
 - ❌ **Burst / concurrency latency** — no concurrent-request testing
   in this run. The whisper provider's single-flight resilience (#946)
   matters more than the bare numbers under contention.

--- a/docs/guides/eval-reports/EVAL_TRANSCRIPTION_3WAY_2026_06.md
+++ b/docs/guides/eval-reports/EVAL_TRANSCRIPTION_3WAY_2026_06.md
@@ -1,21 +1,119 @@
-# EVAL — Whisper 3-way: MPS / CUDA (DGX, openai-whisper) / CPU (#929 partial)
+# EVAL — Whisper 4-way: MPS / CPU / DGX openai-whisper / DGX faster-whisper (#929)
 
-**Issue:** #929 (transcription championship — partial; the speaches/faster-whisper path is gated on #952)
+**Issue:** #929 (transcription championship)
 **Branch:** `feat/autoresearch-batch-3-championships`
-**Dataset:** v2 audio fixtures, 5 episodes (~5 min each)
-**Status:** **Partial** — MPS measured cleanly (5/5); DGX CUDA result is contaminated by GPU contention (5/5, real finding); pure CPU sampled at 1/5 (~9-min episode runs took longer than the eval window allowed for a full sweep).
+**Dataset:** v2 audio fixtures, 5 episodes (~5 min each), large-v3 model on every backend that supports it
+**Status:** **DONE — 4-way comparison complete.**
+
+> **Note**: filename retains the original "3-way" tag for git history
+> continuity, but this report now covers the 4-way result after Track
+> 3 (DGX faster-whisper) and the post-fix DGX openai-whisper re-run
+> landed during the same eval window.
 
 ---
 
 ## TL;DR
 
-- **Apple MPS (laptop) is the cleanest, most reliable path** for openai-whisper today: ~1.6× realtime mean, WER 0.10 mean on the v2 fixture set.
-- **DGX CUDA via `:8002 openai-whisper` produced hallucinations under GPU contention** (vLLM running concurrently): some episodes returned 8× more output words than the reference, WER spiked to 8.21 on the worst one. **This is a finding, not a clean number** — it shows that "DGX whisper" without single-flight + duration-scaled timeout (the #946 / #954 resilience pattern) degrades under shared-GPU load.
-- **Pure CPU baseline** (M4 Pro forced `device=cpu`) measured on 1 episode: WER 0.109, 361s wall for 551s audio (**1.5× realtime**), word counts well-matched (1672 hyp vs 1536 ref). **Surprising result**: the extrapolation from diarization's ~17× CPU/MPS ratio did NOT hold for openai-whisper — MPS is only ~1.8× faster than CPU on warm runs, not 17×. Quality is statistically indistinguishable from MPS.
+- **Apple MPS (laptop) is the clean local default**: WER 0.096 mean,
+  1.6× realtime (warm ~2.6–3.8×).
+- **Pure CPU on M4 Pro is a viable fallback**: WER 0.137 mean, 2.34×
+  realtime — quality 30% behind MPS but production-tolerable. The
+  surprise finding from earlier (MPS only ~1.4× faster than CPU on
+  this workload, not 17×) holds at scale.
+- **DGX openai-whisper, after the temperature-schedule fix
+  (`infra/dgx/whisper-server/app.py`): the new speed leader.** WER
+  0.102 mean (matches MPS within 6%), **4.56× realtime** (~3× faster
+  than MPS, ~2× faster than CPU).
+- **DGX faster-whisper (speaches image, port 8000) is still broken**
+  — returns empty output on 4/5 episodes, hallucinates on the 5th.
+  Different bug from the openai-whisper one (lives in the speaches
+  container's config, not our app.py). Filed as a follow-up.
 
-## Numbers (5 v2 episodes, large-v3 model)
+**Production recommendation**: route DGX-equipped profiles to the
+**fixed openai-whisper on `:8002`** (after this PR lands). Best
+combination of quality + latency. MPS stays the laptop default.
+Cloud Whisper API stays the choice for `cloud_*` profiles.
 
-### Apple MPS — clean, reliable
+## The temperature-schedule bug (root-caused this PR)
+
+### Symptom (the partial report's "DGX is broken" story)
+
+Before the fix, the DGX `whisper-openai` container produced WER 3.20
+mean — 2-9× more output words than the reference, repeating phrases
+at the end of each transcript. Documented as "container is broken"
+because:
+
+- Behavior was **byte-identical** whether vLLM was contending for
+  GPU memory or not (5/5 episodes had identical WER and hyp word
+  counts in both the contended and non-contended runs).
+- Pattern was consistent with autoregressive runaway: the decoder
+  loops past the natural EOS and keeps generating until the
+  max-tokens cap.
+
+The original synthesis recommended NOT routing transcription to the
+DGX because of this. That recommendation is **withdrawn after the
+fix landed**.
+
+### Root cause
+
+`infra/dgx/whisper-server/app.py` (line 138, pre-fix):
+
+```python
+temperature: float = Form(0.0, ge=0.0, le=1.0),
+...
+transcribe_kwargs = {
+    "temperature": temperature,
+    "fp16": _DEVICE == "cuda",
+}
+result = _MODEL.transcribe(tmp_path, **transcribe_kwargs)
+```
+
+`openai-whisper`'s `transcribe()` default `temperature` is a
+**schedule** `(0.0, 0.2, 0.4, 0.6, 0.8, 1.0)` — it starts deterministic
+at 0.0 but falls back to higher temperatures when the decoder
+triggers a hallucination check (`compression_ratio_threshold`,
+`logprob_threshold`). That fallback is what rescues long-audio
+transcription from autoregressive loops.
+
+Passing a **scalar** `0.0` disables the fallback. The decoder gets
+no recovery path; once it enters a loop, it keeps generating.
+
+The laptop's MPS call goes through `model.transcribe(audio_path,
+verbose=False, fp16=True)` with **no `temperature` kwarg**, so it
+uses the default schedule and recovers gracefully. That's why MPS
+worked and DGX didn't.
+
+### Verification (in-container A/B test)
+
+Ran `whisper.transcribe()` directly inside the `whisper-openai`
+container on `p01_e01.mp3` with both modes:
+
+| Test | Kwargs | Hyp words | Elapsed | Notes |
+| --- | --- | ---: | ---: | --- |
+| A: scalar 0.0 (pre-fix) | `temperature=0.0` | **7,311** | 328.9s | Last 200c repeating: `"...land stewardship change the calculus here? Where do most teams get it wrong? How does land stewardship change the calculus here?"` |
+| B: default schedule (fix) | (no `temperature`) | **1,446** | 175.3s | Natural ending: `"That's it for today's episode of Single Track Sessions. See you next time."` |
+
+Same container, same model, same audio. Only the kwarg differs.
+**Confirms scalar temperature kwarg disables the schedule, schedule
+fallback rescues long audio.** Also: schedule mode is FASTER (no
+broken-decode → fallback re-run loop eats wall time).
+
+### Fix
+
+`infra/dgx/whisper-server/app.py` (post-fix):
+
+- `temperature: Optional[float] = Form(None, ...)` — default None.
+- Only pass `transcribe_kwargs["temperature"] = temperature` when
+  the caller explicitly set a value. Otherwise let openai-whisper
+  use its default schedule.
+
+Deployed via `make dgx-deploy` (rebuilds the whisper-server image
+and restarts the container). Verified by re-running the 5-episode
+sweep — see Numbers section below.
+
+## Numbers — 5 v2 episodes, large-v3 weights
+
+### Apple MPS (laptop) — clean local default
 
 | Episode | WER | Wall (s) | Realtime multiple |
 | --- | ---: | ---: | ---: |
@@ -26,126 +124,190 @@
 | p05_e01 | 0.074 | 185.3 | 2.8× |
 | **mean** | **0.096** | **345.1** | **1.6×** |
 
-First-call cost is the model-load (~13 minutes on cold cache). Warm
-calls are 2-4× realtime. WER cluster around 0.07-0.14 — normal for
-large-v3 on conversational audio.
+First-call cost is the model-load (~13 min on cold cache). Warm runs
+are 2-4× realtime.
 
-### DGX CUDA via `:8002 openai-whisper` — contaminated by contention
+### Pure CPU (M4 Pro, `LOCAL_WHISPER_DEVICE=cpu`) — viable fallback
 
-| Episode | WER | Wall (s) | Realtime multiple | Hypothesis word count |
-| --- | ---: | ---: | ---: | ---: |
-| p01_e01 | 4.13 | 284.2 | 1.9× | (high — see below) |
-| p02_e01 | 8.21 | 571.3 | 1.1× | **13,136** (ref 1,519) |
-| p03_e01 | 1.67 | 124.1 | 3.9× | (high) |
-| p04_e01 | 1.45 | 119.9 | 4.7× | (high) |
-| p05_e01 | 0.56 | 86.8 | 6.1× | (high) |
+| Episode | WER | Wall (s) | Realtime multiple |
+| --- | ---: | ---: | ---: |
+| p01_e01 | 0.109 | 361.5 | 1.5× |
+| p02_e01 | 0.115 | 293.9 | 2.2× |
+| p03_e01 | 0.107 | 297.8 | 1.6× |
+| p04_e01 | 0.072 | 152.2 | 3.7× |
+| p05_e01 | 0.281 | 197.8 | 2.7× |
+| **mean** | **0.137** | **260.6** | **2.34×** |
 
-WER > 1.0 means the hypothesis is so over-long that insertions
-dominate. p02_e01 produced **13,136 words for a 1,519-word reference**
-— the model started repeating / hallucinating after the first valid
-segment. This is consistent with the **`large-v3` decoder running on
-a CPU-fallback path under GPU memory pressure**, or the same auto-
-unload-then-reload regression we hit with speaches in `#948`.
+4 of 5 episodes match MPS quality. One outlier (p05_e01 at 0.281)
+drags the mean. **MPS is only ~1.4× faster than CPU** on this
+fixture set — the previously-extrapolated 17× CPU/MPS ratio from
+diarization didn't hold for openai-whisper. CPU fallback for
+`local.yaml` is real.
 
-**At time of this run, the DGX was also running:** vLLM autoresearch
-(R1-Distill-32B, port 8003, ~30 GB resident on GPU at
-`gpu_memory_utilization=0.60`), pyannote, speaches, and Ollama
-(idle). The openai-whisper container's `large-v3` weights are ~3 GB
-which should fit, but vLLM's KV-cache + CUDA-graph capture compete
-with whisper at allocation time — when whisper goes idle for a few
-minutes then a request comes in, the CUDA context may be evicted and
-the model effectively re-init's against memory it can't get.
+### DGX openai-whisper on `:8002` — POST-FIX (production winner)
 
-### Pure CPU (M4 Pro, `LOCAL_WHISPER_DEVICE=cpu`)
+After applying the temperature-schedule fix and re-running:
 
-| Episode | WER | Wall (s) | Realtime multiple | Hyp word count |
-| --- | ---: | ---: | ---: | ---: |
-| p01_e01 | 0.109 | 361.5 | 1.5× | 1,672 (ref 1,536) |
+| Episode | WER | Wall (s) | Realtime multiple | Hyp words | Ref words |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| p01_e01 | 0.077 | 132.1 | 4.2× | 1,608 | 1,536 |
+| p02_e01 | 0.161 | 165.9 | 4.0× | 1,650 | 1,519 |
+| p03_e01 | 0.093 | 96.2 | 5.1× | 1,529 | 1,445 |
+| p04_e01 | 0.065 | 113.4 | 5.0× | 1,512 | 1,448 |
+| p05_e01 | 0.115 | 116.3 | 4.5× | 1,534 | 1,452 |
+| **mean** | **0.102** | **124.8** | **4.56×** | — | — |
 
-**Headline**: only **1 episode** sampled (full 5-episode CPU sweep
-exceeded the eval window). But the single point already invalidates
-the original `~17×` MPS-speedup hypothesis that was extrapolated from
-diarization. For openai-whisper specifically:
+Hyp word counts now match reference within ±10% on every episode
+(no more 7,000-word runaways). Quality is within scoring noise of
+MPS (0.102 vs 0.096 = 6% gap, smaller than the inter-episode
+variance on either backend). Realtime multiple ~3× MPS, ~2× CPU —
+the GPU's actual win.
 
-- CPU: 1.5× realtime, WER 0.109, word-count match.
-- MPS warm: 2.6-3.8× realtime, WER 0.07-0.14, word-count match.
-- MPS includes a 13-min model-load cold-start that drags the
-  5-episode mean to 1.6× — masking that warm MPS is ~1.8× CPU, NOT
-  17×.
+### DGX openai-whisper on `:8002` — PRE-FIX (kept for the audit trail)
 
-This matters for `local.yaml` profile recommendation: **on M4 Pro,
-openai-whisper is realtime-or-better even on CPU**. The MPS path is
-faster but not load-bearing. If MPS is unavailable / disabled (e.g.,
-shared host, GPU pinned to another job), the CPU fallback is still
-production-viable.
+| Episode | WER | Hyp words | Ref words |
+| --- | ---: | ---: | ---: |
+| p01_e01 | 4.131 | 7,368 | 1,536 |
+| p02_e01 | 8.211 | 13,136 | 1,519 |
+| p03_e01 | 1.671 | 3,371 | 1,445 |
+| p04_e01 | 1.448 | 2,821 | 1,448 |
+| p05_e01 | 0.558 | 1,943 | 1,452 |
+| **mean** | **3.204** | — | — |
 
-Why diarization differs from transcription on the CPU vs MPS gap:
-pyannote's segmentation + clustering is much more compute-per-second-
-of-audio than whisper's seq2seq decoder. Diarization saturates the
-GPU's parallelism; openai-whisper's autoregressive decoder is
-sequential and doesn't.
+These numbers are **the result of the temperature-scalar bug**, not
+a property of the DGX. Documented for the audit trail because the
+synthesis report's earlier "DGX whisper unfit for production"
+recommendation was based on them.
+
+### DGX faster-whisper on `:8000` (speaches image) — still broken
+
+| Episode | WER | Wall (s) | Realtime multiple | Hyp words | Ref words |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| p01_e01 | 1.000 | 5,804.1 (97 min) | 0.1× | **0** | 1,536 |
+| p02_e01 | 1.000 | 3,052.6 | 0.2× | **0** | 1,519 |
+| p03_e01 | 1.000 | 989.4 | 0.5× | **0** | 1,445 |
+| p04_e01 | 7.374 | 3,646.4 | 0.2× | 11,011 | 1,448 |
+| p05_e01 | 1.000 | 2,607.9 | 0.2× | **0** | 1,452 |
+| **mean** | **2.275** | **3,220.1** | **0.24×** | — | — |
+
+Two failure modes in one container:
+
+1. **Zero-output (4/5)**: 200 OK with empty transcript after tens
+   of minutes wall time.
+2. **Hallucination (1/5)**: 11,011 words for 1,448 reference.
+
+This is a **different bug from the openai-whisper one** — it lives
+in the speaches container (image
+`ghcr.io/speaches-ai/speaches:latest-cuda`), not in our `app.py`.
+Likely root cause: `WHISPER__COMPUTE_TYPE=default` resolving to a
+quantization (int8) that destroys output on GB10, combined with
+some VAD / chunking config that emits empty transcripts. Diagnosis
+filed as a follow-up.
+
+## 4-way summary
+
+| Backend | WER mean | Realtime × | Status | Per-PR change |
+| --- | ---: | ---: | --- | --- |
+| **DGX openai-whisper FIXED (`:8002`)** | **0.102** | **4.56×** | ✅ new production winner | Fix in this PR |
+| **MPS (laptop, openai-whisper)** | 0.096 | 1.6× | ✅ laptop production default | No change |
+| CPU (laptop, openai-whisper) | 0.137 | 2.34× | ✅ viable fallback | New finding documented |
+| DGX faster-whisper (`:8000`) | 2.275–7.374 | 0.24× | ❌ broken — separate bug | Filed as follow-up |
+| DGX openai-whisper PRE-FIX (`:8002`) | 3.204 | 2.30× | ❌ (audit trail only) | Fixed this PR |
 
 ## What this tells us for #929
 
-- ✅ **MPS is the production-viable default** for laptop-driven runs.
-  Faster than realtime once warm, clean WER, predictable.
-- ✅ **DGX CUDA via openai-whisper is theoretically faster but operationally fragile**
-  on a shared GPU. The same contention pattern that hit `#948` for
-  speaches hits openai-whisper too. Either dedicate the DGX to whisper
-  during transcription windows, or wait for the client-side resilience
-  work (#946 / #954 analog) to stabilize it.
-- ✅ **The speaches/faster-whisper-on-DGX comparison is properly out of
-  scope here.** It's gated on the #952 validation; this report
-  intentionally doesn't conflate "ctranslate2's faster-whisper" with
-  "OpenAI's openai-whisper."
+- ✅ **DGX openai-whisper is the new production transcription default
+  for `cloud_with_dgx_*` profiles** — quality within scoring noise of
+  MPS, ~3× faster on realtime, free per token. The temperature-
+  schedule bug was the only thing blocking it.
+- ✅ **MPS stays the `local.yaml` default**. No reason to change —
+  it's clean and the operator already has it. CPU fallback is also
+  viable if MPS is unavailable.
+- ❌ **DGX faster-whisper (speaches) is not the production path** —
+  separate bug, separate fix. Filed.
+- ⏭️ **Cloud Whisper API stays the choice for `cloud_*` profiles** —
+  not retested this batch.
 
 ## What this DOES NOT tell us
 
-- ❌ **WER under non-contended DGX** — the 8.21 number on p02_e01 is a
-  contention artifact, not the model's true accuracy. Need a re-run with
-  vLLM stopped / GPU dedicated to read the clean DGX WER.
-- ❌ **5-episode CPU mean** — only 1 episode sampled. The single point
-  is enough to invalidate the 17× extrapolation hypothesis but the
-  full WER distribution and per-episode latency variance on CPU stay
-  unknown until a longer eval window.
-- ❌ **Burst / concurrency latency** — no concurrent-request testing
-  in this run. The whisper provider's single-flight resilience (#946)
-  matters more than the bare numbers under contention.
+- ❌ **The speaches/faster-whisper container's root cause.** We
+  documented the empirical failure but haven't yet bisected (the
+  `compute_type=default` hypothesis is the leading suspect but not
+  verified). Filed as follow-up. The container should not be the
+  production path until this is resolved.
+- ❌ **WER on real podcast audio (90 min episodes).** All 5 episodes
+  are v2 synthesized fixtures (~5 min each). Real podcasts have
+  different challenges (noise, accents, music interludes). Synthesis
+  recommendation reasons from the v2 numbers, which the operator has
+  consistently used as the proxy for production audio.
+- ❌ **Burst / concurrency latency.** No concurrent-request testing
+  in this run. The whisper provider's single-flight pattern from
+  #946 and the broader DGX-over-Tailscale resilience patterns from
+  #956 are still the right wrap for any prod DGX whisper consumer.
+
+## Tailscale client-side caveat
+
+The first two attempts at the post-fix 5-episode sweep hung after
+episode 1/2 due to a **DGX-over-Tailscale HTTP response stuck
+mid-transit** — server returned 200 OK but the response body
+didn't reach the laptop. Reproducible. Worked around with a
+per-episode loop driven by `perl -e 'alarm 1200'` (each episode is
+an independent harness invocation; a hang only kills that one
+episode).
+
+**This is NOT a property of DGX whisper.** It's a generic
+blocking-HTTP-over-Tailscale failure mode that bites every long-
+running client. Filed as **#956** (DGX-over-Tailscale client
+resilience). Until #956 lands the shared resilience layer, the
+operator should expect this pattern on any long DGX call from the
+laptop and use the per-call timeout workaround.
 
 ## Recommendation
 
-**For prod (today, without further work):**
+**For prod (after this PR lands):**
 
-- **Laptop runs**: openai-whisper on MPS, model auto-pick. The `local.yaml`
-  profile path already does this. **Keep as default.**
-- **DGX runs**: openai-whisper on `:8002` only when the DGX is NOT
-  running heavy concurrent LLM workloads (e.g., overnight batches
-  with vLLM stopped). The instability under load makes it unsuitable
-  as a real-time primary today.
+- **Laptop runs (`local.yaml`)**: openai-whisper on MPS, model
+  auto-pick. CPU fallback is viable. **No change.**
+- **DGX-equipped runs (`cloud_with_dgx_*`)**: route transcription
+  to **`whisper-openai` on `:8002`** (the fixed container).
+  Quality matches MPS within noise, ~3× faster realtime.
+- **Cloud-only runs (`cloud_*`)**: cloud Whisper API. Not retested
+  this batch.
 
 **Follow-ups (filed):**
 
-1. **Re-measure DGX whisper under dedicated GPU** — stop vLLM, run the
-   same 5 episodes, see if WER and latency normalize. If yes, the
-   issue is purely contention-resilience.
-2. **Add single-flight + duration-scaled timeout to the openai-whisper
-   client path** — same pattern as `TailnetDgxWhisperTranscriptionProvider`
-   from #946. Currently the harness POSTs directly without those guards.
-3. **#952 faster-whisper-vs-openai-whisper WER validation** — once #952
-   runs, we can include speaches as a 4th candidate (different engine,
-   same model weights).
+1. **#956** — DGX-over-Tailscale client resilience (shared
+   timeout/retry/keepalive layer across all DGX clients). Covers
+   the hang pattern we hit during this eval.
+2. **Speaches/faster-whisper root cause** (separate ticket — file
+   if not already; container produces empty output on 4/5
+   episodes, likely `compute_type=default` → bad quantization).
+3. **#946 / #954** — whisper / diarization client resilience.
+   Should expand to use the #956 shared layer instead of bespoke
+   patterns per backend.
 
 ## Artifacts
 
-- `scripts/eval/score/whisper_dgx_vs_cloud_v1.py` — harness with `local` (auto/cpu/mps), `dgx`, and `cloud` slots
+- `infra/dgx/whisper-server/app.py` — the fix (temperature now
+  Optional[float], only passed to transcribe() when explicit)
+- `scripts/eval/score/whisper_dgx_vs_cloud_v1.py` — harness with
+  `local` (auto/cpu/mps), `dgx`, and `cloud` slots
 - `data/eval/runs/whisper_dgx_vs_cloud_v1/local-mps/metrics.json` — MPS 5/5
-- `data/eval/runs/whisper_dgx_vs_cloud_v1/dgx/metrics.json` — DGX 5/5 with the contention pattern documented above
-- `data/eval/runs/whisper_dgx_vs_cloud_v1/local-cpu/metrics.json` — pure CPU (1 ep, lands when bg task completes)
+- `data/eval/runs/whisper_dgx_vs_cloud_v1/local-cpu/metrics.json` — pure CPU episode 1
+- `data/eval/runs/whisper_dgx_vs_cloud_v1/local-cpu-rest/metrics.json` — pure CPU episodes 2-5
+- `data/eval/runs/whisper_dgx_vs_cloud_v1/dgx/metrics.json` — DGX openai-whisper, PRE-fix, contended (audit trail)
+- `data/eval/runs/whisper_dgx_vs_cloud_v1/dgx-openai-noncontended/metrics.json` — DGX openai-whisper, PRE-fix, non-contended (audit trail; identical to contended)
+- `data/eval/runs/whisper_dgx_vs_cloud_v1/dgx-openai-fixed/metrics.json` — DGX openai-whisper, POST-fix (the production-recommended path)
+- `data/eval/runs/whisper_dgx_vs_cloud_v1/dgx-openai-fixed-perep/<ep>/metrics.json` — per-episode raw metrics for the post-fix sweep (the Tailscale-hang workaround pattern)
+- `data/eval/runs/whisper_dgx_vs_cloud_v1/dgx-faster-whisper/metrics.json` — DGX faster-whisper (still broken; separate bug)
 
 ## References
 
 - Issue: #929
-- Whisper-engine validation gate: #952
-- DGX speaches incident that uncovered the contention pattern: #948
-- Diarization client resilience gap (analogous pattern): #954
-- openai-whisper service this used: `infra/dgx/whisper-server/` (#953)
+- This PR fixes: `infra/dgx/whisper-server/app.py` — the temperature-schedule disable
+- DGX-over-Tailscale client resilience (filed this batch): #956
+- Whisper client resilience (existing): #946
+- Diarization client resilience (analogous pattern): #954
+- Whisper-engine validation gate: #952 (blocked on speaches root-cause — see follow-ups)
+- DGX speaches background context: #948 (originally framed as ctranslate2 CPU-only build issue; current container boots with CUDA but produces broken output — different bug class)
+- openai-whisper service deploy: `infra/dgx/whisper-server/` (#953) — the deploy was correct; the temperature contract was the bug

--- a/docs/guides/eval-reports/EVAL_TRANSCRIPTION_3WAY_2026_06.md
+++ b/docs/guides/eval-reports/EVAL_TRANSCRIPTION_3WAY_2026_06.md
@@ -1,0 +1,126 @@
+# EVAL — Whisper 3-way: MPS / CUDA (DGX, openai-whisper) / CPU (#929 partial)
+
+**Issue:** #929 (transcription championship — partial; the speaches/faster-whisper path is gated on #952)
+**Branch:** `feat/autoresearch-batch-3-championships`
+**Dataset:** v2 audio fixtures, 5 episodes (~5 min each)
+**Status:** **Partial** — MPS measured cleanly; DGX CUDA result is contaminated by GPU contention (real finding, not noise); pure CPU still running at submit time.
+
+---
+
+## TL;DR
+
+- **Apple MPS (laptop) is the cleanest, most reliable path** for openai-whisper today: ~1.6× realtime mean, WER 0.10 mean on the v2 fixture set.
+- **DGX CUDA via `:8002 openai-whisper` produced hallucinations under GPU contention** (vLLM running concurrently): some episodes returned 8× more output words than the reference, WER spiked to 8.21 on the worst one. **This is a finding, not a clean number** — it shows that "DGX whisper" without single-flight + duration-scaled timeout (the #946 / #954 resilience pattern) degrades under shared-GPU load.
+- **Pure CPU baseline** (M4 Pro forced `device=cpu`) was still in flight at this writing; result is documented in the harness output when it lands.
+
+## Numbers (5 v2 episodes, large-v3 model)
+
+### Apple MPS — clean, reliable
+
+| Episode | WER | Wall (s) | Realtime multiple |
+| --- | ---: | ---: | ---: |
+| p01_e01 | 0.120 | 819.5 (cold start) | 0.7× |
+| p02_e01 | 0.137 | 385.8 | 1.7× |
+| p03_e01 | 0.083 | 187.8 | 2.6× |
+| p04_e01 | 0.065 | 147.2 | 3.8× |
+| p05_e01 | 0.074 | 185.3 | 2.8× |
+| **mean** | **0.096** | **345.1** | **1.6×** |
+
+First-call cost is the model-load (~13 minutes on cold cache). Warm
+calls are 2-4× realtime. WER cluster around 0.07-0.14 — normal for
+large-v3 on conversational audio.
+
+### DGX CUDA via `:8002 openai-whisper` — contaminated by contention
+
+| Episode | WER | Wall (s) | Realtime multiple | Hypothesis word count |
+| --- | ---: | ---: | ---: | ---: |
+| p01_e01 | 4.13 | 284.2 | 1.9× | (high — see below) |
+| p02_e01 | 8.21 | 571.3 | 1.1× | **13,136** (ref 1,519) |
+| p03_e01 | 1.67 | 124.1 | 3.9× | (high) |
+| p04_e01 | 1.45 | 119.9 | 4.7× | (high) |
+| p05_e01 | 0.56 | 86.8 | 6.1× | (high) |
+
+WER > 1.0 means the hypothesis is so over-long that insertions
+dominate. p02_e01 produced **13,136 words for a 1,519-word reference**
+— the model started repeating / hallucinating after the first valid
+segment. This is consistent with the **`large-v3` decoder running on
+a CPU-fallback path under GPU memory pressure**, or the same auto-
+unload-then-reload regression we hit with speaches in `#948`.
+
+**At time of this run, the DGX was also running:** vLLM autoresearch
+(R1-Distill-32B, port 8003, ~30 GB resident on GPU at
+`gpu_memory_utilization=0.60`), pyannote, speaches, and Ollama
+(idle). The openai-whisper container's `large-v3` weights are ~3 GB
+which should fit, but vLLM's KV-cache + CUDA-graph capture compete
+with whisper at allocation time — when whisper goes idle for a few
+minutes then a request comes in, the CUDA context may be evicted and
+the model effectively re-init's against memory it can't get.
+
+### Pure CPU (M4 Pro, `LOCAL_WHISPER_DEVICE=cpu`)
+
+Still running at time of this write — expected ~10-30 min for a single
+~5-min episode based on extrapolation from diarization's CPU vs MPS
+ratio (~17×). Will document when the bg task lands.
+
+## What this tells us for #929
+
+- ✅ **MPS is the production-viable default** for laptop-driven runs.
+  Faster than realtime once warm, clean WER, predictable.
+- ✅ **DGX CUDA via openai-whisper is theoretically faster but operationally fragile**
+  on a shared GPU. The same contention pattern that hit `#948` for
+  speaches hits openai-whisper too. Either dedicate the DGX to whisper
+  during transcription windows, or wait for the client-side resilience
+  work (#946 / #954 analog) to stabilize it.
+- ✅ **The speaches/faster-whisper-on-DGX comparison is properly out of
+  scope here.** It's gated on the #952 validation; this report
+  intentionally doesn't conflate "ctranslate2's faster-whisper" with
+  "OpenAI's openai-whisper."
+
+## What this DOES NOT tell us
+
+- ❌ **WER under non-contended DGX** — the 8.21 number on p02_e01 is a
+  contention artifact, not the model's true accuracy. Need a re-run with
+  vLLM stopped / GPU dedicated to read the clean DGX WER.
+- ❌ **CPU comparison** — pure CPU still in flight; one-episode result
+  will fill the cell.
+- ❌ **Burst / concurrency latency** — no concurrent-request testing
+  in this run. The whisper provider's single-flight resilience (#946)
+  matters more than the bare numbers under contention.
+
+## Recommendation
+
+**For prod (today, without further work):**
+
+- **Laptop runs**: openai-whisper on MPS, model auto-pick. The `local.yaml`
+  profile path already does this. **Keep as default.**
+- **DGX runs**: openai-whisper on `:8002` only when the DGX is NOT
+  running heavy concurrent LLM workloads (e.g., overnight batches
+  with vLLM stopped). The instability under load makes it unsuitable
+  as a real-time primary today.
+
+**Follow-ups (filed):**
+
+1. **Re-measure DGX whisper under dedicated GPU** — stop vLLM, run the
+   same 5 episodes, see if WER and latency normalize. If yes, the
+   issue is purely contention-resilience.
+2. **Add single-flight + duration-scaled timeout to the openai-whisper
+   client path** — same pattern as `TailnetDgxWhisperTranscriptionProvider`
+   from #946. Currently the harness POSTs directly without those guards.
+3. **#952 faster-whisper-vs-openai-whisper WER validation** — once #952
+   runs, we can include speaches as a 4th candidate (different engine,
+   same model weights).
+
+## Artifacts
+
+- `scripts/eval/score/whisper_dgx_vs_cloud_v1.py` — harness with `local` (auto/cpu/mps), `dgx`, and `cloud` slots
+- `data/eval/runs/whisper_dgx_vs_cloud_v1/local-mps/metrics.json` — MPS 5/5
+- `data/eval/runs/whisper_dgx_vs_cloud_v1/dgx/metrics.json` — DGX 5/5 with the contention pattern documented above
+- `data/eval/runs/whisper_dgx_vs_cloud_v1/local-cpu/metrics.json` — pure CPU (1 ep, lands when bg task completes)
+
+## References
+
+- Issue: #929
+- Whisper-engine validation gate: #952
+- DGX speaches incident that uncovered the contention pattern: #948
+- Diarization client resilience gap (analogous pattern): #954
+- openai-whisper service this used: `infra/dgx/whisper-server/` (#953)

--- a/docs/wip/AUTORESEARCH_LEARNINGS_FOR_V3.md
+++ b/docs/wip/AUTORESEARCH_LEARNINGS_FOR_V3.md
@@ -430,3 +430,143 @@ should:
 **Tuned thresholds shipped:** no — the methodology is shipped; the model selection is unchanged. Composite ranking with the reliability axis still favors `gemini-2.5-flash-lite` by a wide margin (3-10× cost dominance, 3× latency dominance).
 
 **Cross-reference:** Reliability burst against the existing per-provider summarize endpoint is reusable for cross-stage evaluation when future tickets bring GI / KG / speaker models into autoresearch scope.
+
+### #928 / #929 / #930 / #931 — DGX-vs-cloud autoresearch (batch 3, 2026-06-10/11)
+
+**Eval set:** 5 v2 audio fixtures (`p0[1-5]_e01.mp3`, ~5 min each)
+across four transcription backends (MPS / CPU / DGX `whisper-openai`
+on `:8002` / DGX faster-whisper on `:8000`), three summary backends
+(Ollama qwen3.5:35b at Q4 / vLLM R1-Distill-32B at bf16 / vLLM
+Qwen3.6-35B-A3B at bf16 added via Cell C), and a 3-way pyannote
+diarization run (MPS / CUDA / CPU). Reports under
+`docs/guides/eval-reports/EVAL_{DIARIZATION,SUMMARY,TRANSCRIPTION,HYBRID_ROUTING}_*_2026_06.md`.
+
+**Real-prod failure-mode catalogue surfaced (v3-relevant):**
+
+1. **Single-voice TTS confirmed-blocks diarization at the fixture
+   level.** The #930 3-way pyannote comparison was contaminated:
+   all three platforms (MPS / CUDA / CPU) collapsed to a single
+   detected speaker because every voice in v2 is `say --voice Alex`.
+   This re-confirms the gap #934 already tracks — included here
+   because the batch-3 numbers are the cleanest empirical evidence
+   yet that the contamination is total, not partial.
+
+2. **Long-form audio is the trigger condition for openai-whisper
+   autoregressive runaway.** The DGX whisper service produced WER
+   3.20 mean (5–9× extra hyp words) pre-fix because the API contract
+   forced `temperature=0.0` scalar, disabling openai-whisper's
+   built-in fallback schedule. Triggered reliably on the 5-min v2
+   episodes; would trigger harder on the 30-90-min real podcasts
+   the operator wants in production. Post-fix, the same episodes
+   produced WER 0.102 / 4.56× realtime — within scoring noise of
+   MPS. The bug fix lives in
+   `infra/dgx/whisper-server/app.py` + the temperature-schedule
+   nuance is documented in the consumer-contract section of
+   `infra/dgx/vllm-autoresearch/README.md`. **Implication for v3
+   audio**: episodes that span the autoregressive-runaway trigger
+   window (multi-minute, conversational, technical-vocab) are
+   exactly the v3 axis that will catch this class of bug before it
+   reaches prod. The v3 text side already has them
+   (`p07_e01` 11.5k words, `p08_e01` 14.5k); the v3 audio PR
+   should render them as similarly-long voiced episodes, not just
+   as 5-min clips.
+
+3. **Per-episode acoustic difficulty asymmetry on temperature-
+   fallback path.** Pure-CPU openai-whisper produced WER 0.281 on
+   `p05_e01` while the other 4 episodes stayed at 0.07–0.12 mean
+   (CPU 5-ep mean 0.137). Same voice, same fixture set —
+   variance comes from openai-whisper's temperature schedule being
+   non-deterministic once it fires (fallback retry at higher
+   temperatures introduces stochasticity). The episode-level WER
+   variance under fallback-mode decoding is ~3× the clean-decode
+   variance. **Implication for v3 audio**: building a transcription-
+   benchmark suite requires *deliberate* coverage of episodes that
+   trigger the fallback path (faster-paced, denser vocab, longer
+   uninterrupted spans). Clean-decode-only fixtures under-represent
+   the failure regime.
+
+4. **Same-model-different-server ties within scoring noise (#928
+   Cell C).** vLLM-served `Qwen3.6-35B-A3B` at bf16 scored 4.90
+   mean vs Ollama-served `qwen3.5:35b` at Q4_K_M's 5.00 mean
+   (Sonnet 4.6 + GPT-5.4 cross-check, 100% agreement, no
+   contested). The parent eval's 1.75-point gap (Ollama 5.00 vs
+   vLLM R1-Distill 3.25) was the **model choice**, not the
+   serving stack. **Implication for v3 / autoresearch
+   methodology**, not v3 fixtures: future cross-stack model
+   sweeps can hold one variable fixed without needing fixture
+   changes. The fixture set produced well-separated scores
+   across *different* models — which is the diversity v3 already
+   delivers — so no new fixture coverage is needed for this
+   class.
+
+5. **R1-Distill reasoning prose leak as an output-side failure
+   mode.** R1-Distill emits "thinking process" prose (`Okay, so
+   I need to summarize this episode…`) before the actual summary
+   when run without `chat_template_kwargs={enable_thinking:
+   False}` (Qwen3.6 has a clean toggle; R1-Distill does not).
+   This contributed to R1's low coherence (2.2) + fluency (2.4)
+   in the parent #928. **Not a v3-fixture-side failure mode** —
+   the leak is a property of the model's output distribution,
+   not the input. Filed as **#961** (prompt-side fix). Mentioned
+   here so future eval reports don't re-discover it from scratch.
+
+**What v3 should add (audio side, consumed by the operator's TTS PR
+when #934 lands):**
+
+- **Multi-voice TTS realization of the v3 text fixtures.**
+  Re-confirmed need; the text side already emits per-episode
+  voice/accent hints via `PodcastV3.host_accent` /
+  `GuestV3.accent` + manifest `audio_voice_hints` (per #906
+  notes above). Batch-3 adds no new requirement here beyond
+  "ship the audio side so #930 / #934 can verdict on diarization
+  quality, not platform speed."
+- **Long-form voiced episodes (5+ min, ideally 30+ min for
+  prod-shape benchmarks).** The v3 text side already has
+  `p07_e01` 11.5k words and `p08_e01` 14.5k words; the audio PR
+  should render at least one of these as a multi-minute voiced
+  episode. Real-podcast 90-min benchmarking is a separate axis
+  tracked by **#959**.
+- **Episodes that reliably trigger the temperature-fallback
+  path** — see point 3 above. Fast-paced + technical-vocab
+  episodes from the existing v3 text set already qualify; the
+  audio renderer just needs to preserve the density when
+  vocalizing.
+
+**What v3 should NOT change (axes already adequately covered):**
+
+- Diversity across summary candidates: v3 episodes produce well-
+  separated scores across different summary models (Qwen3.6 vs
+  R1-Distill = 1.75-point gap). Sufficient diversity for cross-
+  model sweeps.
+- Diversity across diarization candidates: blocked entirely by
+  the single-voice TTS issue; once #934 lands multi-voice
+  rendering, the existing v3 episode set has enough speaker
+  variety (host + 2-4 guests per episode, per #906 notes) to
+  produce a meaningful diarization eval. No new v3 fixture
+  axis needed.
+
+**Tuned thresholds shipped:** no — this batch shipped a
+*configuration* fix (whisper-server `temperature` API contract
+change) and *infrastructure* default flips (vLLM
+`26.05-py3 + Qwen3.6-35B-A3B + --max-num-seqs 128` as the new
+default in `deploy.py`; Ollama qwen3.5:35b stays the
+`cloud_with_dgx_*` summary default with operational-simplicity
+as the new justification, replacing quality as the prior
+justification). Neither is a fixture-side threshold.
+
+**Cross-ref:** Late-batch findings filed as follow-ups for next
+sessions — **#956** (DGX-over-Tailscale client resilience),
+**#957** (speaches/faster-whisper container root-cause; the
+faster-whisper sweep had a separate bug from openai-whisper's;
+empty output 4/5 episodes, hallucination 1/5),
+**#958** (Cell D / Cell E quantization isolation for #928),
+**#959** (real-podcast 90-min validation across the post-fix
+4-way), **#960** (vLLM as a first-class backend in
+`autoresearch_track_a.py`, replacing the standalone
+`summary_vllm_predict_v1.py` workaround used this batch),
+**#961** (R1-Distill reasoning-suppressed prompt — addresses
+the failure mode in point 5), **#962** (Gemini speaker
+detector provider deploy — unblocks the `cloud_*` slot of
+#930's panel), **#963** (re-test DGX whisper under contention
+now that the temperature bug is fixed), **#964** (Wave audio
+hardening umbrella from the WIP audit).

--- a/infra/dgx/converge/deploy.py
+++ b/infra/dgx/converge/deploy.py
@@ -394,3 +394,126 @@ server.shell(
     commands=[f"cd {WHISPER_INSTALL_ROOT} && docker compose up -d"],
     _sudo=True,
 )
+
+
+# ---------------------------------------------------------------------------
+# #928 — vllm-autoresearch. NVIDIA-prebuilt vLLM container serving an
+# open-weight LLM for autoresearch evaluations (summary / GI / KG).
+# Listens on :8003 so it coexists with the other DGX services (8000=
+# speaches, 8001=pyannote, 8002=openai-whisper). No Dockerfile — vLLM
+# ships its own OpenAI-compatible server in the NVIDIA image.
+# ---------------------------------------------------------------------------
+
+VLLM_INSTALL_ROOT = "/opt/vllm-autoresearch"
+VLLM_COMPOSE_FILE = f"{VLLM_INSTALL_ROOT}/docker-compose.yml"
+VLLM_IMAGE = "nvcr.io/nvidia/vllm:25.11-py3"
+VLLM_PORT = 8003
+
+# Default to the model already cached on the operator's DGX (no fresh
+# download). Coder-tuned and not the ideal long-term summary candidate,
+# but it's what's in cache and exercises the vLLM serving path. Swap
+# this constant + adjust gpu-memory-utilization / max-model-len to test
+# different models — see infra/dgx/vllm-autoresearch/README.md.
+VLLM_MODEL = "Qwen/Qwen3-Coder-Next-FP8"
+# 0.75 (not the operator's reference 0.92) so vLLM coexists with the
+# other DGX services: whisper-openai (~3 GB) + pyannote (~3-4 GB) +
+# faster-whisper (~3-4 GB) + Ollama-loaded model (~10 GB depending
+# on what's resident) → ~15-20 GB already in use of the GB10's
+# ~122 GB. At 0.92 vLLM raises "Free memory on device < desired
+# utilization" at startup. 0.75 = ~91 GB which fits 30B-FP8 + KV cache.
+# If running vLLM in isolation (other services stopped for an
+# autoresearch sweep), bump back to 0.92 for the extra KV headroom.
+VLLM_GPU_MEM_UTIL = "0.75"
+VLLM_MAX_MODEL_LEN = "131072"
+
+files.directory(
+    name="dir: /opt/vllm-autoresearch (install root)",
+    path=VLLM_INSTALL_ROOT,
+    mode="755",
+    present=True,
+    _sudo=True,
+)
+
+# docker-compose.yml. Mirrors the operator's working
+# ``~/docker-compose/vllm-Qwen3-Coder-Next/docker-compose.yml`` byte-for-byte
+# except for the port (8003 not 8000) and container name (so it coexists
+# with the operator's personal coding container if/when that runs).
+VLLM_COMPOSE_CONTENT = f"""# Auto-generated. Edit infra/dgx/converge/deploy.py instead.
+# Re-run ``make dgx-deploy`` from the laptop to redeploy.
+
+services:
+  vllm-autoresearch:
+    image: {VLLM_IMAGE}
+    container_name: vllm-autoresearch
+    runtime: nvidia
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    ipc: host
+    network_mode: host
+    env_file:
+      - {OPERATOR_ENV_FILE}
+    volumes:
+      - {HF_CACHE_HOST}:/root/.cache/huggingface
+    environment:
+      - HF_HOME=/root/.cache/huggingface
+      - HF_HUB_CACHE=/root/.cache/huggingface
+      # GB10 hotfix: torch.compile has been the Blackwell sore spot on
+      # the version we run. Disabling loses ~10-20% steady-state throughput
+      # but is the reliable boot path per the operator's working composes.
+      - VLLM_DISABLE_TORCH_COMPILE=1
+      - NVIDIA_VISIBLE_DEVICES=all
+    command:
+      - vllm
+      - serve
+      - {VLLM_MODEL}
+      - --host
+      - 0.0.0.0
+      - --port
+      - "{VLLM_PORT}"
+      - --dtype
+      - bfloat16
+      - --max-model-len
+      - "{VLLM_MAX_MODEL_LEN}"
+      - --gpu-memory-utilization
+      - "{VLLM_GPU_MEM_UTIL}"
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - qwen3_coder
+    healthcheck:
+      test: ["CMD", "python3", "-c",
+             "import urllib.request; urllib.request.urlopen('http://localhost:{VLLM_PORT}/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 600s
+    restart: unless-stopped
+"""
+
+server.shell(
+    name="compose: write /opt/vllm-autoresearch/docker-compose.yml",
+    commands=[
+        f"cat > {VLLM_COMPOSE_FILE} <<'EOF'\n{VLLM_COMPOSE_CONTENT}EOF",
+        f"chmod 644 {VLLM_COMPOSE_FILE}",
+    ],
+    _sudo=True,
+)
+
+# No build step — we use the NVIDIA-prebuilt image directly.
+# We DO pull because the image is fairly recent (25.11) and the operator
+# may not have it cached on initial deploy. Wrap in `|| true` so a
+# pull blip doesn't bail the deploy when a cached image exists.
+server.shell(
+    name="compose: pull vllm image (tolerated on cache hit)",
+    commands=[
+        f"cd {VLLM_INSTALL_ROOT} && docker compose pull "
+        f"|| echo '::warning::nvcr.io pull failed; falling back to cached image'"
+    ],
+    _sudo=True,
+)
+
+server.shell(
+    name="compose: up -d (start / restart vllm-autoresearch service)",
+    commands=[f"cd {VLLM_INSTALL_ROOT} && docker compose up -d"],
+    _sudo=True,
+)

--- a/infra/dgx/converge/deploy.py
+++ b/infra/dgx/converge/deploy.py
@@ -414,17 +414,20 @@ VLLM_PORT = 8003
 # but it's what's in cache and exercises the vLLM serving path. Swap
 # this constant + adjust gpu-memory-utilization / max-model-len to test
 # different models — see infra/dgx/vllm-autoresearch/README.md.
-VLLM_MODEL = "Qwen/Qwen3-Coder-Next-FP8"
-# 0.75 (not the operator's reference 0.92) so vLLM coexists with the
-# other DGX services: whisper-openai (~3 GB) + pyannote (~3-4 GB) +
-# faster-whisper (~3-4 GB) + Ollama-loaded model (~10 GB depending
-# on what's resident) → ~15-20 GB already in use of the GB10's
-# ~122 GB. At 0.92 vLLM raises "Free memory on device < desired
-# utilization" at startup. 0.75 = ~91 GB which fits 30B-FP8 + KV cache.
-# If running vLLM in isolation (other services stopped for an
-# autoresearch sweep), bump back to 0.92 for the extra KV headroom.
-VLLM_GPU_MEM_UTIL = "0.75"
-VLLM_MAX_MODEL_LEN = "131072"
+VLLM_MODEL = "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"
+# 0.60 (not 0.92) so vLLM coexists with the other DGX services:
+# whisper-openai (~3 GB) + pyannote (~3-4 GB) + faster-whisper (~3-4 GB)
+# + Ollama-loaded model (~10 GB depending on what's resident) →
+# ~15-20 GB already in use of the GB10's ~122 GB. 0.60 = ~73 GB,
+# which fits a 32B bf16 model + KV cache while leaving headroom for
+# the other services. Bump back toward 0.92 only if you stop the
+# other services to give vLLM the whole box.
+VLLM_GPU_MEM_UTIL = "0.60"
+# 32k context — enough for podcast transcripts (~10k chars typical,
+# ~13k tokens at the model's tokenizer rate). The R1-Distill base
+# supports 131072 but holding KV cache for that at full size eats
+# memory we'd rather give to throughput.
+VLLM_MAX_MODEL_LEN = "32768"
 
 files.directory(
     name="dir: /opt/vllm-autoresearch (install root)",

--- a/infra/dgx/converge/deploy.py
+++ b/infra/dgx/converge/deploy.py
@@ -271,3 +271,126 @@ server.shell(
     commands=[f"cd {PYANNOTE_INSTALL_ROOT} && docker compose up -d"],
     _sudo=True,
 )
+
+
+# ---------------------------------------------------------------------------
+# #953 — openai-whisper transcription service. Runs alongside the speaches
+# faster-whisper container on a different port (8002). Reason: speaches'
+# bundled ctranslate2 is a community reimplementation of Whisper inference
+# (#948 surfaced this). Until #952 validates that faster-whisper's WER
+# matches openai-whisper on real podcasts, we want a first-party path
+# available. Both services run side-by-side; the consumer picks via URL.
+# Same Docker-based shape as Speaches + pyannote.
+# ---------------------------------------------------------------------------
+
+WHISPER_INSTALL_ROOT = "/opt/whisper-server"
+WHISPER_COMPOSE_FILE = f"{WHISPER_INSTALL_ROOT}/docker-compose.yml"
+WHISPER_BUILD_CTX = f"{WHISPER_INSTALL_ROOT}/build"
+WHISPER_IMAGE = "podcast-whisper:0.1.0"
+WHISPER_PORT = 8002
+WHISPER_MODEL = "large-v3"
+# Persistent cache for openai-whisper model weights (~3GB for large-v3).
+# Separate from the HF cache because openai-whisper uses its own cache layout
+# (URL-hashed filenames, not HF's snapshots/blobs structure).
+WHISPER_CACHE_HOST = "/opt/llm-models/whisper-cache"
+
+_WHISPER_SRC = _Path(__file__).resolve().parents[1] / "whisper-server"
+
+files.directory(
+    name="dir: /opt/whisper-server (install root)",
+    path=WHISPER_INSTALL_ROOT,
+    mode="755",
+    present=True,
+    _sudo=True,
+)
+
+files.directory(
+    name="dir: /opt/whisper-server/build (Docker build context)",
+    path=WHISPER_BUILD_CTX,
+    mode="755",
+    present=True,
+    _sudo=True,
+)
+
+files.directory(
+    name="dir: /opt/llm-models/whisper-cache (model weights persistence)",
+    path=WHISPER_CACHE_HOST,
+    mode="755",
+    present=True,
+    _sudo=True,
+)
+
+files.put(
+    name="ship: whisper-server/Dockerfile",
+    src=str(_WHISPER_SRC / "Dockerfile"),
+    dest=f"{WHISPER_BUILD_CTX}/Dockerfile",
+    mode="644",
+    create_remote_dir=False,
+    _sudo=True,
+)
+
+files.put(
+    name="ship: whisper-server/app.py",
+    src=str(_WHISPER_SRC / "app.py"),
+    dest=f"{WHISPER_BUILD_CTX}/app.py",
+    mode="644",
+    create_remote_dir=False,
+    _sudo=True,
+)
+
+# docker-compose.yml. Same env_file + GPU passthrough as the other two
+# services. Whisper cache is OUTSIDE the operator's HF cache because
+# openai-whisper writes its own URL-hashed layout, not HF's snapshots.
+WHISPER_COMPOSE_CONTENT = f"""# Auto-generated. Edit infra/dgx/converge/deploy.py instead.
+# Re-run ``make dgx-deploy`` from the laptop to redeploy.
+
+services:
+  whisper-openai:
+    build: {WHISPER_BUILD_CTX}
+    image: {WHISPER_IMAGE}
+    container_name: whisper-openai
+    restart: unless-stopped
+    network_mode: host
+    runtime: nvidia
+    env_file:
+      - {OPERATOR_ENV_FILE}
+    environment:
+      - WHISPER_MODEL={WHISPER_MODEL}
+      - WHISPER_DEVICE=cuda
+      - WHISPER_CACHE_DIR=/root/.cache/whisper
+      - LOG_LEVEL=INFO
+      - UVICORN_HOST=0.0.0.0
+      - UVICORN_PORT={WHISPER_PORT}
+    volumes:
+      # Persistent model cache so the ~3GB large-v3 download survives
+      # container restarts. openai-whisper writes to /root/.cache/whisper.
+      - {WHISPER_CACHE_HOST}:/root/.cache/whisper
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+"""
+
+server.shell(
+    name="compose: write /opt/whisper-server/docker-compose.yml",
+    commands=[
+        f"cat > {WHISPER_COMPOSE_FILE} <<'EOF'\n{WHISPER_COMPOSE_CONTENT}EOF",
+        f"chmod 644 {WHISPER_COMPOSE_FILE}",
+    ],
+    _sudo=True,
+)
+
+server.shell(
+    name="build: whisper-openai image (one-time + on Dockerfile/app changes)",
+    commands=[f"cd {WHISPER_INSTALL_ROOT} && docker compose build"],
+    _sudo=True,
+)
+
+server.shell(
+    name="compose: up -d (start / restart whisper-openai service)",
+    commands=[f"cd {WHISPER_INSTALL_ROOT} && docker compose up -d"],
+    _sudo=True,
+)

--- a/infra/dgx/converge/deploy.py
+++ b/infra/dgx/converge/deploy.py
@@ -406,28 +406,49 @@ server.shell(
 
 VLLM_INSTALL_ROOT = "/opt/vllm-autoresearch"
 VLLM_COMPOSE_FILE = f"{VLLM_INSTALL_ROOT}/docker-compose.yml"
-VLLM_IMAGE = "nvcr.io/nvidia/vllm:25.11-py3"
+# NVIDIA tag history on this GB10 (per the #928 Cell C investigation):
+# - 25.11-py3: vLLM 0.11 / transformers 4.57.1 — works; was the prior
+#   default. Does NOT support qwen3_5_moe architecture (the Qwen3.5/3.6
+#   model family). Use if you need to revert to R1-Distill or older
+#   Qwen3 models.
+# - 26.01-py3 through 26.04-py3: NVIDIA shipped them with transformers
+#   4.57.x patches; still no qwen3_5_moe support. Don't bother.
+# - 26.05-py3: vLLM 0.20.1 / transformers 5.6.0. Supports qwen3_5_moe
+#   AND boots on GB10. Current default per Cell C.
+# - 26.05.post1-py3: post-release hotfix that broke on this operator's
+#   GB10 (verified by operator). Do NOT use even though it would also
+#   support qwen3_5_moe.
+VLLM_IMAGE = "nvcr.io/nvidia/vllm:26.05-py3"
 VLLM_PORT = 8003
 
-# Default to the model already cached on the operator's DGX (no fresh
-# download). Coder-tuned and not the ideal long-term summary candidate,
-# but it's what's in cache and exercises the vLLM serving path. Swap
-# this constant + adjust gpu-memory-utilization / max-model-len to test
-# different models — see infra/dgx/vllm-autoresearch/README.md.
-VLLM_MODEL = "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"
+# Default to Qwen3.6-35B-A3B (same model family as the Ollama
+# qwen3.5:35b champion from #928). Cell C verified vLLM-served Qwen3.6
+# at bf16 ties Ollama-served qwen3.5:35b at Q4_K_M within scoring
+# noise (Sonnet 4.6: 4.90 vs 5.00). The R1-Distill alternative is in
+# /opt/llm-models/huggingface/ if you need to revert — set this back
+# to ``deepseek-ai/DeepSeek-R1-Distill-Qwen-32B`` and switch
+# VLLM_IMAGE to 25.11-py3. See infra/dgx/vllm-autoresearch/README.md.
+VLLM_MODEL = "Qwen/Qwen3.6-35B-A3B"
 # 0.60 (not 0.92) so vLLM coexists with the other DGX services:
 # whisper-openai (~3 GB) + pyannote (~3-4 GB) + faster-whisper (~3-4 GB)
 # + Ollama-loaded model (~10 GB depending on what's resident) →
 # ~15-20 GB already in use of the GB10's ~122 GB. 0.60 = ~73 GB,
-# which fits a 32B bf16 model + KV cache while leaving headroom for
+# which fits a 35B bf16 model + KV cache while leaving headroom for
 # the other services. Bump back toward 0.92 only if you stop the
 # other services to give vLLM the whole box.
 VLLM_GPU_MEM_UTIL = "0.60"
 # 32k context — enough for podcast transcripts (~10k chars typical,
-# ~13k tokens at the model's tokenizer rate). The R1-Distill base
-# supports 131072 but holding KV cache for that at full size eats
-# memory we'd rather give to throughput.
+# ~13k tokens at the model's tokenizer rate). Qwen3.6-35B-A3B
+# supports 32768 natively at this max-num-seqs; bigger contexts need
+# either lowering max-num-seqs further or raising GPU_MEM_UTIL.
 VLLM_MAX_MODEL_LEN = "32768"
+# Qwen3.6-35B-A3B uses Mamba layers; vLLM 0.20 enforces
+# max_num_seqs ≤ Mamba cache blocks. Default 256 fails CUDA-graph
+# capture (only 190 cache blocks available at gpu_mem_util=0.60).
+# 128 is well below the limit with headroom. Tune up only if you
+# raise gpu_mem_util or change the model family. Not used by the
+# 25.11-py3 / R1-Distill alternative — safe to leave in place.
+VLLM_MAX_NUM_SEQS = "128"
 
 files.directory(
     name="dir: /opt/vllm-autoresearch (install root)",
@@ -480,9 +501,8 @@ services:
       - "{VLLM_MAX_MODEL_LEN}"
       - --gpu-memory-utilization
       - "{VLLM_GPU_MEM_UTIL}"
-      - --enable-auto-tool-choice
-      - --tool-call-parser
-      - qwen3_coder
+      - --max-num-seqs
+      - "{VLLM_MAX_NUM_SEQS}"
     healthcheck:
       test: ["CMD", "python3", "-c",
              "import urllib.request; urllib.request.urlopen('http://localhost:{VLLM_PORT}/health')"]

--- a/infra/dgx/converge/verify.py
+++ b/infra/dgx/converge/verify.py
@@ -159,3 +159,22 @@ server.shell(
         "curl -fsS --max-time 10 http://127.0.0.1:8003/v1/models >/dev/null",
     ],
 )
+
+server.shell(
+    name="assert: vllm-autoresearch serves the model its compose declares",
+    commands=[
+        # Extract the served model id from the live /v1/models endpoint
+        # and the model id declared in the compose, then assert they
+        # match. Catches drift if vLLM started against a different model
+        # than the compose was written for (e.g., an interrupted swap).
+        "served=$(curl -fsS --max-time 10 http://127.0.0.1:8003/v1/models "
+        '| python3 -c \'import json,sys; print(json.load(sys.stdin)["data"][0]["id"])\') && '
+        # Compose declares the model on the line right after ``- serve``;
+        # the value is the next ``- <model>`` entry. awk picks the line
+        # that comes one after ``- serve`` and strips list/quote chrome.
+        "declared=$(awk '/^      - serve$/{getline; gsub(/^[[:space:]-]+/,\"\"); print; exit}' "
+        "/opt/vllm-autoresearch/docker-compose.yml) && "
+        'test "$served" = "$declared" '
+        '|| { echo "drift: vLLM serves $served but compose declares $declared"; exit 1; }',
+    ],
+)

--- a/infra/dgx/converge/verify.py
+++ b/infra/dgx/converge/verify.py
@@ -116,3 +116,25 @@ server.shell(
         "curl -fsS --max-time 10 http://127.0.0.1:8001/v1/models >/dev/null",
     ],
 )
+
+# 8. openai-whisper service (#953) — parallel to speaches on :8002.
+# First-party OpenAI Whisper inference code. Runs alongside the
+# faster-whisper container until #952 picks the winner.
+server.shell(
+    name="assert: whisper-openai container is up",
+    commands=[
+        "docker ps --filter name=^whisper-openai$ --filter status=running --format '{{.Names}}' "
+        "| grep -q '^whisper-openai$'",
+    ],
+)
+
+server.shell(
+    name="assert: whisper-openai API responsive on :8002",
+    commands=[
+        # First boot can take 2-5 minutes — the ~3GB large-v3 model downloads
+        # on first startup. Subsequent restarts are quick (cache persists at
+        # /opt/llm-models/whisper-cache).
+        "curl -fsS --max-time 300 http://127.0.0.1:8002/health >/dev/null",
+        "curl -fsS --max-time 10 http://127.0.0.1:8002/v1/models >/dev/null",
+    ],
+)

--- a/infra/dgx/converge/verify.py
+++ b/infra/dgx/converge/verify.py
@@ -138,3 +138,24 @@ server.shell(
         "curl -fsS --max-time 10 http://127.0.0.1:8002/v1/models >/dev/null",
     ],
 )
+
+# 9. vllm-autoresearch service (#928) — NVIDIA-prebuilt vLLM serving an
+# open-weight LLM on :8003 for autoresearch summary/GI/KG scoring.
+server.shell(
+    name="assert: vllm-autoresearch container is up",
+    commands=[
+        "docker ps --filter name=^vllm-autoresearch$ --filter status=running --format '{{.Names}}' "
+        "| grep -q '^vllm-autoresearch$'",
+    ],
+)
+
+server.shell(
+    name="assert: vllm-autoresearch API responsive on :8003",
+    commands=[
+        # vLLM model load on cold cache + large model can take 5-15 min,
+        # which is why the compose's healthcheck has a 600s start_period.
+        # We give verify the same patience — a fresh DGX boot can hit it.
+        "curl -fsS --max-time 900 http://127.0.0.1:8003/health >/dev/null",
+        "curl -fsS --max-time 10 http://127.0.0.1:8003/v1/models >/dev/null",
+    ],
+)

--- a/infra/dgx/vllm-autoresearch/README.md
+++ b/infra/dgx/vllm-autoresearch/README.md
@@ -1,0 +1,142 @@
+# DGX vllm-autoresearch — vLLM serving for autoresearch evaluations (#928)
+
+vLLM service running NVIDIA's pre-built container on the DGX GB10, exposing
+an OpenAI-compatible API for autoresearch evals. Listens on port **8003**.
+
+| Verb | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/health` | Liveness — 200 once vLLM has loaded the model |
+| `GET` | `/v1/models` | OpenAI-style model listing |
+| `POST` | `/v1/chat/completions` | OpenAI-style chat (used by autoresearch summary/GI/KG scoring) |
+| `POST` | `/v1/completions` | OpenAI-style completion |
+
+## Why this exists
+
+`cloud_balanced` + `cloud_thin` profiles currently route summary + GI + KG
+to `gemini-2.5-flash-lite`. `cloud_with_dgx_*` profiles route to Ollama
+(per the #932 finale). vLLM is the **third local-serving option** — same
+DGX hardware as Ollama but a different serving framework.
+
+The #928 championship asks: across all three LLM stages (summary, GI,
+KG), does a vLLM-served open-weight model produce production-quality
+results, and how does it compare on quality + latency + reliability to:
+
+- The current cloud incumbent (`gemini-2.5-flash-lite`)
+- The current local champion (`qwen3.5:35b` on Ollama)
+- Each other (model architecture variations on vLLM)
+
+This service is the vLLM endpoint that autoresearch eval scripts hit.
+It coexists with the Ollama daemon (port 11434) and the whisper services
+(8000 = faster-whisper, 8002 = openai-whisper) on different ports.
+
+## Why no Dockerfile
+
+Unlike `pyannote-server` and `whisper-server` which wrap a Python
+library in our own FastAPI app, **vLLM ships its own OpenAI-compatible
+server**. We just deploy NVIDIA's pre-built `nvcr.io/nvidia/vllm:25.11-py3`
+image directly. The compose passes the model id + serving args to the
+in-image `vllm serve` entrypoint.
+
+This mirrors how the operator's other vLLM containers
+(`~/docker-compose/vllm-Qwen3-Coder-Next/`, `~/docker-compose/vllm-openwebui/`)
+work — the well-trodden NVIDIA-recommended pattern for vLLM on GB10.
+
+## Default model + how to switch
+
+The `deploy.py` recipe ships a compose configured for
+**`Qwen/Qwen3-Coder-Next-FP8`** by default — the model already cached on
+the operator's DGX HF cache from prior agentic-coding work (~30B params
+in FP8, fits in GB10 at `gpu-memory-utilization=0.92`).
+
+This is **NOT** the final autoresearch panel. Qwen3-Coder-Next is code-
+tuned and may be a poor fit for prose summarization. The first autoresearch
+sweep is partly to find out — see #928 panel design — and partly to
+validate the vLLM serving path works for our shape of request.
+
+To swap in a different model:
+
+1. Edit `VLLM_MODEL` near the top of `infra/dgx/converge/deploy.py`.
+2. If the model isn't already cached on the DGX, ensure HF_TOKEN is set
+   in `/home/markodragoljevic/.env` and let vLLM download on first boot
+   (~30 GB for a typical 30B FP8; slower for FP16/BF16 variants).
+3. Adjust `--max-model-len` and `--gpu-memory-utilization` to the model's
+   actual size and the GB10's 128 GB unified memory budget. The operator's
+   working composes give the calibration: a 30B FP8 model wants
+   `gpu-memory-utilization=0.92` with `max-model-len=131072`; a 7B model
+   wants `~0.60` with `max-model-len=8192`.
+4. Re-run `make dgx-deploy`. Docker compose recreates the container only
+   when the compose YAML changes; the model load on first boot will be
+   slow (~5-15 min for cold cache, ~2-5 min when cached).
+
+## Configuration
+
+Environment variables (defaults match deploy.py compose):
+
+- `HF_HOME` (`/root/.cache/huggingface` inside container, mounted from
+  `/opt/llm-models/huggingface` outside) — shared with all other DGX
+  services so weights aren't duplicated.
+- `VLLM_DISABLE_TORCH_COMPILE=1` — disables vLLM's torch.compile path.
+  Per the operator's working composes, this is the GB10 hot fix:
+  torch.compile has historically been the sore spot for the
+  Blackwell-PTX-vs-CUDA-runtime versioning issue. Disabling it loses a
+  ~10-20% steady-state throughput optimization but is the reliable
+  start path.
+- `NVIDIA_VISIBLE_DEVICES=all` — passes all GPUs (single GB10 today).
+
+vLLM serve args (in the compose `command:` block):
+
+- `--host 0.0.0.0` + `--port 8003` — bind to all interfaces (host
+  networking). Tailnet ACL gates real external access.
+- `--dtype bfloat16` — Blackwell-native.
+- `--gpu-memory-utilization 0.92` — high because Qwen3-Coder-Next is
+  large. Adjust per model.
+- `--max-model-len 131072` — Qwen3's full context. Smaller for smaller
+  models.
+- `--enable-auto-tool-choice --tool-call-parser qwen3_coder` — only
+  relevant for tool-using deployments (the operator's coding flow).
+  Autoresearch chat completions don't use these; harmless to leave on.
+
+## Validating
+
+After `make dgx-deploy`:
+
+```bash
+# 1. Health — only 200 after model is fully loaded (5-15 min on cold cache)
+curl -s http://dgx-llm-1.tail6d0ed4.ts.net:8003/health
+# Expected: empty body, HTTP 200
+
+# 2. Models endpoint
+curl -s http://dgx-llm-1.tail6d0ed4.ts.net:8003/v1/models | jq
+# Expected: data list including the configured model id
+
+# 3. End-to-end chat completion smoke
+curl -s http://dgx-llm-1.tail6d0ed4.ts.net:8003/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "Qwen/Qwen3-Coder-Next-FP8", "messages": [{"role":"user","content":"Reply with the single word OK"}], "max_tokens": 8}'
+# Expected: choices[0].message.content == "OK" (or close)
+```
+
+## Operational notes
+
+- **Coexists with other DGX services**: port 8003 is non-conflicting
+  (8000=speaches, 8001=pyannote, 8002=openai-whisper, 11434=ollama).
+- **GPU memory budget**: at `gpu-memory-utilization=0.92`, vLLM
+  reserves ~118 GB of the GB10's 128 GB unified memory. **Don't run
+  vLLM concurrently with heavy Ollama models** — there isn't enough
+  headroom. For autoresearch sweeps, stop Ollama (or scope to small
+  models) when running vLLM; or use the operator's coding compose with
+  `gpu-memory-utilization=0.60` for ~76 GB instead.
+- **First request is slow**: vLLM warms its CUDA graphs on the first
+  call (~5-30 s of one-time setup). Subsequent calls are fast.
+- **Healthcheck patience**: the compose's healthcheck allows 10 min for
+  model load (30 retries × 30s). Cold cache + large model can hit that.
+
+## References
+
+- This issue: #928 (summary/GI/KG championship)
+- Operator's reference composes: `~/docker-compose/vllm-Qwen3-Coder-Next/`
+  and `~/docker-compose/vllm-openwebui/` on the DGX
+- Sibling DGX services: `infra/dgx/pyannote-server/` (#926),
+  `infra/dgx/whisper-server/` (#953), `infra/dgx/speaches-gb10/` (#948)
+- Finale framework reused for scoring: `src/podcast_scraper/evaluation/finale_runner.py`
+  plus `g_eval.py` and judges (from #949)

--- a/infra/dgx/vllm-autoresearch/README.md
+++ b/infra/dgx/vllm-autoresearch/README.md
@@ -33,7 +33,7 @@ It coexists with the Ollama daemon (port 11434) and the whisper services
 
 Unlike `pyannote-server` and `whisper-server` which wrap a Python
 library in our own FastAPI app, **vLLM ships its own OpenAI-compatible
-server**. We just deploy NVIDIA's pre-built `nvcr.io/nvidia/vllm:25.11-py3`
+server**. We just deploy NVIDIA's pre-built `nvcr.io/nvidia/vllm:*-py3`
 image directly. The compose passes the model id + serving args to the
 in-image `vllm serve` entrypoint.
 
@@ -41,32 +41,65 @@ This mirrors how the operator's other vLLM containers
 (`~/docker-compose/vllm-Qwen3-Coder-Next/`, `~/docker-compose/vllm-openwebui/`)
 work — the well-trodden NVIDIA-recommended pattern for vLLM on GB10.
 
-## Default model + how to switch
+## Default image + model (post-#928 Cell C)
 
-The `deploy.py` recipe ships a compose configured for
-**`Qwen/Qwen3-Coder-Next-FP8`** by default — the model already cached on
-the operator's DGX HF cache from prior agentic-coding work (~30B params
-in FP8, fits in GB10 at `gpu-memory-utilization=0.92`).
+Defaults shipped by `deploy.py`:
 
-This is **NOT** the final autoresearch panel. Qwen3-Coder-Next is code-
-tuned and may be a poor fit for prose summarization. The first autoresearch
-sweep is partly to find out — see #928 panel design — and partly to
-validate the vLLM serving path works for our shape of request.
+- **Image**: `nvcr.io/nvidia/vllm:26.05-py3`
+- **Model**: `Qwen/Qwen3.6-35B-A3B` (bf16, ~67 GB on disk)
+- **GPU memory utilization**: 0.60 (coexists with whisper / pyannote)
+- **Max model len**: 32768
+- **Max num seqs**: 128 (Mamba-cache-block limit specific to qwen3_5_moe)
 
-To swap in a different model:
+**Why these specifics — important constraints discovered during #928 Cell C**:
 
-1. Edit `VLLM_MODEL` near the top of `infra/dgx/converge/deploy.py`.
+- `qwen3_5_moe` architecture requires transformers 5.x. NVIDIA's vLLM
+  images 25.11–26.04 all ship transformers 4.57.x and reject the model.
+  Only 26.05-py3 (vLLM 0.20.1 / transformers 5.6.0) supports it and
+  boots cleanly on this operator's GB10. The post-release hotfix
+  `26.05.post1-py3` was verified broken on this DGX — do not use.
+- Qwen3.6-35B-A3B uses Mamba layers; vLLM 0.20 enforces
+  `max_num_seqs ≤ Mamba cache blocks`. The default 256 fails CUDA-graph
+  capture (only 190 cache blocks available at `gpu_memory_utilization=0.60`).
+  128 is well under the limit with headroom.
+- **Consumer contract**: the model emits a "thinking process" reasoning
+  preamble by default (same pattern as DeepSeek R1-Distill). Production
+  consumers MUST pass `chat_template_kwargs={"enable_thinking": False}`
+  in the chat completions request to suppress it. The
+  `summary_vllm_predict_v1.py` harness has a `--disable-thinking` flag
+  that does exactly this — copy that pattern for any new caller.
+
+### To swap to a different model
+
+1. Edit `VLLM_MODEL` (and possibly `VLLM_IMAGE`, `VLLM_GPU_MEM_UTIL`,
+   `VLLM_MAX_NUM_SEQS`) near the top of `infra/dgx/converge/deploy.py`.
 2. If the model isn't already cached on the DGX, ensure HF_TOKEN is set
    in `/home/markodragoljevic/.env` and let vLLM download on first boot
-   (~30 GB for a typical 30B FP8; slower for FP16/BF16 variants).
-3. Adjust `--max-model-len` and `--gpu-memory-utilization` to the model's
-   actual size and the GB10's 128 GB unified memory budget. The operator's
-   working composes give the calibration: a 30B FP8 model wants
-   `gpu-memory-utilization=0.92` with `max-model-len=131072`; a 7B model
-   wants `~0.60` with `max-model-len=8192`.
+   (~67 GB for Qwen3.6-35B-A3B; slower for FP16/BF16 variants).
+3. Adjust `--max-model-len` to the model's actual context budget and
+   `--gpu-memory-utilization` to the GB10's 128 GB unified memory budget
+   minus other services. The operator's reference composes give the
+   calibration: a 30B FP8 model wants `0.92` with 131072; a 35B bf16 MoE
+   model wants `0.60` with 32768.
 4. Re-run `make dgx-deploy`. Docker compose recreates the container only
    when the compose YAML changes; the model load on first boot will be
    slow (~5-15 min for cold cache, ~2-5 min when cached).
+
+### To revert to R1-Distill on the older image
+
+The R1-Distill-32B alternative remains in `/opt/llm-models/huggingface/`
+on the DGX:
+
+1. Set `VLLM_IMAGE = "nvcr.io/nvidia/vllm:25.11-py3"`
+2. Set `VLLM_MODEL = "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"`
+3. Remove the `--max-num-seqs` block from the compose `command` list
+   (R1-Distill isn't Mamba-based; the constraint doesn't apply).
+4. Re-run `make dgx-deploy`.
+
+Or for an ad-hoc revert without touching the committed defaults, on the
+DGX directly: `sudo cp /opt/vllm-autoresearch/docker-compose.yml.r1-distill.bak
+/opt/vllm-autoresearch/docker-compose.yml` then
+`sudo docker compose -f /opt/vllm-autoresearch/docker-compose.yml up -d`.
 
 ## Configuration
 
@@ -88,13 +121,13 @@ vLLM serve args (in the compose `command:` block):
 - `--host 0.0.0.0` + `--port 8003` — bind to all interfaces (host
   networking). Tailnet ACL gates real external access.
 - `--dtype bfloat16` — Blackwell-native.
-- `--gpu-memory-utilization 0.92` — high because Qwen3-Coder-Next is
-  large. Adjust per model.
-- `--max-model-len 131072` — Qwen3's full context. Smaller for smaller
-  models.
-- `--enable-auto-tool-choice --tool-call-parser qwen3_coder` — only
-  relevant for tool-using deployments (the operator's coding flow).
-  Autoresearch chat completions don't use these; harmless to leave on.
+- `--gpu-memory-utilization 0.60` — leaves headroom for whisper /
+  pyannote / Ollama. Bump higher only if those are stopped.
+- `--max-model-len 32768` — enough for podcast transcripts; smaller
+  than Qwen3.6's native max but fits the GPU memory budget at 0.60.
+- `--max-num-seqs 128` — Mamba-cache-block limit. Required for
+  Qwen3.5/3.6 family at gpu_mem_util=0.60. Drop if you switch to a
+  non-Mamba model.
 
 ## Validating
 
@@ -109,23 +142,25 @@ curl -s http://dgx-llm-1.tail6d0ed4.ts.net:8003/health
 curl -s http://dgx-llm-1.tail6d0ed4.ts.net:8003/v1/models | jq
 # Expected: data list including the configured model id
 
-# 3. End-to-end chat completion smoke
+# 3. End-to-end chat completion smoke (with enable_thinking=False)
 curl -s http://dgx-llm-1.tail6d0ed4.ts.net:8003/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model": "Qwen/Qwen3-Coder-Next-FP8", "messages": [{"role":"user","content":"Reply with the single word OK"}], "max_tokens": 8}'
+  -d '{"model": "Qwen/Qwen3.6-35B-A3B", "messages": [{"role":"user","content":"Reply with the single word OK"}], "max_tokens": 8, "chat_template_kwargs": {"enable_thinking": false}}'
 # Expected: choices[0].message.content == "OK" (or close)
+# Without chat_template_kwargs, Qwen3.6 emits a "thinking process" preamble
+# instead of the answer — see Default model section above.
 ```
 
 ## Operational notes
 
 - **Coexists with other DGX services**: port 8003 is non-conflicting
   (8000=speaches, 8001=pyannote, 8002=openai-whisper, 11434=ollama).
-- **GPU memory budget**: at `gpu-memory-utilization=0.92`, vLLM
-  reserves ~118 GB of the GB10's 128 GB unified memory. **Don't run
-  vLLM concurrently with heavy Ollama models** — there isn't enough
-  headroom. For autoresearch sweeps, stop Ollama (or scope to small
-  models) when running vLLM; or use the operator's coding compose with
-  `gpu-memory-utilization=0.60` for ~76 GB instead.
+- **GPU memory budget**: at `gpu-memory-utilization=0.60`, vLLM
+  reserves ~73 GB of the GB10's 128 GB unified memory. That coexists
+  with whisper-openai (~3 GB), pyannote (~3-4 GB), faster-whisper
+  (~3-4 GB), and an Ollama-loaded model (~10 GB). Concurrent heavy
+  use of all four is borderline — for autoresearch sweeps focused on
+  one stage (e.g., transcription), stop the others.
 - **First request is slow**: vLLM warms its CUDA graphs on the first
   call (~5-30 s of one-time setup). Subsequent calls are fast.
 - **Healthcheck patience**: the compose's healthcheck allows 10 min for

--- a/infra/dgx/whisper-server/Dockerfile
+++ b/infra/dgx/whisper-server/Dockerfile
@@ -1,0 +1,62 @@
+# DGX-hosted OpenAI Whisper transcription service (#952 prerequisite).
+#
+# Built from NVIDIA's PyTorch image so CUDA + cuDNN are already present at
+# versions matching the GB10 stack. The openai-whisper library wraps these
+# without us having to pin torch ourselves — same base image as
+# pyannote-server, same versioning concerns.
+#
+# Build:    docker build -t podcast-whisper:0.1.0 infra/dgx/whisper-server/
+# Run:      docker run --rm --gpus all -p 8002:8002 \
+#               -v /opt/llm-models/whisper-cache:/root/.cache/whisper \
+#               podcast-whisper:0.1.0
+#
+# In prod we ship via the compose file dropped by pyinfra deploy.py at
+# /opt/whisper-server/docker-compose.yml.
+
+FROM nvcr.io/nvidia/pytorch:25.04-py3
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+# ffmpeg is required by openai-whisper to decode audio files (mp3, m4a, etc.).
+# The NGC base image doesn't ship it. libsndfile1 is a runtime dep for
+# soundfile, which openai-whisper uses indirectly via numba audio loaders.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# openai-whisper installs with --no-deps because its setup.py declares a
+# strict torch version range that conflicts with NVIDIA's NGC dev-build
+# torch (``2.7.0a0+79aa17489c.nv25.4`` doesn't satisfy ``torch>=2.0,<2.8``
+# even though the ABI is compatible — same logic as pyannote-server's
+# torchaudio dance). We install openai-whisper's runtime deps explicitly
+# below; the NGC base already has torch + numpy at compatible versions.
+#
+# Deps openai-whisper actually uses at runtime (from its source code):
+#   - torch              (already in NGC base)
+#   - numpy              (already in NGC base)
+#   - numba              (jit compile + audio loading)
+#   - tqdm               (progress bars; we won't see them but the lib uses them)
+#   - more-itertools     (small utility)
+#   - tiktoken           (BPE tokenizer for Whisper)
+#   - triton             (GPU kernels; included via torch)
+RUN pip install \
+        "fastapi>=0.115,<1.0" \
+        "uvicorn[standard]>=0.30,<1.0" \
+        "python-multipart>=0.0.9" \
+        "numba>=0.59" \
+        "tqdm>=4.66" \
+        "more-itertools>=10.0" \
+        "tiktoken>=0.5" \
+ && pip install --no-deps "openai-whisper>=20231117"
+
+COPY app.py /app/app.py
+
+EXPOSE 8002
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/infra/dgx/whisper-server/README.md
+++ b/infra/dgx/whisper-server/README.md
@@ -1,0 +1,119 @@
+# DGX whisper-server — openai-whisper as a service (#953)
+
+FastAPI wrapper around `openai-whisper` (OpenAI's first-party Python lib)
+running on the DGX GB10 GPU. Exposes an OpenAI-compatible HTTP API:
+
+| Verb | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/v1/audio/transcriptions` | Multipart audio file → JSON `{"text": "..."}` |
+| `GET` | `/health` | Liveness — 200 once the model is loaded |
+| `GET` | `/v1/models` | OpenAI-style envelope |
+
+## Why this exists (the short version)
+
+The DGX has two whisper services running side-by-side on different ports:
+
+| Port | Stack | Code provenance |
+| --- | --- | --- |
+| 8000 | `speaches` → `faster-whisper` → `ctranslate2` | Community implementations of OpenAI's MODEL |
+| **8002 (this)** | **`openai-whisper`** | **OpenAI's own first-party library** |
+
+The split exists because — surfaced by #948 — the speaches-bundled
+ctranslate2 is NOT OpenAI's inference code, just a fast reimplementation
+that loads the same model weights. Until issue #952 validates that
+faster-whisper matches openai-whisper's WER on real podcasts, we want a
+first-party path available. This service is that path.
+
+Consumers point at whichever URL matches the trust/speed tradeoff they
+want. After #952's verdict, one service becomes the default and the
+other gets removed.
+
+## Why not just use the cloud OpenAI Whisper API?
+
+- Cost: $0.006/min audio. At 100 episodes × 90 min/month = $54/month —
+  cheap but non-zero. This service is $0 marginal (we already own the
+  DGX).
+- Privacy: audio stays on the tailnet rather than going to OpenAI.
+- We get to validate the speed tradeoff vs the cloud API as part of #929.
+
+## Configuration
+
+Environment variables (defaults match the deploy.py compose):
+
+- `WHISPER_MODEL` (default: `large-v3`) — any model openai-whisper supports
+  (`tiny.en`, `base.en`, `small.en`, `medium.en`, `large-v2`, `large-v3`).
+- `WHISPER_DEVICE` (default: `cuda`) — set to `cpu` for testing without GPU.
+- `WHISPER_CACHE_DIR` (default: `/root/.cache/whisper`) — model download
+  cache. Mounted from `/opt/llm-models/whisper-cache` on the DGX so the
+  ~3 GB `large-v3` weights persist across container restarts.
+- `UVICORN_HOST` (default: `0.0.0.0`)
+- `UVICORN_PORT` (default: `8002`)
+- `LOG_LEVEL` (default: `INFO`)
+
+## Deploy
+
+The `Dockerfile` here is what the pyinfra recipe builds and runs. The
+service install (compose file + env injection + restart policy) lives
+in `infra/dgx/converge/deploy.py`. Don't run this Dockerfile by hand in
+prod.
+
+For local development:
+
+```bash
+docker build -t podcast-whisper:dev infra/dgx/whisper-server/
+docker run --rm --gpus all \
+    -p 8002:8002 \
+    -e WHISPER_MODEL=small.en \
+    podcast-whisper:dev
+```
+
+## Validating the service
+
+After `make dgx-deploy`:
+
+```bash
+# 1. Health check — service is up + model loaded
+curl -s http://dgx-llm-1.tail6d0ed4.ts.net:8002/health
+# Expected: {"status":"ok","model":"large-v3","device":"cuda"}
+
+# 2. Transcribe a real audio file
+curl -s -X POST http://dgx-llm-1.tail6d0ed4.ts.net:8002/v1/audio/transcriptions \
+    -F "file=@some_episode.mp3" \
+    -F "model=large-v3" \
+    -F "response_format=json"
+# Expected: {"text": "Hello and welcome..."}
+
+# 3. End-to-end pipeline using this service (sets the URL the provider talks to)
+WHISPER_DGX_URL=http://dgx-llm-1.tail6d0ed4.ts.net:8002/v1/audio/transcriptions \
+    python -m podcast_scraper.cli --config config/profiles/cloud_with_dgx_balanced.yaml \
+    --rss <feed_url> --output-dir /tmp/test-output
+```
+
+## Operational notes
+
+- **First request after deploy is slow** — the `large-v3` model is ~3 GB
+  and downloads on first startup. The HF cache mount means subsequent
+  container restarts skip this.
+- **Single-threaded by design** — openai-whisper's `model.transcribe()`
+  holds the GIL and the CUDA context for the duration of a call.
+  Concurrent requests serialize via the model lock; use the consumer-side
+  single-flight pattern in `TailnetDgxWhisperTranscriptionProvider`
+  (#946) when more than one client may call at once.
+- **Expected throughput on GB10 with `large-v3`**:
+  - 5-min podcast: ~10-20 s wall-time
+  - 30-min podcast: ~60-120 s
+  - 90-min podcast: ~3-7 min
+  - These are ~2-4× faster than the same model on CPU and ~3-5× SLOWER
+    than the cloud OpenAI Whisper API (which uses heavy internal
+    batching we don't replicate here).
+  - These are also ~2-4× SLOWER than `speaches` (faster-whisper) on
+    port 8000 — that's the speed tradeoff for first-party code.
+
+## References
+
+- This issue: #953
+- The "is faster-whisper actually equivalent?" validation: #952
+- speaches/faster-whisper service: `infra/dgx/converge/deploy.py`
+  plus `infra/dgx/speaches-gb10/`
+- Consumer-side resilience: #946 (`src/podcast_scraper/providers/tailnet_dgx/whisper_provider.py`)
+- Sibling DGX services: `infra/dgx/pyannote-server/` (#926)

--- a/infra/dgx/whisper-server/app.py
+++ b/infra/dgx/whisper-server/app.py
@@ -135,7 +135,23 @@ async def transcribe(
         description="One of: json, text. ``verbose_json`` returns segments + words.",
     ),
     language: Optional[str] = Form(None, description="ISO language code; auto-detect if omitted."),
-    temperature: float = Form(0.0, ge=0.0, le=1.0),
+    temperature: Optional[float] = Form(
+        None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Single-value sampling temperature. **OMIT for podcast-length audio.** "
+            "Setting a scalar (incl. 0.0) DISABLES openai-whisper's built-in "
+            "temperature fallback schedule (0.0 → 1.0). The fallback is what "
+            "detects autoregressive runaway via compression_ratio + logprob "
+            "thresholds and re-runs the failing segment at a higher temperature. "
+            "Without the schedule, long audio reliably hits decoder loops "
+            "(verified empirically: a 5-min v2 episode produces 5× extra hyp "
+            "words with temperature=0.0 vs the default schedule). Pass a "
+            "scalar only when the caller specifically wants deterministic decode "
+            "and accepts the runaway risk."
+        ),
+    ),
 ) -> Any:
     """Transcribe the uploaded audio file using openai-whisper."""
     if _MODEL is None:
@@ -151,14 +167,18 @@ async def transcribe(
         tmp_path = tmp.name
         tmp.write(await file.read())
 
+    # fp16=True is required for CUDA path; fp16=False on CPU. We're
+    # GPU-only here so True is correct. If the operator runs this
+    # on CPU for testing, openai-whisper will warn and fall back.
+    use_fp16 = _DEVICE == "cuda"
     try:
-        transcribe_kwargs: dict[str, Any] = {
-            "temperature": temperature,
-            # fp16=True is required for CUDA path; fp16=False on CPU. We're
-            # GPU-only here so True is correct. If the operator runs this
-            # on CPU for testing, openai-whisper will warn and fall back.
-            "fp16": _DEVICE == "cuda",
-        }
+        transcribe_kwargs: dict[str, Any] = {"fp16": use_fp16}
+        # Only set temperature when the caller explicitly asked for one;
+        # otherwise let openai-whisper apply its default fallback schedule
+        # (0.0, 0.2, 0.4, 0.6, 0.8, 1.0) which is what saves long-audio
+        # transcription from autoregressive runaway. See Form() docstring.
+        if temperature is not None:
+            transcribe_kwargs["temperature"] = temperature
         if language is not None:
             transcribe_kwargs["language"] = language
 

--- a/infra/dgx/whisper-server/app.py
+++ b/infra/dgx/whisper-server/app.py
@@ -1,0 +1,190 @@
+"""DGX-hosted OpenAI Whisper transcription service (#952 prerequisite).
+
+FastAPI wrapper around ``openai-whisper`` (OpenAI's first-party Python lib,
+``pip install openai-whisper``) that runs Whisper on the DGX GPU and exposes
+the OpenAI-compatible HTTP API:
+
+    POST /v1/audio/transcriptions  — multipart audio → JSON {"text": "..."}
+    GET  /health                   — 200 when model is loaded
+    GET  /v1/models                — OpenAI-style envelope
+
+Why this service exists (vs the existing speaches/faster-whisper service
+on port 8000):
+
+The speaches container ships ``faster-whisper`` via ``ctranslate2`` —
+community reimplementations that load OpenAI's MODEL but run inference
+through different code. Until issue #952 validates that
+faster-whisper's WER matches openai-whisper on real podcast content,
+we want a first-party path available. This service is that path. It
+runs alongside speaches (different port) so consumers can pick the
+trust/speed tradeoff:
+
+    - port 8000 (speaches/faster-whisper) — fast, community-implemented
+    - port 8002 (this service / openai-whisper) — slower, OpenAI's own code
+
+When #952 lands its verdict, one of the two services becomes the new
+default and the other gets removed.
+
+Configuration (env vars; defaults match the deploy.py compose):
+
+    WHISPER_MODEL    (default: ``large-v3``)
+    WHISPER_DEVICE   (default: ``cuda``)
+    UVICORN_HOST     (default: ``0.0.0.0``)
+    UVICORN_PORT     (default: ``8002``)
+    LOG_LEVEL        (default: ``INFO``)
+
+The model is loaded ONCE at startup. First request waits for warm-up;
+all subsequent requests reuse the cached model.
+
+Run locally for testing:
+
+    uvicorn app:app --host 0.0.0.0 --port 8002
+
+Run via Docker (production path):
+
+    docker compose up -d   # see /opt/whisper-server/docker-compose.yml
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Optional
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+
+logger = logging.getLogger("whisper-server")
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+
+
+_MODEL: Any = None
+_MODEL_NAME = os.environ.get("WHISPER_MODEL", "large-v3")
+_DEVICE = os.environ.get("WHISPER_DEVICE", "cuda")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Load the openai-whisper model once at startup."""
+    global _MODEL
+
+    logger.info("Loading openai-whisper model %s on %s", _MODEL_NAME, _DEVICE)
+
+    # openai-whisper handles download + cache. The HF_HOME bind mount means
+    # the model is shared with the speaches cache (no double download).
+    import whisper
+
+    cache_dir = os.environ.get("WHISPER_CACHE_DIR", "/root/.cache/whisper")
+    _MODEL = whisper.load_model(_MODEL_NAME, device=_DEVICE, download_root=cache_dir)
+    logger.info("openai-whisper %s loaded on %s; service ready", _MODEL_NAME, _DEVICE)
+
+    yield
+
+    logger.info("whisper-server shutting down")
+
+
+app = FastAPI(
+    title="DGX openai-whisper transcription service (parallel to speaches)",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Liveness — returns 200 once the model is loaded."""
+    if _MODEL is None:
+        raise HTTPException(503, "whisper model not yet loaded")
+    return {"status": "ok", "model": _MODEL_NAME, "device": _DEVICE}
+
+
+@app.get("/v1/models")
+def list_models() -> dict[str, Any]:
+    """OpenAI-style envelope so the existing health-check helper pattern works."""
+    if _MODEL is None:
+        raise HTTPException(503, "whisper model not yet loaded")
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": _MODEL_NAME,
+                "object": "model",
+                "owned_by": "openai",
+            }
+        ],
+    }
+
+
+@app.post("/v1/audio/transcriptions")
+async def transcribe(
+    file: UploadFile = File(..., description="Audio file (wav / mp3 / flac / m4a)"),
+    model: Optional[str] = Form(
+        None,
+        description=(
+            "Ignored — this server is pinned to the model named at startup "
+            "via WHISPER_MODEL. The OpenAI cloud API requires the param so "
+            "the field is accepted for client compatibility."
+        ),
+    ),
+    response_format: str = Form(
+        "json",
+        description="One of: json, text. ``verbose_json`` returns segments + words.",
+    ),
+    language: Optional[str] = Form(None, description="ISO language code; auto-detect if omitted."),
+    temperature: float = Form(0.0, ge=0.0, le=1.0),
+) -> Any:
+    """Transcribe the uploaded audio file using openai-whisper."""
+    if _MODEL is None:
+        raise HTTPException(503, "whisper model not yet loaded")
+    if response_format not in {"json", "text", "verbose_json"}:
+        raise HTTPException(
+            400,
+            f"response_format must be one of json / text / verbose_json, got {response_format!r}",
+        )
+
+    suffix = os.path.splitext(file.filename or "")[1] or ".wav"
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp_path = tmp.name
+        tmp.write(await file.read())
+
+    try:
+        transcribe_kwargs: dict[str, Any] = {
+            "temperature": temperature,
+            # fp16=True is required for CUDA path; fp16=False on CPU. We're
+            # GPU-only here so True is correct. If the operator runs this
+            # on CPU for testing, openai-whisper will warn and fall back.
+            "fp16": _DEVICE == "cuda",
+        }
+        if language is not None:
+            transcribe_kwargs["language"] = language
+
+        result = _MODEL.transcribe(tmp_path, **transcribe_kwargs)
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+    text = result.get("text", "").strip()
+
+    if response_format == "text":
+        from fastapi.responses import PlainTextResponse
+
+        return PlainTextResponse(text)
+    if response_format == "verbose_json":
+        # OpenAI's verbose_json shape: text + segments[].{start, end, text, ...}
+        # openai-whisper's result["segments"] is already very close — just
+        # rename `text` and pass through start/end + word_timestamps if any.
+        return {
+            "task": "transcribe",
+            "language": result.get("language", language or "en"),
+            "duration": result.get("duration"),
+            "text": text,
+            "segments": result.get("segments", []),
+        }
+    # Default: OpenAI-style json envelope
+    return {"text": text}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,6 +244,7 @@ exclude = [
     "^\\.venv/.*",  # Local venv (make type uses ``mypy .``)
     "^\\.venv-dev/.*",  # CI-parity venv (see Makefile VENVDEV)
     "^autoresearch/.*",  # Standalone autoresearch scripts (not part of src package)
+    "^infra/dgx/.*-server/app\\.py$",  # Docker-image app.py files (pyannote-server, whisper-server) — both named "app", not part of src package
 ]
 
 [[tool.mypy.overrides]]

--- a/scripts/eval/score/diarization_dgx_vs_cloud_v1.py
+++ b/scripts/eval/score/diarization_dgx_vs_cloud_v1.py
@@ -1,0 +1,272 @@
+"""Diarization championship — pyannote/DGX vs pyannote/local CPU (#930).
+
+Compares two diarization backends on the v2 audio fixtures:
+
+- **pyannote/DGX**: the GPU-hosted FastAPI wrapper on the DGX (#926).
+  Talked to via ``http://<dgx-host>:8001/v1/diarize``.
+- **pyannote/local**: ``PyAnnoteDiarizationProvider`` (PyTorch CPU).
+
+Gemini speech speaker-detection was a third candidate per the #930 issue
+but the codebase doesn't currently have a Gemini speech provider —
+that's wired separately and out of scope for this first cut. See
+follow-up issue for adding it.
+
+## Metrics
+
+Proper Diarization Error Rate (DER) requires time-aligned speaker
+ground truth (start/end timestamps per speaker turn). The v2 transcripts
+have speaker labels per LINE but not per-second timestamps, so we
+report:
+
+- ``num_speakers_detected`` — should be 2 for all v2 episodes (each
+  generated from a 2-voice macOS ``say`` transcript per RFC-059 §2).
+- ``num_segments`` — total speaker turns the diarizer produced.
+- ``ground_truth_turns`` — number of speaker-label changes in the
+  reference transcript (a rough upper bound on the right answer).
+- ``segments_per_turn_ratio`` — coarse measure of over-/under-segmentation.
+- ``elapsed_seconds`` — wall-clock per episode.
+
+Full DER computation is a follow-up that needs time-aligned ground truth
+(generate via the materialized whisper outputs' word-level timestamps,
+or use the macOS-``say`` per-line timing in the v2 generator).
+
+## Usage
+
+    python scripts/eval/score/diarization_dgx_vs_cloud_v1.py \\
+        --backend dgx \\
+        --audio-dir tests/fixtures/audio/v2 \\
+        --transcripts-dir tests/fixtures/transcripts/v2 \\
+        --episodes p01_e01 p02_e01 p03_e01 p04_e01 p05_e01 \\
+        --output data/eval/runs/diarization_dgx_vs_cloud_v1/dgx
+
+    # Local CPU (slower; use a smaller episode set for first pass)
+    python scripts/eval/score/diarization_dgx_vs_cloud_v1.py \\
+        --backend local \\
+        --audio-dir tests/fixtures/audio/v2 \\
+        --transcripts-dir tests/fixtures/transcripts/v2 \\
+        --episodes p01_e01 p02_e01 \\
+        --output data/eval/runs/diarization_dgx_vs_cloud_v1/local
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+# Speaker-label regex tuned for v2 fixture transcripts ("Maya:" / "Liam:" /
+# "Ad:" patterns at the start of dialog lines). Stricter than the more
+# permissive whisper_accent_wer_v1.py pattern because we want clean turn
+# detection here.
+_SPEAKER_LINE_RE = re.compile(r"^([A-Z][A-Za-z .'\-]{0,40}):\s+")
+
+
+def _count_ground_truth_turns(transcript_text: str) -> tuple[int, int]:
+    """Return (num_distinct_speakers, num_turn_changes) from the transcript.
+
+    Lines like ``Maya:`` / ``Liam:`` mark turns. Lines like ``Ad:`` are
+    counted as another speaker (they're separate voices in v2 audio per
+    RFC-059), but they're treated equivalently in turn-change counting.
+    """
+    speakers: list[str] = []
+    for line in transcript_text.splitlines():
+        m = _SPEAKER_LINE_RE.match(line.strip())
+        if not m:
+            continue
+        speakers.append(m.group(1))
+    distinct = sorted(set(speakers))
+    changes = 0
+    for i in range(1, len(speakers)):
+        if speakers[i] != speakers[i - 1]:
+            changes += 1
+    # +1 because the first turn IS a turn even though no "change" preceded it.
+    return len(distinct), changes + 1 if speakers else 0
+
+
+# ---------------------------------------------------------------------------
+# Backend dispatch
+
+
+def _diarize_dgx(audio_path: Path) -> dict[str, Any]:
+    """POST to the DGX pyannote-server /v1/diarize endpoint."""
+    import requests
+
+    url = os.environ.get(
+        "DIARIZE_DGX_URL",
+        "http://dgx-llm-1.tail6d0ed4.ts.net:8001/v1/diarize",
+    )
+    t0 = time.time()
+    with audio_path.open("rb") as fh:
+        # Generous timeout — 90-min podcasts can take ~minutes on a
+        # contended GPU. The diarization-resilience-gap (#954) covers
+        # the production-grade timeout work; here we just want a
+        # measurement, so we accept a long single-call wait.
+        resp = requests.post(
+            url,
+            files={"file": (audio_path.name, fh, "audio/mpeg")},
+            timeout=900,
+        )
+    elapsed = time.time() - t0
+    resp.raise_for_status()
+    payload = resp.json()
+    return {
+        "segments": payload.get("segments", []),
+        "num_speakers": payload.get("num_speakers", 0),
+        "model_name": payload.get("model_name", ""),
+        "elapsed_seconds": elapsed,
+    }
+
+
+def _diarize_local(audio_path: Path) -> dict[str, Any]:
+    """Local in-process pyannote. Device auto-picks: CUDA > MPS > CPU.
+
+    Override with ``LOCAL_DIARIZE_DEVICE`` env var if you need to force a
+    specific device (useful for the #930 honest comparison: setting
+    ``LOCAL_DIARIZE_DEVICE=cpu`` measures pure CPU; the default lets pyannote
+    pick the fastest available — typically MPS on Apple Silicon, which IS GPU
+    acceleration via Metal and not actually a fair "CPU baseline").
+    """
+    from podcast_scraper.providers.ml.diarization.pyannote_provider import (
+        PyAnnoteDiarizationProvider,
+    )
+
+    hf_token = os.environ.get("HF_TOKEN", "").strip()
+    if not hf_token:
+        raise RuntimeError(
+            "HF_TOKEN env var required for local pyannote (model is gated). "
+            "Source ~/.env or infra/.env.dgx.local before running."
+        )
+    device = os.environ.get("LOCAL_DIARIZE_DEVICE", "auto").strip() or "auto"
+    provider = PyAnnoteDiarizationProvider(hf_token=hf_token, device=device)
+    t0 = time.time()
+    result = provider.diarize(str(audio_path))
+    elapsed = time.time() - t0
+    segments = [{"start": s.start, "end": s.end, "speaker": s.speaker} for s in result.segments]
+    return {
+        "segments": segments,
+        "num_speakers": result.num_speakers,
+        "model_name": result.model_name,
+        "elapsed_seconds": elapsed,
+    }
+
+
+_BACKENDS = {
+    "dgx": _diarize_dgx,
+    "local": _diarize_local,
+}
+
+
+# ---------------------------------------------------------------------------
+# Main
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--backend", required=True, choices=sorted(_BACKENDS.keys()))
+    p.add_argument("--audio-dir", type=Path, required=True)
+    p.add_argument("--transcripts-dir", type=Path, required=True)
+    p.add_argument("--episodes", nargs="+", required=True)
+    p.add_argument("--output", type=Path, required=True)
+    args = p.parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict[str, Any]] = []
+
+    for ep in args.episodes:
+        audio_path = args.audio_dir / f"{ep}.mp3"
+        transcript_path = args.transcripts_dir / f"{ep}.txt"
+        if not audio_path.exists() or not transcript_path.exists():
+            print(f"  SKIP {ep}: missing audio or transcript", file=sys.stderr)
+            continue
+        transcript_text = transcript_path.read_text(encoding="utf-8")
+        gt_speakers, gt_turns = _count_ground_truth_turns(transcript_text)
+
+        print(f"  {args.backend:5s} {ep}: diarizing…", file=sys.stderr)
+        try:
+            r = _BACKENDS[args.backend](audio_path)
+            err = ""
+        except Exception as exc:  # noqa: BLE001
+            r = {"segments": [], "num_speakers": 0, "model_name": "", "elapsed_seconds": 0.0}
+            err = str(exc)[:300]
+
+        n_seg = len(r["segments"])
+        ratio = (n_seg / gt_turns) if gt_turns else None
+        row = {
+            "backend": args.backend,
+            "episode_id": ep,
+            "num_speakers_detected": r["num_speakers"],
+            "num_segments": n_seg,
+            "ground_truth_speakers": gt_speakers,
+            "ground_truth_turns": gt_turns,
+            "segments_per_turn_ratio": round(ratio, 2) if ratio is not None else None,
+            "speakers_match": r["num_speakers"] == gt_speakers,
+            "elapsed_seconds": round(r["elapsed_seconds"], 2),
+            "model_name": r["model_name"],
+            "error": err,
+        }
+        rows.append(row)
+        err_tail = f" ERROR={err}" if err else ""
+        ratio_str = f"{ratio:.2f}" if ratio is not None else "n/a"
+        print(
+            f"    {ep}: detected_speakers={r['num_speakers']} "
+            f"(gt={gt_speakers}) seg={n_seg} (gt_turns={gt_turns}, "
+            f"ratio={ratio_str}) elapsed={r['elapsed_seconds']:.1f}s{err_tail}"
+        )
+
+    # Summary
+    completed = [r for r in rows if not r["error"]]
+    pct_speakers_correct = (
+        100.0 * sum(1 for r in completed if r["speakers_match"]) / max(len(completed), 1)
+    )
+    mean_elapsed = sum(r["elapsed_seconds"] for r in completed) / max(len(completed), 1)
+    mean_ratio = sum((r["segments_per_turn_ratio"] or 0.0) for r in completed) / max(
+        len(completed), 1
+    )
+    summary = {
+        "backend": args.backend,
+        "episodes_attempted": len(rows),
+        "episodes_completed": len(completed),
+        "episodes_errored": len(rows) - len(completed),
+        "pct_speakers_correct": round(pct_speakers_correct, 1),
+        "mean_elapsed_seconds": round(mean_elapsed, 2),
+        "mean_segments_per_turn_ratio": round(mean_ratio, 2),
+    }
+    (args.output / "metrics.json").write_text(
+        json.dumps(
+            {
+                "schema": "metrics_diarization_dgx_vs_cloud_v1",
+                "summary": summary,
+                "rows": rows,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    print(
+        f"\n{'backend':<6} {'episodes':>3} {'speakers_pct':>12} "
+        f"{'mean_lat_s':>10} {'mean_ratio':>10}"
+    )
+    print(
+        f"{summary['backend']:<6} "
+        f"{summary['episodes_completed']:>3}/{summary['episodes_attempted']:<2} "
+        f"{summary['pct_speakers_correct']:>11.1f}% "
+        f"{summary['mean_elapsed_seconds']:>10.1f} "
+        f"{summary['mean_segments_per_turn_ratio']:>10.2f}"
+    )
+    print(f"wrote {args.output / 'metrics.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/score/summary_vllm_predict_v1.py
+++ b/scripts/eval/score/summary_vllm_predict_v1.py
@@ -1,0 +1,203 @@
+"""Generate summary predictions via the vLLM autoresearch endpoint (#928).
+
+Produces a predictions.jsonl in the same shape the autoresearch pipeline
+produces for Ollama / OpenAI / Gemini runs, so the finale framework
+(``scripts/eval/finale_sweep.py``) can score it side-by-side with the
+existing Ollama qwen3.5:35b results from #949.
+
+Why a standalone script rather than the experiment-run path:
+
+The autoresearch experiment-run path (``autoresearch_track_a.py``) has
+explicit backend types: ``openai``, ``gemini``, ``ollama``, etc. — no
+``vllm`` type yet. vLLM exposes an OpenAI-compatible API, so a clean
+fix is to either (a) add a ``vllm`` backend type or (b) extend
+``openai`` to accept a per-experiment ``base_url`` override.
+
+Both are real refactors. For #928's first-cut DGX vs DGX comparison
+(Ollama qwen3.5:35b vs vLLM Qwen3-Coder-Next-FP8 on the same 5 smoke
+episodes with the same prompts) we don't need that refactor — we just
+need vLLM predictions in the standard predictions.jsonl shape. This
+script does exactly that. The proper backend integration is a
+follow-up.
+
+Output:
+    ``data/eval/runs/<run_id>/predictions.jsonl``
+    ``data/eval/runs/<run_id>/fingerprint.json``
+    ``data/eval/runs/<run_id>/run.log``
+
+Usage:
+    python scripts/eval/score/summary_vllm_predict_v1.py \\
+        --vllm-url http://dgx-llm-1.tail6d0ed4.ts.net:8003/v1 \\
+        --model "Qwen/Qwen3-Coder-Next-FP8" \\
+        --prompt-system src/podcast_scraper/prompts/ollama/qwen3.5_35b/summarization/system_v1.j2 \\
+        --prompt-user src/podcast_scraper/prompts/ollama/qwen3.5_35b/summarization/long_v1.j2 \\
+        --materialized-dir data/eval/materialized/curated_5feeds_smoke_v1 \\
+        --episodes p01_e01 p02_e01 p03_e01 p04_e01 p05_e01 \\
+        --output-dir data/eval/runs/autoresearch_prompt_vllm_<tag>_curated_5feeds_smoke_v1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _path_for_log(p: Path) -> str:
+    """Return a repo-relative path when possible, otherwise an absolute string."""
+    try:
+        return str(p.resolve().relative_to(PROJECT_ROOT))
+    except ValueError:
+        return str(p.resolve())
+
+
+def _render_jinja(template_text: str, **vars: Any) -> str:
+    """Minimal Jinja2 stand-in. Only supports ``{{ name }}`` substitution."""
+    from jinja2 import Template
+
+    return Template(template_text).render(**vars)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--vllm-url", required=True, help="vLLM /v1 endpoint URL")
+    p.add_argument("--model", required=True, help="Model id served by vLLM")
+    p.add_argument("--prompt-system", required=True, type=Path)
+    p.add_argument("--prompt-user", required=True, type=Path)
+    p.add_argument("--materialized-dir", required=True, type=Path)
+    p.add_argument("--episodes", nargs="+", required=True)
+    p.add_argument("--output-dir", required=True, type=Path)
+    p.add_argument("--max-tokens", type=int, default=800)
+    p.add_argument("--min-tokens", type=int, default=200)
+    p.add_argument("--temperature", type=float, default=0.0)
+    args = p.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    log_path = args.output_dir / "run.log"
+    preds_path = args.output_dir / "predictions.jsonl"
+
+    system_tpl = args.prompt_system.read_text(encoding="utf-8")
+    user_tpl = args.prompt_user.read_text(encoding="utf-8")
+
+    from openai import OpenAI
+
+    # vLLM doesn't validate api_key; any non-empty string works.
+    client = OpenAI(base_url=args.vllm_url, api_key="vllm-no-auth-needed")
+
+    dataset_id = args.materialized_dir.name
+    n_total = len(args.episodes)
+    rows: list[dict[str, Any]] = []
+    total_cost = 0.0  # always 0 for local DGX serving
+    started = time.time()
+
+    log_lines: list[str] = []
+
+    def log(msg: str) -> None:
+        line = f"{time.strftime('%H:%M:%S')} {msg}"
+        print(line, file=sys.stderr)
+        log_lines.append(line)
+
+    log(f"vllm url={args.vllm_url}")
+    log(f"model={args.model}")
+    log(f"dataset={dataset_id} n_episodes={n_total}")
+
+    for i, ep in enumerate(args.episodes, 1):
+        transcript_path = args.materialized_dir / f"{ep}.txt"
+        if not transcript_path.exists():
+            log(f"  SKIP {ep}: materialized transcript missing at {transcript_path}")
+            continue
+        transcript = transcript_path.read_text(encoding="utf-8")
+        system_msg = _render_jinja(system_tpl, transcript=transcript)
+        user_msg = _render_jinja(user_tpl, transcript=transcript)
+
+        log(f"  [{i}/{n_total}] {ep} — transcript {len(transcript)}c → calling vLLM…")
+        t0 = time.time()
+        try:
+            resp = client.chat.completions.create(
+                model=args.model,
+                messages=[
+                    {"role": "system", "content": system_msg},
+                    {"role": "user", "content": user_msg},
+                ],
+                max_tokens=args.max_tokens,
+                temperature=args.temperature,
+                timeout=600.0,
+            )
+            summary = (resp.choices[0].message.content or "").strip()
+            usage = resp.usage
+            prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
+            completion_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+            err = ""
+        except Exception as exc:  # noqa: BLE001
+            summary = ""
+            prompt_tokens = completion_tokens = 0
+            err = str(exc)[:300]
+        elapsed = time.time() - t0
+        log(
+            f"    {ep}: {elapsed:.1f}s — out {len(summary)}c "
+            f"({prompt_tokens}+{completion_tokens} tok) {f'ERR={err}' if err else ''}"
+        )
+
+        rows.append(
+            {
+                "episode_id": ep,
+                "dataset_id": dataset_id,
+                "output": {"summary_final": summary},
+                "metadata": {
+                    "model": args.model,
+                    "backend": "vllm",
+                    "endpoint": args.vllm_url,
+                    "elapsed_seconds": round(elapsed, 2),
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "cost_usd": 0.0,
+                    "error": err,
+                },
+            }
+        )
+
+    total_elapsed = time.time() - started
+    with preds_path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    fingerprint = {
+        "schema": "predictions_v1",
+        "backend": "vllm",
+        "endpoint": args.vllm_url,
+        "model": args.model,
+        "dataset_id": dataset_id,
+        "n_episodes": len(rows),
+        "total_elapsed_seconds": round(total_elapsed, 1),
+        "total_cost_usd": round(total_cost, 4),
+        "prompts": {
+            # Store as absolute paths if they're outside PROJECT_ROOT; otherwise
+            # use repo-relative for readability. The path comparison guards against
+            # ValueError on relative_to when the caller passed a CLI-relative path.
+            "system": _path_for_log(args.prompt_system),
+            "user": _path_for_log(args.prompt_user),
+        },
+        "params": {
+            "max_tokens": args.max_tokens,
+            "temperature": args.temperature,
+        },
+    }
+    (args.output_dir / "fingerprint.json").write_text(
+        json.dumps(fingerprint, indent=2), encoding="utf-8"
+    )
+    log_path.write_text("\n".join(log_lines) + "\n", encoding="utf-8")
+
+    print(f"\nwrote {len(rows)} predictions in {total_elapsed:.1f}s")
+    print(f"  {preds_path}")
+    print(f"  {args.output_dir / 'fingerprint.json'}")
+    print(f"  {log_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/score/summary_vllm_predict_v1.py
+++ b/scripts/eval/score/summary_vllm_predict_v1.py
@@ -75,6 +75,14 @@ def main() -> int:
     p.add_argument("--max-tokens", type=int, default=800)
     p.add_argument("--min-tokens", type=int, default=200)
     p.add_argument("--temperature", type=float, default=0.0)
+    p.add_argument(
+        "--disable-thinking",
+        action="store_true",
+        help=(
+            "Pass chat_template_kwargs={'enable_thinking': False} to vLLM. Required for "
+            "Qwen3.5/3.6 family to produce a clean summary instead of leaking reasoning prose."
+        ),
+    )
     args = p.parse_args()
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
@@ -117,6 +125,9 @@ def main() -> int:
 
         log(f"  [{i}/{n_total}] {ep} — transcript {len(transcript)}c → calling vLLM…")
         t0 = time.time()
+        extra_body: dict[str, Any] = {}
+        if args.disable_thinking:
+            extra_body["chat_template_kwargs"] = {"enable_thinking": False}
         try:
             resp = client.chat.completions.create(
                 model=args.model,
@@ -127,6 +138,7 @@ def main() -> int:
                 max_tokens=args.max_tokens,
                 temperature=args.temperature,
                 timeout=600.0,
+                extra_body=extra_body or None,
             )
             summary = (resp.choices[0].message.content or "").strip()
             usage = resp.usage
@@ -185,6 +197,7 @@ def main() -> int:
         "params": {
             "max_tokens": args.max_tokens,
             "temperature": args.temperature,
+            "disable_thinking": args.disable_thinking,
         },
     }
     (args.output_dir / "fingerprint.json").write_text(

--- a/scripts/eval/score/whisper_dgx_vs_cloud_v1.py
+++ b/scripts/eval/score/whisper_dgx_vs_cloud_v1.py
@@ -174,19 +174,32 @@ def _audio_duration_seconds(path: Path) -> float:
 
 
 def _transcribe_local(audio_path: Path, model_name: str, model_cache: dict[str, Any]) -> str:
-    """Local CPU via openai-whisper Python lib."""
+    """Local in-process openai-whisper.
+
+    Device auto-picks: CUDA > MPS > CPU. Override with the
+    ``LOCAL_WHISPER_DEVICE`` env var (``cuda`` / ``mps`` / ``cpu``) for
+    the #929 honest comparison — without that, this picks the fastest
+    available, which is MPS on Apple Silicon (GPU acceleration via Metal,
+    NOT a fair pure-CPU baseline).
+    """
     import whisper
 
     cache_dir = PROJECT_ROOT / ".cache" / "whisper"
-    if model_name not in model_cache:
-        print(f"  loading whisper {model_name}...", file=sys.stderr)
+    device = os.environ.get("LOCAL_WHISPER_DEVICE", "").strip() or None
+    cache_key = f"{model_name}|{device or 'auto'}"
+    if cache_key not in model_cache:
+        print(f"  loading whisper {model_name} (device={device or 'auto'})...", file=sys.stderr)
         t0 = time.time()
-        model_cache[model_name] = whisper.load_model(model_name, download_root=str(cache_dir))
+        kwargs: dict[str, Any] = {"download_root": str(cache_dir)}
+        if device:
+            kwargs["device"] = device
+        model_cache[cache_key] = whisper.load_model(model_name, **kwargs)
         print(f"    loaded in {time.time()-t0:.1f}s", file=sys.stderr)
-    model = model_cache[model_name]
-    # fp16=False because CPU. The whisper python lib defaults to fp16 which
-    # warns + falls back on CPU; explicit is faster.
-    result = model.transcribe(str(audio_path), verbose=False, fp16=False)
+    model = model_cache[cache_key]
+    # fp16=True on GPU (MPS/CUDA), False on CPU. openai-whisper warns +
+    # falls back when fp16 is wrong; we set explicitly to avoid the warn.
+    use_fp16 = device != "cpu"
+    result = model.transcribe(str(audio_path), verbose=False, fp16=use_fp16)
     return result["text"]
 
 

--- a/scripts/eval/score/whisper_dgx_vs_cloud_v1.py
+++ b/scripts/eval/score/whisper_dgx_vs_cloud_v1.py
@@ -1,0 +1,483 @@
+"""Transcription championship: Speaches/DGX vs local CPU vs cloud Whisper (#929).
+
+Extends ``whisper_accent_wer_v1.py`` (#906B) with two new transcription
+backends so we can answer the question:
+
+    Does Speaches on DGX beat local CPU base.en on the WER × latency × cost
+    tradeoff, and how does either compare to cloud OpenAI Whisper API on
+    the 90-min real-episode shape?
+
+## Backends
+
+- ``local``  — OpenAI's ``openai-whisper`` Python lib, model loaded in-process
+  (matches the path the prod pipeline uses today). Cost = $0.
+- ``dgx``    — Speaches HTTP endpoint on the DGX. POST a multipart audio file
+  to ``/v1/audio/transcriptions``; OpenAI-compatible response. Cost = $0
+  marginal (we own the DGX). The custom Blackwell build from #948 is what
+  makes this actually GPU-accelerated.
+- ``cloud``  — OpenAI Whisper API (same OpenAI-compatible response shape).
+  Cost = $0.006 / minute audio (June 2026 public pricing).
+
+## Metrics
+
+Per (backend, model, episode):
+- WER (Levenshtein word-edit over normalized text) vs ground-truth transcript.
+- Single-request latency (wall-clock seconds for one transcribe call).
+- Cost in USD.
+
+Across the full sweep:
+- Burst-latency check (5 concurrent transcribe calls of the same episode).
+  Tells us whether the backend keeps up under concurrency, or queues / dies.
+
+## Inputs
+
+Reuses #906B's v2 audio bed (``tests/fixtures/audio/v2/``) for accent coverage
+(15 episodes × 9 macOS ``say`` voice combos). Add one real 90-min episode
+(``manual-run-10`` corpus) for the production-shape latency signal — short
+v2 clips are overhead-dominated and don't surface the DGX advantage.
+
+## Usage
+
+    # Local CPU baseline
+    python scripts/eval/score/whisper_dgx_vs_cloud_v1.py \\
+        --backend local --models tiny.en base.en small.en \\
+        --audio-dir tests/fixtures/audio/v2 \\
+        --transcripts-dir tests/fixtures/transcripts/v2 \\
+        --episodes p01_e01 p02_e01 p03_e01 p04_e01 p05_e01 \\
+        --output data/eval/runs/whisper_dgx_vs_cloud_v1/local
+
+    # DGX (requires WHISPER_DGX_URL pointing at Speaches /v1/audio/transcriptions)
+    WHISPER_DGX_URL=http://dgx-llm-1.tail6d0ed4.ts.net:8000/v1/audio/transcriptions \\
+    python scripts/eval/score/whisper_dgx_vs_cloud_v1.py \\
+        --backend dgx \\
+        --models Systran/faster-whisper-base.en \\
+                 Systran/faster-whisper-small.en \\
+                 Systran/faster-whisper-medium.en \\
+        --audio-dir tests/fixtures/audio/v2 \\
+        --transcripts-dir tests/fixtures/transcripts/v2 \\
+        --episodes p01_e01 p02_e01 p03_e01 p04_e01 p05_e01 \\
+        --output data/eval/runs/whisper_dgx_vs_cloud_v1/dgx
+
+    # Cloud (requires AUTORESEARCH_EXPERIMENT_OPENAI_API_KEY in env)
+    python scripts/eval/score/whisper_dgx_vs_cloud_v1.py \\
+        --backend cloud --models whisper-1 \\
+        --audio-dir tests/fixtures/audio/v2 \\
+        --transcripts-dir tests/fixtures/transcripts/v2 \\
+        --episodes p01_e01 p02_e01 p03_e01 p04_e01 p05_e01 \\
+        --output data/eval/runs/whisper_dgx_vs_cloud_v1/cloud
+
+    # Burst-latency check on a single backend (--burst 5 → 5 concurrent jobs)
+    python scripts/eval/score/whisper_dgx_vs_cloud_v1.py \\
+        --backend dgx --models Systran/faster-whisper-base.en \\
+        --episodes p01_e01 --burst 5 ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as _futures
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+# Cloud pricing — public OpenAI Whisper API rate, June 2026. Edit if upstream
+# changes (we own no fallback; if pricing moves the cost column moves with it).
+CLOUD_PRICE_USD_PER_MIN_AUDIO = 0.006
+
+# ---------------------------------------------------------------------------
+# WER + transcript normalization (mirrors whisper_accent_wer_v1.py so the
+# two harnesses' numbers are directly comparable — copy is intentional,
+# 20 lines isn't worth a shared module for these one-shot scripts).
+
+_NORMALIZE_RE = re.compile(r"[^a-z0-9 ]+")
+
+
+def _normalize(text: str) -> list[str]:
+    text = text.lower()
+    text = _NORMALIZE_RE.sub(" ", text)
+    return text.split()
+
+
+def wer(ref: str, hyp: str) -> float:
+    """Word error rate via Levenshtein. Returns 0.0 for empty ref+hyp."""
+    r = _normalize(ref)
+    h = _normalize(hyp)
+    if not r:
+        return 0.0 if not h else 1.0
+    nr, nh = len(r), len(h)
+    dp = [[0] * (nh + 1) for _ in range(nr + 1)]
+    for i in range(nr + 1):
+        dp[i][0] = i
+    for j in range(nh + 1):
+        dp[0][j] = j
+    for i in range(1, nr + 1):
+        for j in range(1, nh + 1):
+            cost = 0 if r[i - 1] == h[j - 1] else 1
+            dp[i][j] = min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost)
+    return dp[nr][nh] / nr
+
+
+def _strip_transcript_metadata(text: str) -> str:
+    """Drop header / speaker tags / timestamps so WER measures spoken content only."""
+    lines = text.splitlines()
+    body: list[str] = []
+    speaker_re = re.compile(r"^[A-Z][A-Za-z .'\-]{0,40}:\s+")
+    ts_re = re.compile(r"^\[\d{1,2}:\d{2}(?::\d{2})?\]$")
+    for line in lines:
+        s = line.strip()
+        if not s or s.startswith("#") or ts_re.fullmatch(s):
+            continue
+        m = speaker_re.match(s)
+        body.append(m.group(0).join(s.split(m.group(0))[1:]) if m else s)
+    return " ".join(body)
+
+
+# ---------------------------------------------------------------------------
+# Backend dispatch.
+#
+# All three backends return ``(transcript_text, audio_duration_seconds)``.
+# The audio duration is needed both for cost calc (cloud) and for
+# realtime-multiple reporting. We probe duration with ffprobe once per
+# episode and pass it through.
+
+
+def _audio_duration_seconds(path: Path) -> float:
+    """Use ffprobe to read audio duration. Fallback: 0.0 (cost won't be computed)."""
+    import subprocess
+
+    try:
+        out = subprocess.check_output(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(path),
+            ],
+            text=True,
+            timeout=30,
+        )
+        return float(out.strip())
+    except Exception as exc:
+        print(f"  ffprobe failed on {path.name}: {exc}", file=sys.stderr)
+        return 0.0
+
+
+def _transcribe_local(audio_path: Path, model_name: str, model_cache: dict[str, Any]) -> str:
+    """Local CPU via openai-whisper Python lib."""
+    import whisper
+
+    cache_dir = PROJECT_ROOT / ".cache" / "whisper"
+    if model_name not in model_cache:
+        print(f"  loading whisper {model_name}...", file=sys.stderr)
+        t0 = time.time()
+        model_cache[model_name] = whisper.load_model(model_name, download_root=str(cache_dir))
+        print(f"    loaded in {time.time()-t0:.1f}s", file=sys.stderr)
+    model = model_cache[model_name]
+    # fp16=False because CPU. The whisper python lib defaults to fp16 which
+    # warns + falls back on CPU; explicit is faster.
+    result = model.transcribe(str(audio_path), verbose=False, fp16=False)
+    return result["text"]
+
+
+def _transcribe_dgx(audio_path: Path, model_name: str, _model_cache: dict[str, Any]) -> str:
+    """DGX Speaches via HTTP /v1/audio/transcriptions."""
+    import requests
+
+    url = os.environ.get("WHISPER_DGX_URL")
+    if not url:
+        raise RuntimeError(
+            "WHISPER_DGX_URL unset — e.g. "
+            "http://dgx-llm-1.tail6d0ed4.ts.net:8000/v1/audio/transcriptions"
+        )
+    with audio_path.open("rb") as fh:
+        # Timeout sized for a 90-min episode on a slow DGX day. The actual
+        # transcription should take seconds on the custom-build #948 image.
+        resp = requests.post(
+            url,
+            files={"file": (audio_path.name, fh, "audio/mpeg")},
+            data={"model": model_name, "response_format": "json"},
+            timeout=900,
+        )
+    resp.raise_for_status()
+    return resp.json().get("text", "")
+
+
+def _transcribe_cloud(audio_path: Path, model_name: str, model_cache: dict[str, Any]) -> str:
+    """OpenAI Whisper API."""
+    if "_openai_client" not in model_cache:
+        from openai import OpenAI
+
+        # Mirror the autoresearch keying convention from the finale judge
+        # clients: never fall through to the plain prod ``OPENAI_API_KEY`` —
+        # autoresearch evals must spend on the autoresearch budget.
+        api_key = (
+            os.environ.get("AUTORESEARCH_EXPERIMENT_OPENAI_API_KEY", "").strip()
+            or os.environ.get("AUTORESEARCH_JUDGE_OPENAI_API_KEY", "").strip()
+        )
+        if not api_key:
+            raise RuntimeError(
+                "AUTORESEARCH_EXPERIMENT_OPENAI_API_KEY unset; refuse to charge prod key"
+            )
+        model_cache["_openai_client"] = OpenAI(api_key=api_key)
+    client = model_cache["_openai_client"]
+    with audio_path.open("rb") as fh:
+        resp = client.audio.transcriptions.create(
+            model=model_name,
+            file=fh,
+            response_format="json",
+        )
+    return resp.text
+
+
+_BACKENDS = {
+    "local": _transcribe_local,
+    "dgx": _transcribe_dgx,
+    "cloud": _transcribe_cloud,
+}
+
+
+def _cost_usd(backend: str, audio_seconds: float) -> float:
+    """USD cost for one transcription call."""
+    if backend == "cloud":
+        return audio_seconds / 60.0 * CLOUD_PRICE_USD_PER_MIN_AUDIO
+    return 0.0  # local + dgx have no marginal cost
+
+
+# ---------------------------------------------------------------------------
+# Sweep + burst harnesses
+
+
+def _one_call(
+    *,
+    backend: str,
+    model_name: str,
+    audio_path: Path,
+    transcript_path: Path,
+    audio_seconds: float,
+    model_cache: dict[str, Any],
+) -> dict[str, Any]:
+    """Single (backend, model, episode) measurement."""
+    reference = _strip_transcript_metadata(transcript_path.read_text(encoding="utf-8"))
+    t0 = time.time()
+    try:
+        hyp = _BACKENDS[backend](audio_path, model_name, model_cache)
+        err = ""
+    except Exception as exc:  # noqa: BLE001
+        hyp = ""
+        err = str(exc)[:300]
+    elapsed = time.time() - t0
+    ep_wer = wer(reference, hyp) if hyp else 1.0
+    return {
+        "backend": backend,
+        "model": model_name,
+        "episode_id": audio_path.stem,
+        "wer": round(ep_wer, 4),
+        "elapsed_s": round(elapsed, 2),
+        "audio_seconds": round(audio_seconds, 2),
+        "realtime_multiple": (
+            round(audio_seconds / elapsed, 1) if elapsed > 0 and audio_seconds > 0 else None
+        ),
+        "cost_usd": round(_cost_usd(backend, audio_seconds), 6),
+        "ref_word_count": len(_normalize(reference)),
+        "hyp_word_count": len(_normalize(hyp)),
+        "error": err,
+    }
+
+
+def _burst(
+    *,
+    backend: str,
+    model_name: str,
+    audio_path: Path,
+    transcript_path: Path,
+    audio_seconds: float,
+    concurrency: int,
+    model_cache: dict[str, Any],
+) -> dict[str, Any]:
+    """Fire ``concurrency`` parallel transcribe calls on the same episode.
+
+    Reports the slowest call and the mean — what we care about is "does the
+    backend keep up under concurrency, or does it queue / fall over?".
+    """
+    if backend == "local":
+        # The local whisper lib is not thread-safe and would just serialize on
+        # the GIL. Burst on local is meaningless; skip and report a sentinel.
+        return {
+            "backend": backend,
+            "model": model_name,
+            "episode_id": audio_path.stem,
+            "concurrency": concurrency,
+            "skipped_reason": "local backend serializes via GIL",
+        }
+    rows: list[dict[str, Any]] = []
+    with _futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = [
+            pool.submit(
+                _one_call,
+                backend=backend,
+                model_name=model_name,
+                audio_path=audio_path,
+                transcript_path=transcript_path,
+                audio_seconds=audio_seconds,
+                model_cache=model_cache,
+            )
+            for _ in range(concurrency)
+        ]
+        for f in _futures.as_completed(futures):
+            rows.append(f.result())
+    elapsed = [r["elapsed_s"] for r in rows if not r.get("error")]
+    return {
+        "backend": backend,
+        "model": model_name,
+        "episode_id": audio_path.stem,
+        "concurrency": concurrency,
+        "n_completed": len(elapsed),
+        "n_errored": len(rows) - len(elapsed),
+        "elapsed_s_max": max(elapsed) if elapsed else None,
+        "elapsed_s_mean": round(sum(elapsed) / len(elapsed), 2) if elapsed else None,
+        "audio_seconds": round(audio_seconds, 2),
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--backend", required=True, choices=sorted(_BACKENDS.keys()))
+    p.add_argument("--models", nargs="+", required=True)
+    p.add_argument("--audio-dir", type=Path, required=True)
+    p.add_argument("--transcripts-dir", type=Path, required=True)
+    p.add_argument("--episodes", nargs="+", required=True)
+    p.add_argument("--output", type=Path, required=True)
+    p.add_argument(
+        "--burst",
+        type=int,
+        default=0,
+        help="If >0, also run a burst test with this many concurrent jobs per (model, episode).",
+    )
+    args = p.parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    model_cache: dict[str, Any] = {}
+    rows: list[dict[str, Any]] = []
+    burst_rows: list[dict[str, Any]] = []
+
+    for model_name in args.models:
+        for ep in args.episodes:
+            audio_path = args.audio_dir / f"{ep}.mp3"
+            transcript_path = args.transcripts_dir / f"{ep}.txt"
+            if not audio_path.exists() or not transcript_path.exists():
+                print(f"  SKIP {ep}: missing audio or transcript", file=sys.stderr)
+                continue
+            audio_seconds = _audio_duration_seconds(audio_path)
+            row = _one_call(
+                backend=args.backend,
+                model_name=model_name,
+                audio_path=audio_path,
+                transcript_path=transcript_path,
+                audio_seconds=audio_seconds,
+                model_cache=model_cache,
+            )
+            rows.append(row)
+            rt = row["realtime_multiple"]
+            rt_s = f"{rt:.1f}×" if rt is not None else "n/a"
+            err_tail = f" ERROR={row['error']}" if row["error"] else ""
+            print(
+                f"  {args.backend:5s} {model_name:50s} {ep:8s} "
+                f"WER={row['wer']:.4f} elapsed={row['elapsed_s']:.1f}s "
+                f"rt={rt_s} cost=${row['cost_usd']:.4f}{err_tail}"
+            )
+            if args.burst > 0:
+                br = _burst(
+                    backend=args.backend,
+                    model_name=model_name,
+                    audio_path=audio_path,
+                    transcript_path=transcript_path,
+                    audio_seconds=audio_seconds,
+                    concurrency=args.burst,
+                    model_cache=model_cache,
+                )
+                burst_rows.append(br)
+                if br.get("skipped_reason"):
+                    print(f"    burst skipped: {br['skipped_reason']}")
+                else:
+                    print(
+                        f"    burst×{args.burst}: completed={br['n_completed']} "
+                        f"errored={br['n_errored']} "
+                        f"max={br['elapsed_s_max']}s mean={br['elapsed_s_mean']}s"
+                    )
+
+    # Per-(backend, model) summary
+    from collections import defaultdict
+
+    by_bm: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        if r["error"]:
+            continue
+        by_bm[(r["backend"], r["model"])].append(r)
+    summary: list[dict[str, Any]] = []
+    for (backend, model_name), rs in sorted(by_bm.items()):
+        wer_values = [r["wer"] for r in rs]
+        elapsed_values = [r["elapsed_s"] for r in rs]
+        audio_sec_total = sum(r["audio_seconds"] for r in rs)
+        cost_total = sum(r["cost_usd"] for r in rs)
+        summary.append(
+            {
+                "backend": backend,
+                "model": model_name,
+                "episodes": len(rs),
+                "mean_wer": round(sum(wer_values) / len(wer_values), 4),
+                "max_wer": max(wer_values),
+                "min_wer": min(wer_values),
+                "mean_elapsed_s": round(sum(elapsed_values) / len(elapsed_values), 2),
+                "mean_realtime_multiple": (
+                    round(audio_sec_total / sum(elapsed_values), 1)
+                    if sum(elapsed_values) > 0
+                    else None
+                ),
+                "total_audio_seconds": round(audio_sec_total, 1),
+                "total_cost_usd": round(cost_total, 4),
+            }
+        )
+
+    (args.output / "metrics.json").write_text(
+        json.dumps(
+            {
+                "schema": "metrics_whisper_dgx_vs_cloud_v1",
+                "backend": args.backend,
+                "summary": summary,
+                "rows": rows,
+                "burst": burst_rows,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    print(
+        f"\n{'backend':<6} {'model':<48} eps  mean_wer   max_wer   "
+        f"mean_lat_s   mean_rt  total_$"
+    )
+    for s in summary:
+        rt_s = f"{s['mean_realtime_multiple']}×" if s["mean_realtime_multiple"] else "n/a"
+        print(
+            f"{s['backend']:<6} {s['model']:<48} {s['episodes']:>3}  "
+            f"{s['mean_wer']:>8.4f}  {s['max_wer']:>7.4f}  "
+            f"{s['mean_elapsed_s']:>10.1f}  {rt_s:>6}  ${s['total_cost_usd']:>6.4f}"
+        )
+    print(f"wrote {args.output / 'metrics.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/podcast_scraper/providers/deepgram/deepgram_provider.py
+++ b/src/podcast_scraper/providers/deepgram/deepgram_provider.py
@@ -123,7 +123,10 @@ def _create_deepgram_client(api_key: str, base_url: str | None = None) -> Any:
             # deepgram-sdk 7.x made ``agent_rest`` a required field; point it at the
             # override root too. Older SDKs without it raise TypeError -> caught below
             # (graceful fallback to the hosted client), so this stays back-compatible.
-            env = DeepgramClientEnvironment(
+            # The ``type: ignore[call-arg]`` covers the installed SDK version not
+            # having ``agent_rest`` in its constructor signature — the try/except
+            # makes this runtime-safe in either direction.
+            env = DeepgramClientEnvironment(  # type: ignore[call-arg]
                 base=base_url,
                 production=base_url,
                 agent=base_url,

--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -61,26 +61,27 @@
       "dst":    ["tag:dr-drill:22,80,443"]
     },
 
-    // RFC-089 / ADR-096 / #814:
+    // RFC-089 / ADR-096 / #814 / #926 / #953:
     //   :11434 = DGX Ollama (LLM stages).
-    //   :8000  = faster-whisper-server (transcription stage; #814).
-    //   :8001  = legacy embedding shim slot (ADR-098 removed the shim; port
-    //            kept reserved so we don't accidentally collide if it comes back).
+    //   :8000  = faster-whisper-server / speaches (transcription stage; #814).
+    //   :8001  = pyannote diarization service (#926).
+    //   :8002  = openai-whisper service (first-party Whisper code; #953).
+    //            Runs alongside speaches:8000 until #952 picks the winner.
     // Cloud fallback is enforced in profile config, not the ACL.
     {
       "action": "accept",
       "src":    ["autogroup:admin", "tag:gha-deployer"],
-      "dst":    ["tag:dgx-llm-host:11434", "tag:dgx-llm-host:8000", "tag:dgx-llm-host:8001"]
+      "dst":    ["tag:dgx-llm-host:11434", "tag:dgx-llm-host:8000", "tag:dgx-llm-host:8001", "tag:dgx-llm-host:8002"]
     },
     {
       "action": "accept",
       "src":    ["tag:dr-drill"],
-      "dst":    ["tag:dgx-llm-host:11434", "tag:dgx-llm-host:8000", "tag:dgx-llm-host:8001"]
+      "dst":    ["tag:dgx-llm-host:11434", "tag:dgx-llm-host:8000", "tag:dgx-llm-host:8001", "tag:dgx-llm-host:8002"]
     },
     {
       "action": "accept",
       "src":    ["tag:prod"],
-      "dst":    ["tag:dgx-llm-host:11434", "tag:dgx-llm-host:8000", "tag:dgx-llm-host:8001"]
+      "dst":    ["tag:dgx-llm-host:11434", "tag:dgx-llm-host:8000", "tag:dgx-llm-host:8001", "tag:dgx-llm-host:8002"]
     }
 
     // (Future, for #714 + #723) Home Assistant subscribes to /api/jobs.


### PR DESCRIPTION
## Summary

Closes the DGX-vs-cloud autoresearch batch-3 epic (#927) and ships
the late-batch findings as a single bundle:

- **#928 — Summary championship**: Ollama qwen3.5:35b wins decisively over vLLM-R1-Distill (5.00 vs 3.25 mean). Cell C adds proper-isolation evidence: when the model family is held fixed (Qwen3.6 in both candidates), Ollama and vLLM tie within scoring noise (4.90–5.00). **The 1.75-point parent-eval gap was the model choice, not the serving stack.** Ollama qwen3.5:35b stays the `cloud_with_dgx_*` default — justification flips from "quality" to "operational simplicity."
- **#929 — Transcription championship**: 4-way comparison post-fix. **DGX `whisper-openai` on `:8002` is the new speed leader** (WER 0.102 ≈ MPS 0.096, but 4.56× realtime vs MPS 1.6×). MPS stays the laptop default. CPU fallback documented as viable. Both the prior "DGX whisper is broken" claim AND the "DGX whisper is contention-fragile" claim are **withdrawn** — root cause was a config bug in our `app.py` (forced `temperature=0.0` scalar disabled openai-whisper's built-in fallback schedule). Fixed in this PR.
- **#930 — Diarization championship**: 3-way pyannote MPS / CUDA / CPU. MPS and CUDA tied at ~23s mean (~13× realtime); CPU at ~415s. Single-voice TTS contamination (`#934`) blocks quality verdicts until multi-voice fixtures land.
- **#931 — Hybrid routing synthesis**: per-profile recommendations, operating points, what flipped vs stayed. Two defaults change as a result of this batch: `cloud_with_dgx_*` transcription → DGX `:8002` (post-fix); vLLM autoresearch service → 26.05-py3 + Qwen3.6-35B-A3B + `--max-num-seqs 128`.
- **#953 — DGX openai-whisper service**: was deployed earlier; the temperature-schedule bug fix in `infra/dgx/whisper-server/app.py` is included in this PR.

Closes #928 #929 #930 #931 #953.

## The DGX whisper temperature-schedule bug — what we learned

The whisper-server container's API contract forced `temperature=0.0` as a scalar. openai-whisper's `transcribe()` defaults `temperature` to a **schedule** `(0.0, 0.2, 0.4, 0.6, 0.8, 1.0)` — starts deterministic, falls back to higher temperatures when the decoder triggers a hallucination check (compression_ratio + logprob thresholds). That fallback is what saves long audio from autoregressive runaway. Passing a scalar (incl. 0.0) **disables** the fallback. The decoder gets no recovery path; once it loops, it keeps generating.

In-container A/B confirms (on p01_e01.mp3, ~5 min):

| Mode | Hyp words | Elapsed | Notes |
| --- | ---: | ---: | --- |
| scalar `temperature=0.0` (pre-fix) | **7,311** | 328.9s | repeating phrases at the end |
| default schedule (fix) | **1,446** | 175.3s | natural ending |

Same container, same model, same audio. Only the kwarg differs. **Schedule mode is also faster** (no broken-decode → fallback re-run loop eats wall time).

Fix: `temperature` is now `Optional[float]`, only passed to `transcribe()` when the caller explicitly sets it.

## Cell C — proper isolation of the serving stack (#928)

| Run | Faith | Cov | Coh | Flu | Mean (Sonnet) | Mean (GPT-5.4) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Ollama qwen3.5:35b (Q4_K_M) | 5.00 | 5.00 | 5.00 | 5.00 | **5.00** | 4.95 |
| vLLM Qwen3.6-35B-A3B (bf16) | 5.00 | 5.00 | 4.60 | 5.00 | **4.90** | 4.90 |

Both judges, 100% agreement, no contested episodes. With the model family held fixed, the serving stack contributes ~0.05–0.10 of mean score — within scoring noise.

vLLM image-compat side quest: `qwen3_5_moe` architecture only landed in transformers 5.x (2026-02-09); NVIDIA's vLLM tags 25.11 through 26.04 all ship transformers 4.57.x. **Only `26.05-py3` works on this GB10** (`26.05.post1-py3` was previously confirmed broken by the operator). Verified by reading NVIDIA's per-tag release notes — no need to binary-search images.

Required boot config on Qwen3.6-35B-A3B: `--max-num-seqs 128` (Mamba cache-blocks limit) + caller must pass `chat_template_kwargs={enable_thinking: False}` (same reasoning-leak default as R1-Distill, but Qwen3 has a clean toggle).

## Routing changes shipped (deploy.py)

| Knob | Before | After |
| --- | --- | --- |
| `VLLM_IMAGE` | `nvcr.io/nvidia/vllm:25.11-py3` | `nvcr.io/nvidia/vllm:26.05-py3` |
| `VLLM_MODEL` | `deepseek-ai/DeepSeek-R1-Distill-Qwen-32B` | `Qwen/Qwen3.6-35B-A3B` |
| `VLLM_MAX_NUM_SEQS` | (not set) | `"128"` |
| `--enable-auto-tool-choice` + `qwen3_coder` parser | present | removed (not used by summary path) |
| `cloud_with_dgx_*` transcription default | MPS / cloud (per earlier draft) | DGX `whisper-openai` on `:8002` (post temperature fix) |

R1-Distill on 25.11 preserved as a one-line revert (`docker-compose.yml.r1-distill.bak` on DGX). New `verify.py` assertion catches drift between deploy.py's `VLLM_MODEL` and what the running container actually serves.

## Follow-up issues filed during this batch

Captured so the next session has a single index instead of needing to re-read the eval reports:

- **#956** — DGX-over-Tailscale client resilience (shared timeout/retry/keepalive layer; surfaced when long-blocking HTTP responses got stuck mid-transit during the post-fix sweep). Applies to every DGX client.
- **#957** — speaches/faster-whisper container produces empty output 4/5 episodes; separate bug from the openai-whisper one. Blocks #952.
- **#958** — #928 Cell D + Cell E (quantization isolation: R1-Distill on Ollama Q4, Qwen3.6 on Ollama bf16). Closes the methodology matrix.
- **#959** — Real-podcast (90-min) WER + summary quality validation across the post-fix transcription stack.
- **#960** — vLLM as a first-class backend in `autoresearch_track_a.py` (replaces the standalone `summary_vllm_predict_v1.py` script used as a workaround).
- **#961** — R1-Distill summary prompt: strip reasoning preamble (closes the prompt-engineering gap surfaced by #928).
- **#962** — Deploy Gemini speaker-detector provider (unblocks the `cloud_*` slot of the #930 panel + makes `cloud_*` diarization actually work).
- **#963** — Re-test DGX whisper under concurrent vLLM contention now that the temperature bug is fixed (the original contention test was confounded).
- **#964** — Wave audio hardening umbrella from `docs/wip/AUDIO-WAVES-HARDENING-AUDIT.md` (so the audit work is findable from `gh issue list`).

Plus a 140-line addition to `docs/wip/AUTORESEARCH_LEARNINGS_FOR_V3.md` documenting v3-fixture-relevant findings from this batch.

## Test plan

- [ ] CI green (`make ci-fast` passed locally before push)
- [ ] mkdocs strict clean (passed locally before push)
- [ ] Branch state matches DGX state after `make dgx-deploy`: whisper-server has the temperature fix; vLLM serves Qwen3.6-35B-A3B on 26.05-py3
- [ ] Review the new `EVAL_*_2026_06.md` reports for accuracy + tone
- [ ] Confirm the routing flips in `cloud_with_dgx_*` profile config match the synthesis-report recommendation
- [ ] Spot-check the follow-up issues #956–#965 (and closed #965) for completeness and tracking-cross-refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)