### PR TITLE
fix(ci): grant packages:read so DR drill orchestrator loads (fixes scheduled startup_failure)

### DIFF
--- a/.github/workflows/drill-exercise.yml
+++ b/.github/workflows/drill-exercise.yml
@@ -45,6 +45,11 @@ on:
 permissions:
   contents: read
   actions: write
+  # drill-deploy (reusable) requests ``packages: read`` to pull the GHCR image; a caller
+  # cannot grant a reusable less than it requests, so the orchestrator must grant it too —
+  # otherwise the whole workflow fails to load (``packages: none`` < ``packages: read``,
+  # startup_failure on every trigger; #815 added drill-deploy but not this grant).
+  packages: read
   # drill-infra-plan (reusable) posts PR comments when permissions are evaluated for workflow_call.
   pull-requests: write
 


### PR DESCRIPTION
## Problem
`DR drill — exercise (orchestrated)` (`drill-exercise.yml`, Wed 02:00 UTC cron) has ended in **`startup_failure` with 0 jobs on every run since 2026-05-27** — silently dead for ~4 weeks. GitHub reported only *"likely a workflow file issue"* (startup failures create no check-runs/annotations, so it's invisible to `gh`/API).

## Root cause
The orchestrator's `deploy` job (L138) calls the reusable `drill-deploy.yml`, which declares `permissions: packages: read` (to pull the GHCR image). GitHub **forbids a caller from granting a reusable less permission than it requests**, and the orchestrator's top-level `permissions:` omitted `packages` (→ `packages: none` < `packages: read`). So the whole workflow was rejected as an invalid workflow file **before any job ran**, on every trigger. Introduced by #815 (`739d1c44`), which added `drill-deploy` + the cron but not the grant. (`26952c1f` fixed an unrelated required-input class earlier; this is the actual blocker.)

## Fix
Add `packages: read` to `drill-exercise.yml`'s top-level `permissions:`. One line; only `drill-deploy` requests `packages` among the reusables.

## Validation
Dispatched the workflow from this branch (`gh workflow run drill-exercise.yml --ref …`):
- **Before:** `startup_failure`, 0 jobs.
- **After:** loads and runs — `gate` ✅, `plan` started. Cancelled immediately so `apply` was **skipped** (no Hetzner infra provisioned); teardown ran harmlessly.

The next scheduled Wed 02:00 UTC run will now load; a full end-to-end drill can be run manually anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)