### PR TITLE
chore(scripts): resolve_profile.py UX + codecov.yml verification

### DIFF
--- a/scripts/tools/resolve_profile.py
+++ b/scripts/tools/resolve_profile.py
@@ -91,7 +91,8 @@ def main(argv: list[str] | None = None) -> int:
             print(name)
         return 0
     if not args.profile:
-        print("error: profile name required (or pass --list)", file=sys.stderr)
+        print("error: profile name required (or pass --list).", file=sys.stderr)
+        print(f"Available: {sorted(_PROFILE_PRESETS)}", file=sys.stderr)
         return 2
     if args.profile not in _PROFILE_PRESETS:
         print(


### PR DESCRIPTION
## Summary

- Small UX polish to \`scripts/tools/resolve_profile.py\`: when invoked with no profile name, also print the available preset list to stderr (saves a second \`--list\` invocation).
- **Purpose**: verify the \`codecov.yml\` shipped in PR #977 (commit \`151922bf\`) correctly excludes \`scripts/**\` from patch-coverage measurement.

PR #975 hit a 55% patch-coverage false-fail because it added ~224 lines of \`scripts/\` and \`infra/\` Python that codecov counted as 0% covered. PR #977 added a 15-line \`codecov.yml\` mirroring \`pyproject.toml\`'s coverage source filter. This PR is the smallest possible test of that fix — a single touched script file, no test changes, no \`src/\` changes.

**Expected outcome**:
- \`codecov/patch\` — pass (no measured lines in the diff, so the gate is a no-op)
- \`codecov/project\` — unchanged (no \`src/\` lines changed)

If \`codecov/patch\` instead fails at 0% or fails for any reason, the \`codecov.yml\` ignore list needs another iteration.

## Test plan

- [ ] Wait for codecov to post; confirm \`codecov/patch\` posts pass (or no patch report, equivalent to pass for a fully-ignored diff)
- [ ] If pass: merge, close the gap-verification work item
- [ ] If fail: diagnose, iterate on \`codecov.yml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)