### PR TITLE
fix(infra): per-workspace Hetzner delete protection — drill destroyable, prod stays hardened

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -75,8 +75,9 @@ resource "hcloud_volume" "corpus" {
   # delete_protection — Hetzner refuses to delete the volume until this
   # is flipped to false in a prior apply. Corpus is the most expensive
   # thing to recreate (snapshots are weekly at best); worth the
-  # two-step ratchet to destroy.
-  delete_protection = true
+  # two-step ratchet to destroy. PROD keeps this true (default); the drill
+  # workspace sets enable_delete_protection=false so its teardown can destroy.
+  delete_protection = var.enable_delete_protection
 }
 
 # === The VPS itself ===
@@ -92,9 +93,11 @@ resource "hcloud_server" "prod" {
   # Hetzner with "protected: deletion/rebuild protection enabled" before
   # any destruction happens. To legitimately destroy the server (DR
   # drill, planned migration), first apply a change setting these to
-  # false, then run the destroy / wipe-then-apply.
-  delete_protection  = true
-  rebuild_protection = true
+  # false, then run the destroy / wipe-then-apply. PROD keeps these true
+  # (var default); the drill workspace sets enable_delete_protection=false
+  # so its automated teardown destroys instead of orphaning the server.
+  delete_protection  = var.enable_delete_protection
+  rebuild_protection = var.enable_delete_protection
 
   ssh_keys     = [hcloud_ssh_key.operator.id]
   firewall_ids = [hcloud_firewall.main.id]

--- a/infra/terraform/terraform.drill.ci.tfvars
+++ b/infra/terraform/terraform.drill.ci.tfvars
@@ -10,6 +10,11 @@
 manage_tailscale_acl     = false
 tailscale_advertise_tags = ["tag:dr-drill"]
 tailnet_hostname         = "dr-podcast"
+# Drill servers are ephemeral — disable Hetzner delete/rebuild protection so the
+# orchestrator's teardown (`tofu destroy`) can actually remove them. PROD keeps
+# protection on (var default true). Without this, destroy hits "server deletion is
+# protected" and orphans the drill server (observed 2026-06-17, run 27681998910).
+enable_delete_protection = false
 hcloud_environment_label = "drill"
 # Break-glass: public SSH while Tailscale join is broken or slow (narrow in a private tfvars).
 hcloud_inbound_ssh_troubleshoot_cidrs = ["0.0.0.0/0", "::/0"]

--- a/infra/terraform/terraform.drill.tfvars.example
+++ b/infra/terraform/terraform.drill.tfvars.example
@@ -8,6 +8,9 @@ manage_tailscale_acl     = false
 tailscale_advertise_tags = ["tag:dr-drill"]
 tailnet_hostname         = "dr-podcast"
 hcloud_environment_label = "drill"
+# Ephemeral drill infra must be destroyable by the automated teardown — disable
+# Hetzner delete/rebuild protection (PROD keeps it on via the var default).
+enable_delete_protection = false
 
 # Optional: allow inbound TCP/22 from these CIDRs for operator SSH when the tailnet is down.
 # CI uses 0.0.0.0/0 and ::/0 in terraform.drill.ci.tfvars; use your /32 here for a tighter drill VM.

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -96,6 +96,12 @@ variable "manage_tailscale_acl" {
   default     = true
 }
 
+variable "enable_delete_protection" {
+  type        = bool
+  description = "Hetzner delete/rebuild protection on the server + corpus volume. True (default) hardens PROD against accidental destroy/rebuild (post-2026-05-30 incident). Set false ONLY for the ephemeral drill workspace so its automated teardown (`tofu destroy`) can actually delete the drill server/volume instead of hitting \"server deletion is protected\" and orphaning infra — see infra/README.md \"DR drill workspace\"."
+  default     = true
+}
+
 variable "tailscale_advertise_tags" {
   type        = list(string)
   description = "Tailscale tags for tailscale_tailnet_key and for `tailscale up --advertise-tags` in cloud-init. Prod uses [\"tag:prod\"]; drill uses e.g. [\"tag:dr-drill\"] per tailscale/policy.hujson tagOwners."


### PR DESCRIPTION
## Problem
DR-drill `teardown` failed (run 27681998910) with `hcloud: server deletion is protected` → the drill server orphaned. Root cause: `main.tf` set `delete_protection`/`rebuild_protection` **unconditionally `true`**, so the ephemeral `drill` workspace inherited prod's post-incident hardening. The orchestrator teardown runs `tofu destroy` directly (it doesn't first apply a "protection off" change), so Hetzner rejects the delete.

## Fix (code only — nothing applied)
- New `variable "enable_delete_protection"` (bool, **default `true`**).
- `main.tf`: server `delete_protection`/`rebuild_protection` and the corpus volume `delete_protection` now read the var.
- `terraform.drill.ci.tfvars` (+ `.example`): set `enable_delete_protection = false`.

**Prod is unaffected** — no prod override exists, so it falls back to the `true` default and stays protected. Only the `drill` workspace flips to `false`, so its automated teardown can destroy its own server/volume.

## Validation
`tofu fmt -check` clean (offline — no `init`, no backend/state access, no apply/destroy). Not applied anywhere.

## Operator follow-up (infra — not done here)
The currently-orphaned drill server was created *with* protection. To clear it: apply the **drill** workspace (flips its protection to `false`), then `tofu destroy` — or toggle protection off in the Hetzner console. Prod is never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)