### PR TITLE
feat(registry): wire registry into runtime + codecov fix + GI/KG scaffolds (#907)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,6 +478,10 @@ backend, summary model, GI/KG thresholds, anything — the lifecycle is:
 6. Tests                          →  tests/integration/providers/ml/...
      - Behavior test: resolve_profile_to_settings(name) returns the expected
        provider/model/endpoint triple
+7. Verify the runtime sees it     →  make profile-drift-check
+     - Each profile YAML that declares `profile: <preset>` is cross-checked
+       against the registry. Wired into make ci-fast — drift is now a CI
+       failure, not a documentation drift problem.
 ```
 
 Steps **4 and 5 are the part that's easy to skip** and the most expensive to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,7 +341,9 @@ make lint
 
 ```bash
 make test-unit          # Fast feedback (~30s)
-make ci-fast            # Default pre-push gate (~6-10 min)
+make profile-drift-check # Confirm config/profiles/*.yaml match registry presets (~1s)
+make profile-resolve PROFILE=<name>  # Print resolved settings for a registry preset (ops debug)
+make ci-fast            # Default pre-push gate (~6-10 min; runs profile-drift-check)
 make ci                 # Full suite before PR (~10-15 min)
 make check-zombie       # After any stuck/hung make run (macOS)
 ```

--- a/Makefile
+++ b/Makefile
@@ -565,6 +565,24 @@ check-test-policy:
 	$(PYTHON) scripts/tools/check_test_policy.py --fix-hint
 	$(PYTHON) scripts/tools/check_self_hosted_runner_allowlist.py
 
+profile-drift-check:
+	# #907 Option B: every config/profiles/*.yaml that declares a `profile:` field
+	# must agree with the named registry preset on routing
+	# (transcription_provider, summary_provider, summary_model). Catches hand-edits
+	# that fork a YAML from its eval-report-justified registry default.
+	# Wired into ci-fast; safe to run standalone in <1s.
+	$(PYTHON) -m pytest tests/integration/providers/ml/test_profile_yaml_registry_drift.py -q --no-cov --disable-socket --allow-hosts=127.0.0.1,localhost
+
+profile-resolve: ## Print the resolved settings dict for PROFILE=<name>. Usage: make profile-resolve PROFILE=cloud_with_dgx_primary
+	@if [ -z "$(PROFILE)" ]; then \
+		echo "PROFILE not set. Available presets:"; \
+		$(PYTHON) scripts/tools/resolve_profile.py --list | sed 's/^/  /'; \
+		echo ""; \
+		echo "Usage: make profile-resolve PROFILE=<name> [DGX_TAILNET_HOST=<host>]"; \
+		exit 2; \
+	fi
+	@$(PYTHON) scripts/tools/resolve_profile.py "$(PROFILE)"
+
 # Optional ARGS: e.g. make check-pricing-assumptions ARGS="--strict"
 # Runs the staleness report AND the #651 profile-coverage guard
 # (fails when a profile references a model without a YAML rate row).
@@ -2062,6 +2080,7 @@ ci-fast:
 	echo ""; echo "=== ci-fast [$$(date '+%Y-%m-%d %H:%M:%S')] spelling ==="; $(MAKE) spelling; \
 	echo ""; echo "=== ci-fast [$$(date '+%Y-%m-%d %H:%M:%S')] check-test-policy ==="; $(MAKE) check-test-policy; \
 	echo ""; echo "=== ci-fast [$$(date '+%Y-%m-%d %H:%M:%S')] quality-metrics-ci ==="; $(MAKE) quality-metrics-ci; \
+	echo ""; echo "=== ci-fast [$$(date '+%Y-%m-%d %H:%M:%S')] profile-drift-check ==="; $(MAKE) profile-drift-check; \
 	echo ""; echo "=== ci-fast [$$(date '+%Y-%m-%d %H:%M:%S')] test-fast (pytest) ==="; $(MAKE) test-fast; \
 	echo ""; echo "=== ci-fast [$$(date '+%Y-%m-%d %H:%M:%S')] corpus-snapshot-selftest ==="; $(MAKE) corpus-snapshot-selftest; \
 	echo ""; echo "=== ci-fast [$$(date '+%Y-%m-%d %H:%M:%S')] test-ui ==="; $(MAKE) test-ui; \

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+# Codecov configuration — mirrors pyproject.toml's [tool.coverage.run] source filter.
+#
+# Without this, Codecov treats paths absent from coverage.xml as 0% covered
+# for patch-coverage purposes, dragging PR diffs that touch scripts/ or infra/
+# below the patch target despite full src/ test coverage. PR #975 hit this
+# (55% patch with green ci-fast); the file did not exist at the time.
+#
+# The ignore list below MUST stay in sync with pyproject.toml's coverage
+# source scope. If `coverage.run.source` changes, mirror it here.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 77.47%
+
+ignore:
+  - "scripts/**"
+  - "infra/**"
+  - "tests/**"
+  - "tools/**"
+  - "docs/**"
+  - "config/**"
+  - "web/**"
+  - "**.md"
+  - "**.yaml"
+  - "**.yml"
+  - "**.j2"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/config/profiles/cloud_balanced.yaml
+++ b/config/profiles/cloud_balanced.yaml
@@ -1,3 +1,10 @@
+# 2026-06-12 (#907 Option B): opted into registry-driven defaults via the
+# `profile:` declaration below. Routing fields (transcription_provider,
+# summary_provider, summary_model) are cross-checked against the registry
+# preset by tests/integration/providers/ml/test_profile_yaml_registry_drift.py.
+
+profile: cloud_balanced
+
 # Profile: cloud_balanced — production default
 #
 # Best compound score (quality × cost × latency) from v2 eval + autoresearch.

--- a/config/profiles/cloud_thin.yaml
+++ b/config/profiles/cloud_thin.yaml
@@ -1,3 +1,8 @@
+# 2026-06-12 (#907 Option B): opted into registry-driven defaults.
+# See tests/integration/providers/ml/test_profile_yaml_registry_drift.py.
+
+profile: cloud_thin
+
 # Profile: cloud_thin — cloud APIs only (no local spaCy / FAISS)
 #
 # Use with pipeline image built using ``INSTALL_EXTRAS=llm`` (``pyproject`` **``. [llm]``**).

--- a/config/profiles/cloud_with_dgx_primary.yaml
+++ b/config/profiles/cloud_with_dgx_primary.yaml
@@ -11,12 +11,22 @@
 # Cloud fallbacks: OPENAI_API_KEY (Whisper), GEMINI_API_KEY (summary).
 # Diarization falls back to in-process pyannote (no cheap cloud alternative
 # to bill against — TailnetDgxDiarizationProvider handles this transparently).
+#
+# 2026-06-12 (#907 Option B): opted into registry-driven defaults. The
+# `profile:` field below names the registry preset; routing fields below
+# (transcription_provider, summary_provider, summary_model) are now
+# cross-checked against the registry by
+# tests/integration/providers/ml/test_profile_yaml_registry_drift.py. If
+# this YAML disagrees with the registry preset, CI fails — update either
+# this file or the registry (with new research_ref evidence).
+
+profile: cloud_with_dgx_primary
 
 transcription:
   primary: tailnet_dgx_whisper
   fallback: openai
 
-dgx_tailnet_host: your-dgx.tailnet.ts.net
+dgx_tailnet_host: ${DGX_TAILNET_HOST:-your-dgx.tailnet.ts.net}
 # Registry-driven choice (`tailnet_dgx_whisper_openai` in
 # src/podcast_scraper/providers/ml/model_registry.py).
 #

--- a/config/profiles/local_dgx_balanced.yaml
+++ b/config/profiles/local_dgx_balanced.yaml
@@ -1,9 +1,14 @@
+# 2026-06-12 (#907 Option B): opted into registry-driven defaults.
+# See tests/integration/providers/ml/test_profile_yaml_registry_drift.py.
+
+profile: local_dgx_balanced
+
 # Profile: local_dgx_balanced — DGX-hosted Ollama with cloud degradation fallback (RFC-089)
 #
 # Point ollama_api_base / dgx_tailnet_host at your DGX MagicDNS name before running.
 # See docs/guides/DGX_RUNBOOK.md.
 
-dgx_tailnet_host: your-dgx.tailnet.ts.net
+dgx_tailnet_host: ${DGX_TAILNET_HOST:-your-dgx.tailnet.ts.net}
 ollama_api_base: http://your-dgx.tailnet.ts.net:11434/v1
 
 transcription_provider: whisper

--- a/config/profiles/local_dgx_full.yaml
+++ b/config/profiles/local_dgx_full.yaml
@@ -1,8 +1,13 @@
+# 2026-06-12 (#907 Option B): opted into registry-driven defaults.
+# See tests/integration/providers/ml/test_profile_yaml_registry_drift.py.
+
+profile: local_dgx_full
+
 # Profile: local_dgx_full — pure DGX measurement profile (no cloud fallback in config)
 #
 # For autoresearch / comparison runs only. Do not use for prod or pre-prod pipelines.
 
-dgx_tailnet_host: your-dgx.tailnet.ts.net
+dgx_tailnet_host: ${DGX_TAILNET_HOST:-your-dgx.tailnet.ts.net}
 ollama_api_base: http://your-dgx.tailnet.ts.net:11434/v1
 
 transcription_provider: whisper

--- a/docs/guides/EXPERIMENT_GUIDE.md
+++ b/docs/guides/EXPERIMENT_GUIDE.md
@@ -1707,6 +1707,31 @@ pipeline will keep running the previous defaults.
    `resolve_profile_to_settings(name)` and asserts the expected
    provider/model/endpoint triple. Catches accidental drift.
 
+### Step 6b: Verify the runtime actually sees the change
+
+`make profile-drift-check` runs the test that asserts every
+`config/profiles/*.yaml` declaring a `profile: <preset>` field agrees with
+its registry preset on routing (`transcription_provider`,
+`summary_provider`, `summary_model`). Run it locally after a registry edit:
+
+```bash
+make profile-drift-check
+```
+
+The check is also wired into `make ci-fast`, so CI will fail loudly if a
+profile YAML drifts from its declared preset. When it fails, you have two
+options:
+
+- **Update the YAML** to match the new registry default — this is what the
+  materialize-decisions flow normally expects.
+- **Update the registry** (with a new `research_ref` + `headline_metric`)
+  if the YAML was the deliberate choice. The eval-report-justified change
+  is the source of truth; the YAML must follow.
+
+Profile YAMLs that don't declare `profile:` are silently skipped — the
+drift check only applies to YAMLs that have opted in. Opting a new YAML
+in is a one-line edit at the top of the file.
+
 ### Why this step exists
 
 Before this discipline, eval reports documented decisions that the runtime

--- a/docs/wip/NEXT_BATCH_REGISTRY_RUNTIME.md
+++ b/docs/wip/NEXT_BATCH_REGISTRY_RUNTIME.md
@@ -7,6 +7,89 @@
 
 ---
 
+## Step 0 — codecov.yml that matches the coverage source filter
+
+**Why this is first**: PR #975 landed with `codecov/patch fail (55%)` even
+though `make ci-fast` was green. The root cause is that
+`[tool.coverage.run] source = ["podcast_scraper"]` in `pyproject.toml`
+correctly excludes `scripts/` and `infra/` from measurement, but the repo
+has no `codecov.yml`, so Codecov's default treats those out-of-source
+diff lines as uncovered for patch-coverage purposes. PR #975 added 224
+lines of script/infra Python which got counted as 0/224, dragging the
+patch ratio down to 55%. Every future PR that touches an eval driver or
+the pyinfra deploy will hit the same false-fail.
+
+The fix is a 15-line config file that mirrors `pyproject.toml`'s
+existing source filter into Codecov's view.
+
+### File: `codecov.yml` (NEW, repo root)
+
+```yaml
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%   # allow small variation; matches existing CI policy
+    patch:
+      default:
+        target: 77.47%  # current project's patch target (the threshold #975 hit)
+        # Ignore paths that pyproject.toml's [tool.coverage.run] source
+        # filter excludes. Without this, codecov counts their added lines
+        # as 0% covered on every PR diff, regardless of test thoroughness.
+
+ignore:
+  # These match `source = ["podcast_scraper"]` in pyproject.toml.
+  - "scripts/**"
+  - "infra/**"
+  - "tests/**"
+  - "tools/**"
+  - "docs/**"
+  - "config/**"
+  - "web/**"
+  - "**.md"
+  - "**.yaml"
+  - "**.yml"
+  - "**.j2"
+
+# Comment behavior: brief, only after first push. Keeps PR conversations clean.
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+```
+
+### Verification path
+
+1. Apply the config above.
+2. Open a tiny test PR that touches only a `scripts/eval/*.py` file — verify Codecov posts patch=100% (nothing counted; out of scope) rather than 0%.
+3. Run `make ci-fast` locally to confirm coverage % under `[tool.coverage.report]` is unchanged (this is local coverage.py, not Codecov — the change is purely Codecov-side).
+
+### What this is NOT
+
+- Not a global coverage threshold bump. `[tool.coverage.run]` and the
+  per-test-type `--cov-fail-under` settings in the Makefile stay
+  unchanged.
+- Not a way to hide actual uncovered production code. Files under
+  `src/podcast_scraper/` are still fully measured; the ignore list
+  only mirrors what's already excluded by `pyproject.toml`.
+
+### Acceptance
+
+- [ ] `codecov.yml` exists at repo root with the above content.
+- [ ] Open a small follow-up PR after the registry-runtime work that
+      touches at least one `scripts/eval/*.py` line; codecov/patch
+      passes with 100% (or whatever the actual src/ patch hit-rate is)
+      instead of being dragged down by the script lines.
+- [ ] No new tests required for the fix itself — it's a CI config
+      that catches the existing tests correctly.
+
+### Estimated effort
+
+~15 min including the verification PR.
+
+---
+
 ## Why
 
 #975 set up the registry as canonical: every `StageOption` carries `research_ref`, every `ProfilePreset` names one option per stage, and `resolve_profile_to_settings(name)` returns a flat dict the pipeline could ingest.

--- a/scripts/tools/resolve_profile.py
+++ b/scripts/tools/resolve_profile.py
@@ -1,0 +1,115 @@
+"""Print the resolved settings dict for a registry profile preset.
+
+Ops-debug tool for the #907 registry-driven config flow. Given a profile
+name (e.g. ``cloud_with_dgx_primary``), prints what
+``resolve_profile_to_settings()`` returns — the same dict that ``Config``
+layers under the YAML / explicit data when constructing a config.
+
+Useful for:
+- Confirming a registry edit produced the routing you intended before
+  rebuilding the pipeline image.
+- Debugging "what would the runtime pick up if I set ``profile: X``?"
+  without touching the actual pipeline.
+- Sanity-checking that ``DGX_TAILNET_HOST`` env-var threading produces
+  the expected endpoint URL on a given operator machine.
+
+Usage::
+
+    python scripts/tools/resolve_profile.py cloud_with_dgx_primary
+    DGX_TAILNET_HOST=my-dgx.tailnet.ts.net \\
+        python scripts/tools/resolve_profile.py local_dgx_balanced
+    python scripts/tools/resolve_profile.py --list
+
+Or via the make target::
+
+    make profile-resolve PROFILE=cloud_with_dgx_primary
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict
+
+from podcast_scraper.providers.ml.model_registry import (
+    _PROFILE_PRESETS,
+    resolve_profile_to_settings,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "profile",
+        nargs="?",
+        help="Registry profile preset name (e.g. cloud_with_dgx_primary).",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Print available preset names and exit.",
+    )
+    parser.add_argument(
+        "--dgx-tailnet-host",
+        default=None,
+        help=(
+            "Override DGX Tailscale MagicDNS host (otherwise reads "
+            "DGX_TAILNET_HOST env var; falls back to a sentinel hostname)."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "table"),
+        default="table",
+        help="Output format. ``table`` is human-readable; ``json`` is machine-parseable.",
+    )
+    return parser
+
+
+def _render_table(settings: Dict[str, Any]) -> str:
+    width = max((len(k) for k in settings), default=0)
+    lines = []
+    # Group metadata (underscore-prefixed) at the bottom for legibility.
+    payload = {k: v for k, v in settings.items() if not k.startswith("_")}
+    metadata = {k: v for k, v in settings.items() if k.startswith("_")}
+    for key in sorted(payload):
+        lines.append(f"  {key:<{width}}  {payload[key]!r}")
+    if metadata:
+        lines.append("")
+        lines.append("  metadata:")
+        for key in sorted(metadata):
+            lines.append(f"    {key:<{width}}  {metadata[key]!r}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.list:
+        for name in sorted(_PROFILE_PRESETS):
+            print(name)
+        return 0
+    if not args.profile:
+        print("error: profile name required (or pass --list)", file=sys.stderr)
+        return 2
+    if args.profile not in _PROFILE_PRESETS:
+        print(
+            f"error: unknown profile {args.profile!r}. " f"Known: {sorted(_PROFILE_PRESETS)}",
+            file=sys.stderr,
+        )
+        return 2
+    host = args.dgx_tailnet_host or os.environ.get("DGX_TAILNET_HOST")
+    settings = resolve_profile_to_settings(args.profile, dgx_tailnet_host=host)
+    if args.format == "json":
+        print(json.dumps(settings, indent=2, sort_keys=True))
+    else:
+        print(f"Profile: {args.profile}")
+        print(f"DGX host: {host or '(unset — sentinel fallback)'}")
+        print()
+        print(_render_table(settings))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/podcast_scraper/config.py
+++ b/src/podcast_scraper/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import threading
 import warnings
 from datetime import date
@@ -646,6 +647,56 @@ OPERATOR_ONLY_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
 # accept these names too. Add a new key here whenever a new nested-form
 # rewrite lands (see ``_flatten_dgx_stage_routing`` for ``transcription``).
 NESTED_PROFILE_TOP_LEVEL_KEYS: frozenset[str] = frozenset({"transcription"})
+
+
+_ENV_VAR_PATTERN = re.compile(
+    r"""\$\{                       # opening ${
+        (?P<name>[A-Za-z_][A-Za-z0-9_]*)
+        (?::-(?P<default>[^}]*))?  # optional :- default
+    \}""",
+    re.VERBOSE,
+)
+
+
+def _expand_env_in_string(value: str) -> str:
+    """Substitute ``${VAR}`` and ``${VAR:-default}`` in a single string.
+
+    Supports the bash-style ``:-`` form: if VAR is unset *or empty*, use
+    the default; otherwise use VAR's value. Operator-facing YAMLs use this
+    to keep hostnames / API keys out of git while still having a sensible
+    no-env fallback for ``--config`` smoke tests.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group("name")
+        default = match.group("default")
+        env_val = os.environ.get(name)
+        if env_val:
+            return env_val
+        if default is not None:
+            return default
+        # No env var, no default — keep the literal so misconfiguration
+        # surfaces loudly downstream rather than silently expanding to "".
+        return match.group(0)
+
+    return _ENV_VAR_PATTERN.sub(_replace, value)
+
+
+def _expand_env_vars(data: Any) -> Any:
+    """Recursively expand ``${VAR}`` / ``${VAR:-default}`` in a parsed YAML/JSON tree.
+
+    Applied to dict/list/string nodes only; other scalars pass through.
+    Returns a NEW structure (does not mutate input). Used by ``Config``'s
+    profile loader and the standalone ``_load_config_file`` so every YAML
+    config that enters the runtime gets the same substitution semantics.
+    """
+    if isinstance(data, dict):
+        return {k: _expand_env_vars(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_expand_env_vars(v) for v in data]
+    if isinstance(data, str):
+        return _expand_env_in_string(data)
+    return data
 
 
 class Config(BaseModel):
@@ -3061,12 +3112,18 @@ class Config(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _resolve_profile(cls, data: Any) -> Any:
-        """Resolve ``profile`` field: load named preset, merge as defaults (#593).
+        """Resolve ``profile`` field with layered defaults (#593, #907).
 
-        If ``profile: cloud_balanced`` is set, loads
-        ``config/profiles/cloud_balanced.yaml`` and merges its values as
-        defaults — explicit fields in ``data`` override profile defaults.
-        The ``profile`` key is consumed and not passed to Pydantic fields.
+        Cascade (highest wins):
+          1. Explicit fields in ``data`` (CLI args, env vars, code-level kwargs).
+          2. Profile YAML at ``config/profiles/<name>.yaml`` (operator policy).
+          3. Registry preset from ``model_registry._PROFILE_PRESETS`` via
+             ``resolve_profile_to_settings(name, dgx_tailnet_host=...)``
+             (research-driven defaults — only fields Config knows about).
+
+        Either the YAML file or the registry preset may be missing; if both
+        are missing the profile name is logged and ignored. The ``profile``
+        key itself is consumed and not passed to Pydantic fields.
         """
         if not isinstance(data, dict):
             return data
@@ -3077,10 +3134,32 @@ class Config(BaseModel):
             return cls._merge_audio_preprocessing_preset(data)
 
         profile_name = str(profile_name).strip()
-        # Resolve profile YAML path
+
+        # Layer 3: registry preset (broadest defaults — research-driven).
+        # Filtered to fields Config actually declares, so resolver outputs
+        # like ``transcription_endpoint`` that have no matching Config field
+        # are dropped silently rather than tripping ``extra="forbid"``.
+        registry_settings: Dict[str, Any] = {}
+        try:
+            from podcast_scraper.providers.ml.model_registry import (
+                resolve_profile_to_settings,
+            )
+
+            raw = resolve_profile_to_settings(
+                profile_name,
+                dgx_tailnet_host=data.get("dgx_tailnet_host"),
+            )
+            config_field_names = set(cls.model_fields.keys())
+            registry_settings = {
+                k: v for k, v in raw.items() if not k.startswith("_") and k in config_field_names
+            }
+        except ValueError:
+            # Not a registry preset — YAML-only mode (existing behaviour).
+            pass
+
+        # Layer 2: profile YAML at config/profiles/<name>.yaml.
         from pathlib import Path
 
-        # Try config/profiles/ relative to project root, then package resources
         candidates = [
             Path("config/profiles") / f"{profile_name}.yaml",
             Path(__file__).parent.parent.parent / "config" / "profiles" / f"{profile_name}.yaml",
@@ -3091,22 +3170,28 @@ class Config(BaseModel):
                 profile_path = c
                 break
 
-        if profile_path is None:
+        profile_dict: Dict[str, Any] = {}
+        if profile_path is not None:
+            import yaml
+
+            profile_dict = yaml.safe_load(profile_path.read_text(encoding="utf-8")) or {}
+            profile_dict = _expand_env_vars(profile_dict)
+            # The YAML itself may declare ``profile:`` (the registry opt-in).
+            # That meta-key must not leak into the merged dict — Config has
+            # ``extra="forbid"`` and has no ``profile`` field.
+            profile_dict.pop("profile", None)
+        elif not registry_settings:
             import logging
 
             logging.getLogger(__name__).warning(
-                "Profile '%s' not found in config/profiles/; ignoring", profile_name
+                "Profile '%s' not found in registry or config/profiles/; ignoring",
+                profile_name,
             )
-            # Still resolve audio preset if set directly on data.
             return cls._merge_audio_preprocessing_preset(data)
 
-        # Load profile YAML
-        import yaml
-
-        profile_dict = yaml.safe_load(profile_path.read_text(encoding="utf-8")) or {}
-
-        # Merge: profile provides defaults, explicit data overrides
-        merged = dict(profile_dict)
+        # Merge registry < YAML < explicit data.
+        merged: Dict[str, Any] = dict(registry_settings)
+        merged.update(profile_dict)
         merged.update(data)  # explicit fields win
 
         # After deployment profile resolution, also resolve
@@ -3166,6 +3251,7 @@ class Config(BaseModel):
         import yaml
 
         preset_dict = yaml.safe_load(preset_path.read_text(encoding="utf-8")) or {}
+        preset_dict = _expand_env_vars(preset_dict)
         merged = dict(preset_dict)
         merged.update(data)
         return merged
@@ -5433,4 +5519,5 @@ def load_config_file(
     if not isinstance(data, dict):
         raise ValueError("Config file must contain a mapping/object at the top level")
 
-    return data
+    expanded = _expand_env_vars(data)
+    return cast(Dict[str, Any], expanded)

--- a/src/podcast_scraper/providers/ml/model_registry.py
+++ b/src/podcast_scraper/providers/ml/model_registry.py
@@ -921,6 +921,32 @@ _SUMMARY_OPTIONS: Dict[str, StageOption] = {
 }
 
 
+# --- GI / KG / NER / clustering stages — scaffolding (#907 follow-up) -------
+#
+# Empty by design. The structure exists so future eval reports can register
+# their winners here following the same materialize-decisions discipline as
+# transcription + summary above. NEVER add entries here without a
+# ``research_ref`` pointing at an eval report that justifies the choice — the
+# whole point of this registry is that every default is backed by measured
+# evidence, not opinion.
+#
+# When a GI / KG / NER / clustering eval lands:
+#   1. Add the winning option as a StageOption (with research_ref, headline_metric).
+#   2. Extend ProfilePreset (below) to name a default per profile.
+#   3. Update resolve_profile_to_settings() to surface the new stage's fields.
+#   4. Add a drift test row for the new fields in
+#      tests/integration/providers/ml/test_profile_yaml_registry_drift.py.
+#
+# Until then, profile YAMLs continue to be the source of truth for these
+# stages; the runtime reads them directly. This is fine — the registry only
+# pretends to be canonical for stages where the materialize-decisions flow
+# has actually run.
+_GI_OPTIONS: Dict[str, StageOption] = {}
+_KG_OPTIONS: Dict[str, StageOption] = {}
+_NER_OPTIONS: Dict[str, StageOption] = {}
+_CLUSTERING_OPTIONS: Dict[str, StageOption] = {}
+
+
 @dataclass(frozen=True)
 class ProfilePreset:
     """A named composition of StageOptions — the registry-driven view of a profile.
@@ -1001,6 +1027,26 @@ def get_summary_option(option_id: str) -> StageOption:
     return _SUMMARY_OPTIONS[option_id]
 
 
+def get_gi_options() -> Dict[str, StageOption]:
+    """All registered GI options (id → StageOption). Empty until eval lands (#907)."""
+    return dict(_GI_OPTIONS)
+
+
+def get_kg_options() -> Dict[str, StageOption]:
+    """All registered KG options (id → StageOption). Empty until eval lands (#907)."""
+    return dict(_KG_OPTIONS)
+
+
+def get_ner_options() -> Dict[str, StageOption]:
+    """All registered NER options (id → StageOption). Empty until eval lands (#907)."""
+    return dict(_NER_OPTIONS)
+
+
+def get_clustering_options() -> Dict[str, StageOption]:
+    """All registered clustering options (id → StageOption). Empty until eval lands (#907)."""
+    return dict(_CLUSTERING_OPTIONS)
+
+
 def get_profile_preset(name: str) -> ProfilePreset:
     """Look up a profile preset by name. The canonical source for profile YAMLs."""
     if name not in _PROFILE_PRESETS:
@@ -1036,12 +1082,22 @@ def resolve_endpoint(
     return template.format(dgx_tailnet_host=host)
 
 
-def resolve_profile_to_settings(name: str) -> Dict[str, Any]:
+def resolve_profile_to_settings(
+    name: str,
+    dgx_tailnet_host: Optional[str] = None,
+) -> Dict[str, Any]:
     """Resolve a profile preset to the runtime settings the pipeline expects.
 
     Returns a flat dict the Config can ingest. Profile YAMLs become thin
-    viewers — eventually a YAML reads `profile: cloud_with_dgx_primary` and
-    this resolver fills in the rest.
+    viewers — a YAML reads `profile: cloud_with_dgx_primary` and this
+    resolver fills in the rest at validation time.
+
+    Args:
+        name: ProfilePreset name (e.g. "cloud_with_dgx_primary").
+        dgx_tailnet_host: optional explicit Tailscale host; threaded into
+            resolve_endpoint() for each stage option's endpoint template.
+            When None, the resolver's per-endpoint call falls back to the
+            DGX_TAILNET_HOST env var, then to the fail-fast sentinel.
     """
     preset = get_profile_preset(name)
     tx = get_transcription_option(preset.transcription)
@@ -1054,16 +1110,18 @@ def resolve_profile_to_settings(name: str) -> Dict[str, Any]:
         # Field name depends on provider — keeping the canonical mapping minimal here.
         # Consumers may need additional translation; this returns the registry view.
         settings.setdefault("transcription_model", tx.model)
-    if tx.endpoint is not None:
-        settings["transcription_endpoint"] = tx.endpoint
+    resolved_tx_endpoint = resolve_endpoint(tx.endpoint, dgx_tailnet_host)
+    if resolved_tx_endpoint is not None:
+        settings["transcription_endpoint"] = resolved_tx_endpoint
     if tx.extra_settings:
         settings["transcription_extra"] = dict(tx.extra_settings)
 
     settings["summary_provider"] = sm.provider
     if sm.model is not None:
         settings["summary_model"] = sm.model
-    if sm.endpoint is not None:
-        settings["summary_endpoint"] = sm.endpoint
+    resolved_sm_endpoint = resolve_endpoint(sm.endpoint, dgx_tailnet_host)
+    if resolved_sm_endpoint is not None:
+        settings["summary_endpoint"] = resolved_sm_endpoint
     if sm.extra_settings:
         settings["summary_extra"] = dict(sm.extra_settings)
 

--- a/tests/integration/providers/ml/test_model_registry_stage_options.py
+++ b/tests/integration/providers/ml/test_model_registry_stage_options.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 import pytest
 
 from podcast_scraper.providers.ml.model_registry import (
+    get_clustering_options,
+    get_gi_options,
+    get_kg_options,
+    get_ner_options,
     get_profile_preset,
     get_summary_option,
     get_summary_options,
@@ -62,6 +66,30 @@ class TestStageOptionRegistries:
             get_transcription_option("not-a-real-option")
         with pytest.raises(ValueError, match="Unknown summary option"):
             get_summary_option("not-a-real-option")
+
+
+class TestScaffoldedStageRegistries:
+    """GI / KG / NER / clustering stage registries are scaffolded empty.
+
+    The structure exists (so future eval reports can register winners), but
+    every entry MUST land with a research_ref. Until those evals run, the
+    registries stay empty — profile YAMLs are the source of truth for these
+    stages. The presence-but-emptiness is the explicit invariant; this test
+    breaks loudly if someone slips in an entry without going through the
+    materialize-decisions discipline.
+    """
+
+    def test_gi_registry_empty(self) -> None:
+        assert get_gi_options() == {}
+
+    def test_kg_registry_empty(self) -> None:
+        assert get_kg_options() == {}
+
+    def test_ner_registry_empty(self) -> None:
+        assert get_ner_options() == {}
+
+    def test_clustering_registry_empty(self) -> None:
+        assert get_clustering_options() == {}
 
 
 class TestProfilePresets:
@@ -181,3 +209,34 @@ class TestResolveEndpoint:
         assert url is not None
         assert "explicit-dgx" in url
         assert "env-dgx" not in url
+
+
+class TestResolveProfileToSettingsHostThreading:
+    """Covers the dgx_tailnet_host arg added to resolve_profile_to_settings()."""
+
+    def test_explicit_host_arg_threads_through(self) -> None:
+        settings = resolve_profile_to_settings(
+            "cloud_with_dgx_primary",
+            dgx_tailnet_host="my-dgx.example.ts.net",
+        )
+        # Both transcription + summary endpoints (when present) should have
+        # the host substituted.
+        if "transcription_endpoint" in settings:
+            assert "my-dgx.example.ts.net" in settings["transcription_endpoint"]
+            assert "{dgx_tailnet_host}" not in settings["transcription_endpoint"]
+        if "summary_endpoint" in settings:
+            assert "{dgx_tailnet_host}" not in settings["summary_endpoint"]
+
+    def test_no_host_falls_back_to_sentinel(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.delenv("DGX_TAILNET_HOST", raising=False)
+        settings = resolve_profile_to_settings("cloud_with_dgx_primary")
+        # Endpoints carry the sentinel so downstream HTTP fails fast rather
+        # than silently routing to a placeholder hostname.
+        if "transcription_endpoint" in settings:
+            assert "REPLACE_ME_DGX_TAILNET_HOST" in settings["transcription_endpoint"]
+
+    def test_env_var_used_when_no_explicit_host(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("DGX_TAILNET_HOST", "env-dgx.example.ts.net")
+        settings = resolve_profile_to_settings("cloud_with_dgx_primary")
+        if "transcription_endpoint" in settings:
+            assert "env-dgx.example.ts.net" in settings["transcription_endpoint"]

--- a/tests/integration/providers/ml/test_model_registry_stage_options.py
+++ b/tests/integration/providers/ml/test_model_registry_stage_options.py
@@ -220,9 +220,12 @@ class TestResolveProfileToSettingsHostThreading:
             dgx_tailnet_host="my-dgx.example.ts.net",
         )
         # Both transcription + summary endpoints (when present) should have
-        # the host substituted.
+        # the host substituted. Use urlparse for anchored hostname check —
+        # CodeQL flags bare substring containment as py/incomplete-url-substring-sanitization.
+        from urllib.parse import urlparse
+
         if "transcription_endpoint" in settings:
-            assert "my-dgx.example.ts.net" in settings["transcription_endpoint"]
+            assert urlparse(settings["transcription_endpoint"]).hostname == "my-dgx.example.ts.net"
             assert "{dgx_tailnet_host}" not in settings["transcription_endpoint"]
         if "summary_endpoint" in settings:
             assert "{dgx_tailnet_host}" not in settings["summary_endpoint"]
@@ -236,7 +239,11 @@ class TestResolveProfileToSettingsHostThreading:
             assert "REPLACE_ME_DGX_TAILNET_HOST" in settings["transcription_endpoint"]
 
     def test_env_var_used_when_no_explicit_host(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        from urllib.parse import urlparse
+
         monkeypatch.setenv("DGX_TAILNET_HOST", "env-dgx.example.ts.net")
         settings = resolve_profile_to_settings("cloud_with_dgx_primary")
         if "transcription_endpoint" in settings:
-            assert "env-dgx.example.ts.net" in settings["transcription_endpoint"]
+            # Anchored hostname check (CodeQL: py/incomplete-url-substring-sanitization
+            # flags bare ``host in url`` patterns).
+            assert urlparse(settings["transcription_endpoint"]).hostname == "env-dgx.example.ts.net"

--- a/tests/integration/providers/ml/test_profile_yaml_registry_drift.py
+++ b/tests/integration/providers/ml/test_profile_yaml_registry_drift.py
@@ -1,0 +1,98 @@
+"""Drift detection: profile YAML routing must match the declared registry preset.
+
+When a YAML under ``config/profiles/`` declares a top-level ``profile:`` field
+that names a known ``_PROFILE_PRESETS`` entry, the YAML's routing fields must
+agree with what ``resolve_profile_to_settings(name, ...)`` returns. Otherwise
+the eval reports document a decision the runtime never adopts.
+
+Today most profile YAMLs do NOT declare ``profile:`` (they predate #907's
+runtime wiring). Those YAMLs are skipped — adding ``profile:`` to them is the
+opt-in for drift-checking.
+
+Adding a new profile preset to the registry without a matching YAML
+declaration is fine and won't trip this test. The test only fires once a YAML
+has explicitly opted in by declaring ``profile:``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+import yaml
+
+from podcast_scraper.providers.ml.model_registry import (
+    _PROFILE_PRESETS,
+    resolve_profile_to_settings,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.critical_path]
+
+_PROFILE_DIR = Path(__file__).resolve().parents[4] / "config" / "profiles"
+
+_ROUTING_FIELDS = (
+    "transcription_provider",
+    "summary_provider",
+    "summary_model",
+)
+
+
+def _opted_in_yamls() -> List[Tuple[Path, Dict[str, Any]]]:
+    """Yield (path, parsed_dict) for every YAML that declares a ``profile:`` field."""
+    opted_in: List[Tuple[Path, Dict[str, Any]]] = []
+    if not _PROFILE_DIR.is_dir():
+        return opted_in
+    for path in sorted(_PROFILE_DIR.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError:
+            continue
+        if isinstance(data, dict) and "profile" in data:
+            opted_in.append((path, data))
+    return opted_in
+
+
+_OPTED_IN = _opted_in_yamls()
+
+
+@pytest.mark.parametrize(
+    "path,data",
+    _OPTED_IN,
+    ids=[p.name for p, _ in _OPTED_IN] or ["no-opted-in-yamls"],
+)
+def test_profile_yaml_matches_registry_preset(path: Path, data: Dict[str, Any]) -> None:
+    """Every routing field present in the YAML must equal the registry's value."""
+    profile_name = data["profile"]
+    assert profile_name in _PROFILE_PRESETS, (
+        f"{path.name} declares profile={profile_name!r}, which is not in the "
+        f"registry. Known presets: {sorted(_PROFILE_PRESETS)}"
+    )
+    expected = resolve_profile_to_settings(profile_name, dgx_tailnet_host="drift-check.example")
+    for field in _ROUTING_FIELDS:
+        if field not in data:
+            continue  # YAML omits this field — registry default applies, no drift.
+        # nosec B608 — not SQL; just a multi-line f-string assert message.
+        msg = (
+            f"{path.name}: field {field!r} = {data[field]!r} disagrees with "  # nosec B608
+            f"registry preset {profile_name!r} "
+            f"(expected {expected.get(field)!r}). "
+            f"Update either the YAML or the registry preset "
+            f"(with new research_ref) to bring them back in sync."
+        )
+        assert data[field] == expected.get(field), msg
+
+
+def test_no_opted_in_yamls_is_self_documenting() -> None:
+    """Smoke test that surfaces an informative message if no YAML has opted in yet.
+
+    Without this, the parametrized test above generates a single ``no-opted-in-yamls``
+    case that silently passes — making the drift check look broken at a glance.
+    """
+    if not _OPTED_IN:
+        pytest.skip(
+            "No profile YAML declares `profile: <name>` yet — drift check is a no-op. "
+            "Opt in by adding `profile: <preset_name>` to a YAML under config/profiles/."
+        )
+    # When at least one YAML opts in, this test passes trivially.
+    assert _OPTED_IN

--- a/tests/unit/podcast_scraper/test_cli_profile_routing.py
+++ b/tests/unit/podcast_scraper/test_cli_profile_routing.py
@@ -219,9 +219,18 @@ class TestAllShippedProfilesRoundTripThroughCLI:
     ) -> None:
         import yaml
 
+        from podcast_scraper.config import _expand_env_vars
+
         with open(f"config/profiles/{profile_name}.yaml") as f:
+            # ``profile:`` is a meta-key consumed by ``Config._resolve_profile``
+            # (the #907 registry opt-in declaration); it never becomes a Config
+            # attribute, so the round-trip check must skip it just like ``rss``.
+            # ``_expand_env_vars`` applies the ``${VAR:-default}`` substitution
+            # so expectations match the post-load Config attribute.
             expected = {
-                k: v for k, v in yaml.safe_load(f).items() if not k.startswith("_") and k != "rss"
+                k: v
+                for k, v in _expand_env_vars(yaml.safe_load(f)).items()
+                if not k.startswith("_") and k not in ("rss", "profile")
             }
         args = parse_args(
             [

--- a/tests/unit/podcast_scraper/test_config_env_var_expansion.py
+++ b/tests/unit/podcast_scraper/test_config_env_var_expansion.py
@@ -1,0 +1,104 @@
+"""``${VAR}`` / ``${VAR:-default}`` expansion in YAML configs (#907 follow-up).
+
+Operator-facing YAMLs use this syntax to keep hostnames / API keys / secrets
+out of git. The expansion runs at YAML-load time inside ``Config``'s profile
+loader and inside ``_load_config_file`` so every YAML entry point gets the
+same substitution semantics.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.config import (
+    _expand_env_in_string,
+    _expand_env_vars,
+    Config,
+)
+
+
+class TestExpandEnvInString:
+    def test_set_var_substitutes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FOO", "bar")
+        assert _expand_env_in_string("prefix-${FOO}-suffix") == "prefix-bar-suffix"
+
+    def test_unset_var_with_default_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+        assert _expand_env_in_string("${MISSING_VAR:-fallback}") == "fallback"
+
+    def test_set_var_overrides_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HOST", "real-host.example")
+        result = _expand_env_in_string("${HOST:-default-host.example}")
+        assert result == "real-host.example"
+
+    def test_empty_var_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bash-style ``:-`` treats empty same as unset; matches operator
+        intuition (an env file with ``HOST=`` should fall back, not produce
+        an empty hostname)."""
+        monkeypatch.setenv("HOST", "")
+        assert _expand_env_in_string("${HOST:-fallback}") == "fallback"
+
+    def test_unset_var_no_default_keeps_literal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unset variable with no default leaves the literal in place so
+        downstream failures surface loudly rather than collapsing to ``""``."""
+        monkeypatch.delenv("UNSET_VAR", raising=False)
+        assert _expand_env_in_string("${UNSET_VAR}") == "${UNSET_VAR}"
+
+    def test_multiple_vars_per_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("USER", "marko")
+        monkeypatch.setenv("DOMAIN", "example.com")
+        assert _expand_env_in_string("${USER}@${DOMAIN}") == "marko@example.com"
+
+    def test_non_var_string_passes_through(self) -> None:
+        assert _expand_env_in_string("plain text") == "plain text"
+        assert _expand_env_in_string("path/with/$dollars/but/no/braces") == (
+            "path/with/$dollars/but/no/braces"
+        )
+
+
+class TestExpandEnvVarsRecursive:
+    def test_nested_dict_and_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HOST", "h.example")
+        monkeypatch.setenv("PORT", "8002")
+        data = {
+            "endpoint": "http://${HOST}:${PORT}/v1",
+            "fallbacks": ["${HOST}", "static-value"],
+            "nested": {"inner": "${HOST:-fallback}"},
+            "untouched_int": 42,
+            "untouched_bool": True,
+        }
+        expanded = _expand_env_vars(data)
+        assert expanded == {
+            "endpoint": "http://h.example:8002/v1",
+            "fallbacks": ["h.example", "static-value"],
+            "nested": {"inner": "h.example"},
+            "untouched_int": 42,
+            "untouched_bool": True,
+        }
+        # Original not mutated.
+        assert data["endpoint"] == "http://${HOST}:${PORT}/v1"
+
+
+class TestEnvVarExpansionInConfigLoad:
+    @pytest.fixture
+    def _fake_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for name in ("GEMINI_API_KEY", "OPENAI_API_KEY"):
+            monkeypatch.setenv(name, "test-dummy")
+
+    def test_dgx_tailnet_host_env_var_expands_in_profile_yaml(
+        self, _fake_keys: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When DGX_TAILNET_HOST is set, the profile's
+        ``${DGX_TAILNET_HOST:-…}`` template substitutes to the env value."""
+        monkeypatch.setenv("DGX_TAILNET_HOST", "my-real-dgx.tailnet.ts.net")
+        cfg = Config.model_validate({"profile": "cloud_with_dgx_primary"})
+        assert cfg.dgx_tailnet_host == "my-real-dgx.tailnet.ts.net"
+
+    def test_dgx_tailnet_host_default_when_env_unset(
+        self, _fake_keys: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When DGX_TAILNET_HOST is unset, the YAML's ``:-`` default kicks in.
+        Currently ``your-dgx.tailnet.ts.net`` — the sanitized placeholder."""
+        monkeypatch.delenv("DGX_TAILNET_HOST", raising=False)
+        cfg = Config.model_validate({"profile": "cloud_with_dgx_primary"})
+        assert cfg.dgx_tailnet_host == "your-dgx.tailnet.ts.net"

--- a/tests/unit/podcast_scraper/test_config_registry_profile.py
+++ b/tests/unit/podcast_scraper/test_config_registry_profile.py
@@ -1,0 +1,86 @@
+"""Registry-layered profile resolution on ``Config`` (#907 Option B).
+
+Covers the 2026-06-12 amendment to ``Config._resolve_profile`` that layers
+``resolve_profile_to_settings()`` UNDER the existing YAML-profile loader.
+
+Resolution order (highest wins):
+  1. Explicit fields in the caller's dict / CLI args.
+  2. Profile YAML at ``config/profiles/<name>.yaml``.
+  3. Registry preset (``model_registry._PROFILE_PRESETS``) — research-driven
+     defaults filtered to Config field names.
+
+These tests pin the precedence semantics and the field-filter behaviour
+that prevents ``extra="forbid"`` from rejecting resolver-only keys.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_scraper.config import Config
+
+
+@pytest.fixture
+def _fake_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "DEEPGRAM_API_KEY",
+    ):
+        monkeypatch.setenv(name, "test-dummy")
+
+
+class TestRegistryLayering:
+    """The registry resolver fills in routing fields when the YAML omits them."""
+
+    def test_registry_routing_applies_under_yaml(self, _fake_keys: None) -> None:
+        """Loading by profile name surfaces registry-driven routing.
+
+        ``cloud_with_dgx_primary`` is in ``_PROFILE_PRESETS``; its
+        ``transcription_provider`` should be ``tailnet_dgx_whisper`` per
+        the registry, regardless of what the YAML happens to set.
+        """
+        cfg = Config.model_validate({"profile": "cloud_with_dgx_primary"})
+        # Either the YAML or the registry must provide this; both currently
+        # agree, so we assert the post-merge value (registry-driven default
+        # when the YAML is empty, YAML override when explicit).
+        assert cfg.transcription_provider == "tailnet_dgx_whisper"
+
+    def test_explicit_field_overrides_registry(self, _fake_keys: None) -> None:
+        """Explicit data wins over registry defaults (layer 1 > layer 3).
+
+        Uses ``cloud_balanced`` (flat ``transcription_provider:`` in the YAML)
+        rather than ``cloud_with_dgx_primary`` because the latter uses a
+        nested ``transcription: {primary, fallback}`` block that gets
+        flattened AFTER the explicit-data merge — masking the precedence
+        signal we want to assert.
+        """
+        # cloud_balanced registry default for summary is gemini-2.5-flash-lite;
+        # override to a different gemini model to exercise the precedence path.
+        cfg = Config.model_validate(
+            {
+                "profile": "cloud_balanced",
+                "summary_provider": "openai",  # override registry's 'gemini'
+            }
+        )
+        assert cfg.summary_provider == "openai"
+
+    def test_unknown_profile_name_is_warned_not_errored(
+        self, _fake_keys: None, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A profile name absent from BOTH registry and config/profiles/
+        logs a warning and falls back to Pydantic field defaults."""
+        with caplog.at_level("WARNING"):
+            cfg = Config.model_validate({"profile": "definitely-not-a-real-profile"})
+        assert "not found" in caplog.text.lower()
+        # Field defaults still apply; Config still constructs cleanly.
+        assert cfg is not None
+
+    def test_resolver_only_keys_are_dropped_not_rejected(self, _fake_keys: None) -> None:
+        """Resolver emits keys like ``transcription_endpoint`` that Config
+        doesn't have. Those must be filtered out before Pydantic sees them
+        (Config has ``extra="forbid"``)."""
+        # Construction must not raise.
+        cfg = Config.model_validate({"profile": "cloud_with_dgx_primary"})
+        assert not hasattr(cfg, "transcription_endpoint")


### PR DESCRIPTION
## Summary

- Wire `resolve_profile_to_settings()` into `Config` so registry presets are the research-driven defaults the runtime actually adopts (cascade: explicit > YAML > registry > Pydantic). Drift becomes a CI failure via `make profile-drift-check`.
- All 5 shipped profile YAMLs (`cloud_balanced`, `cloud_thin`, `cloud_with_dgx_primary`, `local_dgx_balanced`, `local_dgx_full`) declare `profile: <name>` and pass the drift gate.
- Folded in 4 originally-out-of-scope items:
  - **codecov.yml** — mirrors `pyproject.toml`'s coverage source filter so future PRs touching `scripts/` or `infra/` don't false-fail on patch coverage (PR #975 hit 55% from exactly this).
  - **Env-var expansion** — `${VAR}` / `${VAR:-default}` in every YAML load path; DGX profile YAMLs use `${DGX_TAILNET_HOST:-your-dgx.tailnet.ts.net}` so the operator hostname stays out of git.
  - **`make profile-resolve PROFILE=<name>`** — operator CLI that prints the resolved settings dict (ops debug + dry-run).
  - **GI / KG / NER / clustering registry scaffolds** — empty `Dict[str, StageOption]` registries + getters. Tests assert emptiness so entries can only land with an eval-report `research_ref` (preserves the materialize-decisions discipline).

## Plan

`docs/wip/NEXT_BATCH_REGISTRY_RUNTIME.md` — Step 0 (codecov) → Step 10 (push).

## Test plan

- [x] `make profile-drift-check` — 6 passes (5 opted-in YAMLs + self-doc test)
- [x] `tests/unit/podcast_scraper/test_config_registry_profile.py` — 4 new tests covering registry layering, explicit override precedence, resolver-only key filtering
- [x] `tests/unit/podcast_scraper/test_config_env_var_expansion.py` — 10 new tests covering `${VAR}` / `${VAR:-default}` semantics + integration with profile load
- [x] `tests/integration/providers/ml/test_model_registry_stage_options.py` — extended with 4 emptiness asserts for the GI/KG/NER/clustering scaffolds
- [x] `tests/integration/providers/ml/test_profile_yaml_registry_drift.py` — discovery-based drift test (NEW)
- [x] `make ci-fast` — green
- [ ] After merge: verify `codecov/patch` no longer false-fails on scripts/infra-only diffs
- [ ] Operator-side smoke: run pipeline with `profile: cloud_with_dgx_primary` and confirm transcription routes to `:8002` (whisper-openai) as before

## Out of scope (next batches)

- First `_GI_OPTIONS` / `_KG_OPTIONS` / `_NER_OPTIONS` / `_CLUSTERING_OPTIONS` entries — pending v2 eval reports per stage
- #970 Cell E (Ollama Qwen3.6 bf16) — deferred, blocked on DGX availability
- #876 prod re-diarization — parked until 2.7 ship
- Wave audio review fixes (`docs/wip/AUDIO-WAVES-HARDENING-AUDIT.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)