### PR TITLE
v2.7 observability batch: #803 control plane + #805 bootstrap + main-CI hotfix + deps

### DIFF
--- a/.github/workflows/autoresearch-eval-nightly.yml
+++ b/.github/workflows/autoresearch-eval-nightly.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, dgx-spark]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v6

--- a/.github/workflows/backup-corpus-prod.yml
+++ b/.github/workflows/backup-corpus-prod.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Checkout (resolver script; GH-744)
         if: steps.preflight.outputs.skip != 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/backup-corpus.yml
+++ b/.github/workflows/backup-corpus.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (manifest scripts)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,7 +70,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Checkout (resolver script; GH-744)
         if: steps.preflight.outputs.skip != 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -259,6 +259,11 @@ jobs:
             echo "- Container \`PODCAST_DEFAULT_CORPUS_PATH\` (smoke \`path=\`): \`$CONTAINER_CORPUS\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Record deploy start time (#803 D1)
+        id: deploy_t0
+        if: steps.preflight.outputs.skip != 'true'
+        run: echo "ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
       - name: Deploy (git reset + compose pull + compose up + VPS-local /api/health)
         # deploy.sh on the VPS exits 0 only on healthy stack — failures here
         # surface red within the SSH session. VPS-local probe is
@@ -340,3 +345,47 @@ jobs:
             echo "- Smoke probe \`path=\`: \`$CONTAINER_CORPUS\`"
           } >> "$GITHUB_STEP_SUMMARY"
           bash scripts/ops/post_deploy_smoke.sh "$PROBE_FQDN" --corpus-path "$CONTAINER_CORPUS"
+
+      - name: Emit deploy event to Loki (#803 D1)
+        # Pushed directly to Loki: the GHA runner's logs don't reach it. Fires on success AND
+        # failure (feeds the failure-rate / MTTR panels). Non-fatal — never turns a deploy red.
+        if: always() && steps.preflight.outputs.skip != 'true'
+        env:
+          LOKI_PUSH_URL: ${{ secrets.PROD_GRAFANA_CLOUD_LOKI_URL }}
+          LOKI_USER: ${{ secrets.PROD_GRAFANA_CLOUD_LOKI_USER }}
+          LOKI_TOKEN: ${{ secrets.PROD_GRAFANA_CLOUD_API_KEY }}
+          START_MS: ${{ steps.deploy_t0.outputs.ms }}
+          JOB_STATUS: ${{ job.status }}
+          SHA_SHORT: ${{ steps.sha.outputs.short }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          if [ -z "${LOKI_PUSH_URL:-}" ] || [ -z "${LOKI_TOKEN:-}" ]; then
+            echo "::warning::Grafana Loki creds absent; skipping deploy-event emission"
+            exit 0
+          fi
+          duration_ms=$(( $(date +%s%3N) - ${START_MS:-$(date +%s%3N)} ))
+          bash scripts/ops/emit_deploy_event.sh \
+            --status "$JOB_STATUS" --sha "$SHA_SHORT" \
+            --duration-ms "$duration_ms" --triggered-by "$ACTOR" \
+            || echo "::warning::deploy-event emission failed (non-fatal)"
+
+      - name: Mark Sentry release boundary (#803 D2)
+        # Draws the release boundary on the Sentry error timeline. Only on a fully green deploy.
+        # Needs secrets.SENTRY_AUTH_TOKEN (Internal Integration, Release: Admin) + vars.SENTRY_ORG.
+        if: success() && steps.preflight.outputs.skip != 'true'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECTS: ${{ vars.SENTRY_PROJECTS }}
+          SHA_SHORT: ${{ steps.sha.outputs.short }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SENTRY_AUTH_TOKEN:-}" ] || [ -z "${SENTRY_ORG:-}" ] || [ -z "${SENTRY_PROJECTS:-}" ]; then
+            echo "::warning::SENTRY_AUTH_TOKEN/SENTRY_ORG/SENTRY_PROJECTS absent; skipping Sentry release boundary"
+            exit 0
+          fi
+          bash scripts/ops/mark_sentry_release.sh \
+            --org "$SENTRY_ORG" --version "sha-$SHA_SHORT" \
+            --environment prod --projects "$SENTRY_PROJECTS" \
+            || echo "::warning::Sentry release boundary failed (non-fatal)"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Free disk space
       # #703: cold pipeline (ml) builds tip over the runner's free-disk
@@ -124,7 +124,7 @@ jobs:
             tag: podcast-scraper:test
             build_args: "INSTALL_EXTRAS=ml\nPRELOAD_ML_MODELS=true"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Free disk space
       # #703: cold pipeline (ml) builds tip over the runner's free-disk

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,7 +72,7 @@ jobs:
       actions: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/drill-deploy.yml
+++ b/.github/workflows/drill-deploy.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: "DR drill — checkout: shallow (resolver scripts)"
         if: steps.preflight.outputs.skip != 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/drill-e2e.yml
+++ b/.github/workflows/drill-e2e.yml
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: "DR drill — checkout: shallow (smoke + resolver scripts)"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/drill-exercise.yml
+++ b/.github/workflows/drill-exercise.yml
@@ -239,7 +239,7 @@ jobs:
           echo "All DR drill post-conditions green."
 
       - name: "DR drill — checkout (orphan check script)"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/drill-infra-apply.yml
+++ b/.github/workflows/drill-infra-apply.yml
@@ -67,7 +67,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: "DR drill — tofu: restore drill state from earlier apply (same run)"
         env:

--- a/.github/workflows/drill-infra-destroy.yml
+++ b/.github/workflows/drill-infra-destroy.yml
@@ -80,7 +80,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: "DR drill — tfstate bridge: download teardown artifact"
         env:

--- a/.github/workflows/drill-infra-plan.yml
+++ b/.github/workflows/drill-infra-plan.yml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 10
     environment: drill
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: "DR drill — pre-flight: secrets and tokens (OpenTofu provider)"
         id: preflight

--- a/.github/workflows/drill-restore-corpus.yml
+++ b/.github/workflows/drill-restore-corpus.yml
@@ -96,7 +96,7 @@ jobs:
           fi
 
       - name: "DR drill — checkout: shallow (resolver scripts + prod-ssh-key action)"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/drill-stack-playwright.yml
+++ b/.github/workflows/drill-stack-playwright.yml
@@ -71,7 +71,7 @@ jobs:
           fi
 
       - name: "DR drill — checkout: shallow (Playwright + resolver scripts)"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Confirm destructive apply
         if: inputs.dry_run == false

--- a/.github/workflows/infra-apply.yml
+++ b/.github/workflows/infra-apply.yml
@@ -87,7 +87,7 @@ jobs:
           esac
           echo "mode=$MODE confirmed"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         # Don't persist GITHUB_TOKEN as a git credential — the Auto-commit
         # step below uses ``INFRA_STATE_COMMIT_TOKEN`` (a PAT in the prod
         # environment) for its push, and a persisted GITHUB_TOKEN

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Pre-flight — required secrets present?
         id: preflight
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@v2

--- a/.github/workflows/infra-drift.yml
+++ b/.github/workflows/infra-drift.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Pre-flight — required secrets present?
         id: preflight

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@
 # Generates comprehensive metrics, reports, and trend tracking
 # See docs/ci/METRICS.md — test metrics and health tracking (Layer 3)
 #
-# Note: Linter warnings about "Unable to resolve action" for actions/checkout@v6
+# Note: Linter warnings about "Unable to resolve action" for actions/checkout@v7
 # and actions/cache@v5 are false positives - these are standard GitHub Actions
 # that exist in the marketplace but the linter cannot resolve them offline.
 #
@@ -67,7 +67,7 @@ jobs:
       # Gated pyannote diarization models download only with a terms-accepted token.
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Free disk space
       run: |
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10  # Fast checks: format, lint, markdown, type
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
@@ -179,7 +179,7 @@ jobs:
     timeout-minutes: 20  # Slower checks: security, complexity, deadcode, docstrings, spelling
     needs: [nightly-lint, nightly-build]  # Wait for lint, build to pass (docs removed - doesn't gate security)
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
@@ -213,7 +213,7 @@ jobs:
     timeout-minutes: 15
     needs: [nightly-metrics]  # Very last step - validates docs after all tests and metrics pass
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Free disk space
       run: |
@@ -254,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
@@ -279,7 +279,7 @@ jobs:
     timeout-minutes: 15
     needs: [nightly-lint, nightly-build]  # Wait for lint, build to pass (docs removed - doesn't gate unit tests)
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Free disk space
       run: |
@@ -359,7 +359,7 @@ jobs:
     timeout-minutes: 5
     needs: [nightly-lint, nightly-build]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: actions/setup-node@v6
       with:
         node-version: "22"
@@ -386,7 +386,7 @@ jobs:
       HF_HUB_CACHE: /home/runner/.cache/huggingface/hub
       ML_MODELS_VALIDATED: "true"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Free disk space
       run: |
@@ -475,7 +475,7 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       HF_HUB_OFFLINE: "1"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Free disk space
       run: |
@@ -555,7 +555,7 @@ jobs:
       needs.nightly-build.result == 'success' &&
       needs.nightly-test-e2e.result == 'success'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: actions/setup-node@v6
       with:
         node-version: "22"
@@ -596,7 +596,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v6
@@ -833,7 +833,7 @@ jobs:
       # Nightly mode uses p01-p05 podcasts with production models
       E2E_TEST_MODE: "nightly"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Free disk space
       run: |
@@ -930,7 +930,7 @@ jobs:
       - nightly-only-tests
     if: always()
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -56,7 +56,7 @@ jobs:
     outputs:
       result: ${{ steps.smoke.outputs.result }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 

--- a/.github/workflows/prod-failover-stand-up.yml
+++ b/.github/workflows/prod-failover-stand-up.yml
@@ -114,7 +114,7 @@ jobs:
     environment: drill
     steps:
       - name: "Prod failover — checkout: shallow (resolver scripts + prod-ssh-key action)"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/prod-restore-corpus.yml
+++ b/.github/workflows/prod-restore-corpus.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Checkout (resolver script + prod-ssh-key action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -111,7 +111,7 @@ jobs:
       stack-profiles: ${{ steps.filter.outputs.stack-profiles }}
       stack-compose: ${{ steps.filter.outputs.stack-compose }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: dorny/paths-filter@v4
       id: filter
       with:
@@ -182,7 +182,7 @@ jobs:
       needs.build.result == 'success' &&
       needs.viewer-unit.result == 'success'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: actions/setup-node@v6
       with:
         node-version: "22"
@@ -203,7 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10  # Fast checks: format, lint, markdown, type
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -261,7 +261,7 @@ jobs:
     # sources, so viewer-only PRs (web/gi-kg-viewer/**) can skip this.
     if: needs.detect-changes.outputs.python == 'true'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -333,7 +333,7 @@ jobs:
     # instead; pytest doesn't apply to web/gi-kg-viewer/**.
     if: needs.detect-changes.outputs.python == 'true'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -487,7 +487,7 @@ jobs:
     needs: [detect-changes, test-unit]
     if: needs.detect-changes.outputs.python == 'true'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -510,7 +510,7 @@ jobs:
     timeout-minutes: 5
     needs: [lint, build]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: actions/setup-node@v6
       with:
         # Vite 8 requires ^20.19 || >=22.12; bare "20" on the runner can be older and breaks Vite
@@ -548,7 +548,7 @@ jobs:
       # it the preload skips diarization gracefully (build still green). Optional secret.
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     # Restore is ~9GB compressed; without cleanup, cache-hit runs can run out of disk mid-tar
     # ("Wrote only N of M bytes"). Always free space before restore, not only on cache miss.
     - name: Free disk space (before ML cache restore or download)
@@ -631,7 +631,7 @@ jobs:
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/2.4' || github.ref == 'refs/heads/release/2.5' || github.ref == 'refs/heads/release/2.6') &&
       needs.detect-changes.outputs.python == 'true'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Free disk space
       run: |
         sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /home/linuxbrew/.linuxbrew
@@ -759,7 +759,7 @@ jobs:
       !contains(github.event.pull_request.head.ref, 'docs/') &&
       needs.detect-changes.outputs.python == 'true'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Free disk space
       run: |
         sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /home/linuxbrew/.linuxbrew
@@ -879,7 +879,7 @@ jobs:
       !contains(github.event.pull_request.head.ref, 'docs/') &&
       needs.detect-changes.outputs.python == 'true'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Free disk space
       run: |
         sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /home/linuxbrew/.linuxbrew
@@ -1006,7 +1006,7 @@ jobs:
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/2.4' || github.ref == 'refs/heads/release/2.5' || github.ref == 'refs/heads/release/2.6') &&
       needs.detect-changes.outputs.python == 'true'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Free disk space
       run: |
         sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /home/linuxbrew/.linuxbrew
@@ -1134,7 +1134,7 @@ jobs:
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/2.4' || github.ref == 'refs/heads/release/2.5' || github.ref == 'refs/heads/release/2.6') &&
       needs.detect-changes.outputs.python == 'true'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Free disk space
       run: |
         sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /home/linuxbrew/.linuxbrew
@@ -1191,7 +1191,7 @@ jobs:
       needs.viewer-e2e.result == 'success' &&
       (needs.coverage-unified.result == 'success' || needs.coverage-unified.result == 'skipped')
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
@@ -1222,7 +1222,7 @@ jobs:
     needs: [detect-changes, security-quality, test-unit, test-integration, test-integration-fast, test-e2e, test-e2e-fast, viewer-e2e]  # Python tests + Playwright before merge report
     if: always() && needs.detect-changes.outputs.python == 'true'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         # Full history required for wily (code quality trends) on main/release
         fetch-depth: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/2.4' || github.ref == 'refs/heads/release/2.5' || github.ref == 'refs/heads/release/2.6') && 0 || 1 }}
@@ -1239,7 +1239,7 @@ jobs:
         pip install -e .
         # Same tools as nightly metrics + Makefile quality: not in base install — without these,
         # `radon` is missing, metrics fall back to complexity 0 / empty MI (flat code-quality chart).
-        pip install "radon>=5.1.0,<5.2" "interrogate>=1.5.0,<2.0.0" "vulture>=2.10,<3.0.0" "codespell>=2.2.0,<3.0.0"
+        pip install "radon>=5.1.0,<5.2" "interrogate>=1.7.0,<2.0.0" "vulture>=2.10,<3.0.0" "codespell>=2.2.0,<3.0.0"
     - name: Download coverage artifacts
       uses: actions/download-artifact@v8
       with:
@@ -1544,7 +1544,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -40,7 +40,7 @@ jobs:
     name: Snyk - Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Free disk space
         run: |
@@ -100,7 +100,7 @@ jobs:
       group: snyk-docker-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Match docker.yml (#703): hosted toolchains are unused for pure docker builds.
       - name: Free disk space
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Free disk space
         run: |

--- a/.github/workflows/stack-test.yml
+++ b/.github/workflows/stack-test.yml
@@ -74,7 +74,7 @@ jobs:
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # workflow_run runs against the default branch by default; pin to
           # the upstream's SHA so a subsequent push doesn't shift this run
@@ -217,7 +217,7 @@ jobs:
       REGISTRY: ghcr.io
       OWNER: chipi
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 

--- a/.github/workflows/tailscale-cleanup.yml
+++ b/.github/workflows/tailscale-cleanup.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Pre-flight — required env present?
         env:

--- a/.github/workflows/verify-backup-restore.yml
+++ b/.github/workflows/verify-backup-restore.yml
@@ -36,7 +36,7 @@ jobs:
       VIEWER_PORT: '8090'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/Makefile
+++ b/Makefile
@@ -2323,6 +2323,24 @@ docker-clean:
 	docker rmi podcast-scraper:test podcast-scraper:test-llm podcast-scraper:test-fast podcast-scraper:multi-model 2>/dev/null || true
 	@echo "Cleaned up Docker test images"
 
+# --- Observability control plane (podcast_obs, #803) ---
+.PHONY: obs-test obs-e2e obs-docker-build obs-summary obs-serve
+
+obs-test: ## Unit tests for the observability control plane (podcast_obs). Fast, no network.
+	$(PYTHON) -m pytest tests/unit/podcast_obs/ -q --no-cov --disable-socket --allow-hosts=127.0.0.1,localhost
+
+obs-e2e: ## Live E2E — hits real APIs, self-skips unconfigured sources. Source .env / set PODCAST_OBS_* first.
+	$(PYTHON) -m pytest tests/e2e_observability/ -v --no-cov -p no:cacheprovider
+
+obs-docker-build: ## Build the standalone control-plane image (podcast-obs:latest); tiny context via Dockerfile.dockerignore.
+	docker build -f docker/observability/Dockerfile -t podcast-obs:latest .
+
+obs-summary: ## Control-plane glance for the configured target. Needs PODCAST_OBS_* in env (source .env).
+	$(PYTHON) -m podcast_obs summary
+
+obs-serve: ## Run the observability MCP server. Usage: make obs-serve OBS_ARGS="--transport http --port 8848"
+	$(PYTHON) -m podcast_obs serve $(OBS_ARGS)
+
 install-hooks:
 	@if [ ! -d .git ]; then echo "Error: Not a git repository"; exit 1; fi
 	@echo "Installing git pre-commit hook..."

--- a/config/examples/.env.example
+++ b/config/examples/.env.example
@@ -228,15 +228,18 @@ CACHE_DIR=.cache
 # PODCAST_OBS_SENTRY_TOKEN=sntryu_...
 # PODCAST_OBS_SENTRY_ENV=prod
 #
-# Loki cost-today + error logs — query API needs a logs:READ token (the agent's
-# GRAFANA_CLOUD_API_KEY is logs:write and will 401 on queries). URL/user are the
-# same values as GRAFANA_CLOUD_LOKI_URL / GRAFANA_CLOUD_LOKI_USER.
+# Loki cost-today + error logs — needs a Cloud ACCESS-POLICY token with logs:read
+# (the agent's GRAFANA_CLOUD_API_KEY is logs:write and 401s on queries). URL/user
+# are the same values as GRAFANA_CLOUD_LOKI_URL / GRAFANA_CLOUD_LOKI_USER.
 # PODCAST_OBS_LOKI_URL=https://logs-prod-xxx.grafana.net
 # PODCAST_OBS_LOKI_USER=123456
-# PODCAST_OBS_GRAFANA_TOKEN=glc_...   # logs:read (+ alerting read), used for Loki + alerts
+# PODCAST_OBS_LOKI_TOKEN=glc_...      # Cloud access-policy token, logs:read
 #
-# Grafana alerts — the stack URL (token reuses PODCAST_OBS_GRAFANA_TOKEN above).
+# Grafana alerts — the stack URL + a Grafana SERVICE-ACCOUNT token (glsa_, alerting
+# read). NOTE: a DIFFERENT token type from the Loki access-policy token above —
+# Grafana Cloud separates the data plane (Loki, glc_) from the Grafana API (glsa_).
 # PODCAST_OBS_GRAFANA_URL=https://your-stack.grafana.net
+# PODCAST_OBS_GRAFANA_TOKEN=glsa_...
 #
 # Multi-target alternative (switch deploys with `--target`):
 # PODCAST_OBS_CONFIG=config/observability.yaml

--- a/config/examples/.env.example
+++ b/config/examples/.env.example
@@ -200,6 +200,47 @@ CACHE_DIR=.cache
 # - Use separate keys for development/production
 # - Rotate API keys regularly
 #
+# ============================================================================
+# Observability control plane (#803, `podcast_obs`)
+# ============================================================================
+# Standalone prod control plane — read by `python -m podcast_obs ...`. Distinct
+# from the GRAFANA_CLOUD_* / PROD_SENTRY_DSN_* names above: those configure the
+# stack's own shipping; these configure the read-only control plane that QUERIES
+# the same backends. All optional — a source whose vars are unset reports
+# "configured: false" and the rest still work. For multiple deploys, prefer a
+# YAML config (PODCAST_OBS_CONFIG) — see config/observability.example.yaml and
+# docs/guides/OBSERVABILITY_CONTROL_PLANE.md.
+#
+# Target (the deploy to observe) — credential-free /api probes:
+# PODCAST_OBS_API_BASE=https://prod-podcast.<your-tailnet>   # or http://localhost:8080
+# PODCAST_OBS_ENV_LABEL=prod          # the deploy's Loki/metrics env label
+# PODCAST_OBS_TIMEOUT=10              # per-request seconds
+#
+# GitHub deploys (deploy-prod.yml runs) — fine-grained PAT, Actions:read.
+# Omit to fall back to the authenticated `gh` CLI token.
+# PODCAST_OBS_GITHUB_REPO=chipi/podcast_scraper
+# PODCAST_OBS_GITHUB_TOKEN=github_pat_...
+#
+# Sentry issues — an org-owned auth token (Internal Integration: Issue&Event:Read),
+# NOT a DSN. Projects are comma-separated slugs.
+# PODCAST_OBS_SENTRY_ORG=your-org-slug
+# PODCAST_OBS_SENTRY_PROJECTS=api,pipeline,viewer
+# PODCAST_OBS_SENTRY_TOKEN=sntryu_...
+# PODCAST_OBS_SENTRY_ENV=prod
+#
+# Loki cost-today + error logs — query API needs a logs:READ token (the agent's
+# GRAFANA_CLOUD_API_KEY is logs:write and will 401 on queries). URL/user are the
+# same values as GRAFANA_CLOUD_LOKI_URL / GRAFANA_CLOUD_LOKI_USER.
+# PODCAST_OBS_LOKI_URL=https://logs-prod-xxx.grafana.net
+# PODCAST_OBS_LOKI_USER=123456
+# PODCAST_OBS_GRAFANA_TOKEN=glc_...   # logs:read (+ alerting read), used for Loki + alerts
+#
+# Grafana alerts — the stack URL (token reuses PODCAST_OBS_GRAFANA_TOKEN above).
+# PODCAST_OBS_GRAFANA_URL=https://your-stack.grafana.net
+#
+# Multi-target alternative (switch deploys with `--target`):
+# PODCAST_OBS_CONFIG=config/observability.yaml
+
 # See Also:
 # - docs/api/CONFIGURATION.md - Complete environment variable documentation
 # - examples/config.example.yaml - Configuration file examples

--- a/config/grafana/grafana-dashboard-deploy-observability.json
+++ b/config/grafana/grafana-dashboard-deploy-observability.json
@@ -1,0 +1,59 @@
+{
+  "title": "Podcast Scraper — Deploys (#803)",
+  "uid": "podcast-scraper-deploys",
+  "tags": ["podcast-scraper", "deploys", "observability"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "description": "Import into Grafana Cloud podcast-scraper folder. Requires deploy_event log lines pushed by deploy-prod.yml (#803 D1): {app=\"podcast_scraper\", event_type=\"deploy_event\"} with JSON {status, sha, duration_ms, triggered_by}. MTTR (failed→next-success) is deferred — it needs correlation a single LogQL panel can't express.",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Deploys per week (12w)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({app=\"podcast_scraper\", event_type=\"deploy_event\"} [1w]))",
+          "legendFormat": "deploys/week"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Failure rate (4w)",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({app=\"podcast_scraper\", event_type=\"deploy_event\"} | json | status != \"success\" [4w])) / sum(count_over_time({app=\"podcast_scraper\", event_type=\"deploy_event\"} [4w]))",
+          "legendFormat": "failed / total"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "p95 deploy duration (4w, ms)",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "quantile_over_time(0.95, {app=\"podcast_scraper\", event_type=\"deploy_event\"} | json | unwrap duration_ms [4w])",
+          "legendFormat": "p95 ms"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Deploys by status over time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "sum by (status) (count_over_time({app=\"podcast_scraper\", event_type=\"deploy_event\"} | json [1d]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    }
+  ]
+}

--- a/config/observability.example.yaml
+++ b/config/observability.example.yaml
@@ -1,0 +1,30 @@
+# podcast_obs — observability control plane config (#803). Copy, edit, then:
+#   PODCAST_OBS_CONFIG=config/observability.yaml python -m podcast_obs summary --target local
+#
+# Target-agnostic: define every deploy you want to observe. Probes that need a source
+# this target doesn't wire (Sentry/Grafana on a local stack) simply report "not configured".
+# Secrets never live in this file — use `<field>_env: ENV_VAR_NAME` indirection.
+
+default_target: local
+
+targets:
+  # Your local `make serve` stack — the credential-free basics (health/version/runs) work here.
+  local:
+    api_base: http://localhost:8080
+
+  # Prod over Tailscale. Fill in the rest as you wire each source (later slices).
+  prod:
+    api_base: https://prod-podcast.tail-xxxxx.ts.net
+    # github:
+    #   repo: chipi/podcast_scraper
+    #   token_env: PODCAST_OBS_GH_TOKEN        # a read-only Actions:read token
+    # sentry:
+    #   org: your-org
+    #   projects: [api, pipeline]
+    #   environment: prod
+    #   token_env: PODCAST_OBS_SENTRY_TOKEN
+    # grafana:
+    #   url: https://your-stack.grafana.net
+    #   token_env: PODCAST_OBS_GRAFANA_TOKEN
+    #   loki_url: https://logs-prod-xxx.grafana.net
+    #   loki_user: "123456"

--- a/config/observability.example.yaml
+++ b/config/observability.example.yaml
@@ -20,7 +20,7 @@ targets:
     #   token_env: PODCAST_OBS_GH_TOKEN        # a read-only Actions:read token
     # sentry:
     #   org: your-org
-    #   projects: [api, pipeline]
+    #   projects: [api, pipeline, viewer]   # real slugs (Settings → Projects), not DSN names
     #   environment: prod
     #   token_env: PODCAST_OBS_SENTRY_TOKEN
     # grafana:

--- a/config/observability.example.yaml
+++ b/config/observability.example.yaml
@@ -25,6 +25,7 @@ targets:
     #   token_env: PODCAST_OBS_SENTRY_TOKEN
     # grafana:
     #   url: https://your-stack.grafana.net
-    #   token_env: PODCAST_OBS_GRAFANA_TOKEN
+    #   token_env: PODCAST_OBS_GRAFANA_TOKEN     # service-account token (glsa_) for alerting
     #   loki_url: https://logs-prod-xxx.grafana.net
     #   loki_user: "123456"
+    #   loki_token_env: PODCAST_OBS_LOKI_TOKEN   # access-policy token (glc_), logs:read

--- a/docker/observability/Dockerfile
+++ b/docker/observability/Dockerfile
@@ -1,0 +1,38 @@
+# Standalone prod observability control plane (#803).
+#
+# Intentionally LIGHT: installs ONLY podcast_obs + httpx/PyYAML/mcp — never the heavy
+# podcast_scraper pipeline deps (torch/spaCy/...). The podcast_obs package has zero coupling to
+# podcast_scraper, so copying just that one directory is enough. The result is a small image you
+# run on your MBP, an Orb, or a Mac mini inside the Tailscale network as a mini control plane.
+#
+# Build (from repo root):
+#   docker build -f docker/observability/Dockerfile -t podcast-obs:latest .
+# One-shot probe:
+#   docker run --rm -e PODCAST_OBS_API_BASE=https://prod-podcast.<tailnet> podcast-obs summary
+# Run the agent-facing MCP/HTTP control plane:
+#   docker run --rm -p 8848:8848 \
+#     -v "$PWD/config/observability.yaml:/config/observability.yaml:ro" \
+#     -e PODCAST_OBS_CONFIG=/config/observability.yaml podcast-obs
+FROM python:3.12-slim
+
+# Pinned to match the pyproject [observability] extra.
+RUN pip install --no-cache-dir \
+      "httpx>=0.28.1,<1.0.0" \
+      "PyYAML>=6.0.3,<7.0.0" \
+      "mcp>=1.2.0,<2.0.0"
+
+WORKDIR /app
+COPY src/podcast_obs /app/podcast_obs
+
+# Run unprivileged.
+RUN useradd --create-home --uid 10001 obs
+USER obs
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# streamable-http transport so an agent on another tailnet box can reach it. Override the CMD for
+# stdio (`serve --transport stdio`) or a one-shot probe (`summary --target prod`).
+EXPOSE 8848
+ENTRYPOINT ["python", "-m", "podcast_obs"]
+CMD ["serve", "--transport", "http", "--host", "0.0.0.0", "--port", "8848"]

--- a/docker/observability/Dockerfile.dockerignore
+++ b/docker/observability/Dockerfile.dockerignore
@@ -1,0 +1,7 @@
+# Minimal build context for the observability image (BuildKit uses this file for
+# `-f docker/observability/Dockerfile`). The image only COPYs src/podcast_obs, so ship just that
+# — keeps the context tiny and avoids the repo's heavy dirs (.test_outputs 16G, .venv, node_modules).
+*
+!src
+src/*
+!src/podcast_obs

--- a/docker/observability/docker-compose.example.yml
+++ b/docker/observability/docker-compose.example.yml
@@ -1,0 +1,27 @@
+# Example: run the #803 observability control plane as a container on a tailnet host.
+#
+# 1. cp ../../config/observability.example.yaml ./observability.yaml  (edit targets)
+# 2. export the read-scoped tokens referenced by the YAML's `<field>_env:` keys
+# 3. docker compose -f docker-compose.example.yml up -d
+#
+# Reaching prod over Tailscale (and being reachable by agents on other boxes) requires this
+# container to be on the tailnet: run it on a tailnet host with host networking, or add a
+# tailscale sidecar. See docs/guides/OBSERVABILITY_CONTROL_PLANE.md.
+
+services:
+  podcast-obs:
+    build:
+      context: ../..
+      dockerfile: docker/observability/Dockerfile
+    # image: ghcr.io/chipi/podcast-obs:latest   # once published
+    environment:
+      PODCAST_OBS_CONFIG: /config/observability.yaml
+      # Secrets stay out of the YAML (via `<field>_env:` indirection) — provide them here:
+      PODCAST_OBS_GH_TOKEN: ${PODCAST_OBS_GH_TOKEN:-}
+      PODCAST_OBS_SENTRY_TOKEN: ${PODCAST_OBS_SENTRY_TOKEN:-}
+      PODCAST_OBS_GRAFANA_TOKEN: ${PODCAST_OBS_GRAFANA_TOKEN:-}
+    volumes:
+      - ./observability.yaml:/config/observability.yaml:ro
+    ports:
+      - "8848:8848"
+    restart: unless-stopped

--- a/docs/guides/BOOTSTRAP_PREREQUISITES.md
+++ b/docs/guides/BOOTSTRAP_PREREQUISITES.md
@@ -1,0 +1,110 @@
+# Bootstrap prerequisites (accounts + credentials)
+
+Self-contained checklist of the one-time **account and credential** work an operator must
+complete **before** the first `tofu apply` and first deploy in
+[PROD_RUNBOOK § First-time bootstrap](PROD_RUNBOOK.md#first-time-bootstrap). Everything here
+lives in this repo so a second operator can bootstrap from the repo alone (the bus-factor
+goal of [#805](https://github.com/chipi/podcast_scraper/issues/805)).
+
+> **Tailscale auth model:** this project runs on the Tailscale **Free plan**, which has no OAuth
+> clients. We use two separate credentials instead: **`TS_AUTHKEY`** (a device-join *auth key*,
+> consumed by `tailscale/github-action` and cloud-init) and **`TS_API_KEY`** (a Personal API
+> *access token*, used by the Terraform `tailscale` provider to manage the ACL and mint per-server
+> auth keys). The older [#714](https://github.com/chipi/podcast_scraper/issues/714) checklist
+> describes an **OAuth** client (`TS_OAUTH_CLIENT_ID`/`SECRET`) — that is **superseded**; do not
+> follow it. See `infra/terraform/variables.tf` (`tailscale_api_key` description) for the
+> in-code statement of this model.
+>
+> **Secret retrieval is password-manager-agnostic.** Commands below show values as
+> `<placeholders>`. Retrieve each from whatever secrets store you use (`pass`, a `.env` you keep
+> offline, `op read …` if you use 1Password, etc.). No specific manager is required.
+
+---
+
+## A. Operator laptop tooling
+
+- [ ] `brew install opentofu sops age actionlint shellcheck`
+- [ ] `gh auth login` (GitHub CLI, authenticated to `chipi/podcast_scraper`)
+- [ ] An Ed25519 SSH key at `~/.ssh/id_ed25519` (`ssh-keygen -t ed25519` if absent) — OpenTofu
+      registers its public half on the VPS as the operator key.
+
+## B. Hetzner Cloud account
+
+- [ ] Account at [hetzner.com/cloud](https://www.hetzner.com/cloud/) with a billing method
+      (EU residents: SEPA is cheapest).
+- [ ] A dedicated Cloud Project named `podcast-scraper-prod` (clean billing line + scoped tokens).
+- [ ] In that project: **Settings → API Tokens → Generate** with **Read & Write** scope → this is
+      `HCLOUD_TOKEN`.
+- [ ] Confirm an EU location is available: **Falkenstein (fsn1)** or **Nuremberg (nbg1)**
+      (RFC-082 Decision 1).
+
+## C. Tailscale (Free plan)
+
+- [ ] A tailnet (note its name, e.g. `tail-xxxxx.ts.net`).
+- [ ] **Settings → DNS → MagicDNS** enabled.
+- [ ] **Settings → DNS → HTTPS Certificates** enabled (so `tailscale cert` / `tailscale serve` can
+      issue Let's Encrypt for `prod-podcast.<tailnet>`).
+- [ ] **`TS_AUTHKEY`** — a reusable, tagged **auth key** (Settings → Keys → Generate auth key;
+      tags `tag:prod`, `tag:gha-deployer`). Device-join credential; ~90-day expiry on Free plan.
+- [ ] **`TS_API_KEY`** — a **Personal API access token** (Settings → Keys → API access tokens).
+      Used by the Terraform provider; ~90-day expiry on Free plan.
+- [ ] **Access Controls** (`policy.hujson`): owners for `tag:prod` and `tag:gha-deployer`; rule
+      `tag:gha-deployer` → `tag:prod:22` (SSH); rule operator's user → `tag:prod:443` and `:80`.
+
+## D. sops + age (Terraform state encryption)
+
+- [ ] `age-keygen -o ~/.config/sops/age/keys.txt`.
+- [ ] Copy the **public** key into `infra/.sops.yaml` (replacing the `age1PLACEHOLDER…` value;
+      commit-safe).
+- [ ] Save the **private** key contents to your secrets store as
+      `sops/podcast-scraper/tofu-state-age-key`.
+- [ ] Verify round-trip: `echo test | sops -e --age "$(grep 'public key:' ~/.config/sops/age/keys.txt | sed 's/.*: //')" /dev/stdin >/dev/null`.
+
+## E. Runtime service accounts (host `.env`, staged later as `PROD_*` secrets)
+
+These are needed for the running stack, staged once in repo settings and rendered into the host
+`.env` by `deploy-prod.yml` (see [PROD_RUNBOOK § Stage `.env`](PROD_RUNBOOK.md#stage-env-workflow-staged-from-gh-secrets-841)).
+Stage incrementally — a missing one just disables that feature (the stack still starts).
+
+- [ ] **LLM providers** (whichever your prod profile uses; `cloud_balanced` default uses OpenAI +
+      Gemini): OpenAI, Anthropic, Gemini, Mistral, DeepSeek, Grok API keys.
+- [ ] **Sentry**: an org + **three** projects (`api`, `pipeline`, `viewer`) → one DSN each.
+- [ ] **Grafana Cloud**: a stack with Prometheus + Loki endpoints, their tenant IDs, and an access
+      token with `metrics:write` + `logs:write`.
+- [ ] **Backup repo PAT** (`BACKUP_REPO_TOKEN`, optional) and outbound **job webhook URL** (optional).
+
+## F. Stage the infrastructure GHA secrets
+
+With the above in hand, stage the **infra** credentials (the runtime `PROD_*` secrets are staged
+separately per the runbook):
+
+```bash
+gh secret set HCLOUD_TOKEN      --repo chipi/podcast_scraper --app actions --body '<from §B>'
+gh secret set TS_AUTHKEY        --repo chipi/podcast_scraper --app actions --body '<tskey-auth-… from §C>'
+gh secret set TS_API_KEY        --repo chipi/podcast_scraper --app actions --body '<tskey-api-… from §C>'
+gh secret set TFSTATE_AGE_KEY   --repo chipi/podcast_scraper --app actions --body "$(cat ~/.config/sops/age/keys.txt)"
+gh secret set BACKUP_REPO_TOKEN --repo chipi/podcast_scraper --app actions --body '<backup-repo-pat, optional>'
+gh secret set OPERATOR_SSH_PUBLIC_KEY --repo chipi/podcast_scraper --body "$(cat ~/.ssh/id_ed25519.pub)"
+gh variable set TAILNET_NAME    --repo chipi/podcast_scraper --body 'tail-xxxxx.ts.net'
+```
+
+`PROD_SSH_PRIVATE_KEY` (the CI deploy key) and `PROD_TAILNET_FQDN` are set during bootstrap, not
+here — see [PROD_RUNBOOK § GitHub Actions SSH to prod](PROD_RUNBOOK.md#github-actions-ssh-to-prod-prod_ssh_private_key)
+and [§ First `tofu apply`](PROD_RUNBOOK.md#first-tofu-apply-operators-laptop).
+
+## G. Exit criterion (smoke before `tofu apply`)
+
+- [ ] Hetzner API token works:
+
+  ```bash
+  HCLOUD_TOKEN='<from §B>'
+  curl -fsS -H "Authorization: Bearer $HCLOUD_TOKEN" https://api.hetzner.cloud/v1/server_types \
+    | jq '.server_types[] | select(.name=="cx33") | {name, prices: .prices[0]}'
+  # Expect a JSON object (NOT 401/403).
+  ```
+
+- [ ] `gh secret list --repo chipi/podcast_scraper` shows the §F secrets.
+- [ ] Your secrets store holds: Hetzner token, `TS_AUTHKEY`, `TS_API_KEY`, sops-age private key.
+
+Once all boxes are checked, proceed to
+[PROD_RUNBOOK § First-time bootstrap](PROD_RUNBOOK.md#first-time-bootstrap).

--- a/docs/guides/OBSERVABILITY_CONTROL_PLANE.md
+++ b/docs/guides/OBSERVABILITY_CONTROL_PLANE.md
@@ -1,0 +1,194 @@
+# Prod observability control plane (`podcast_obs`, #803)
+
+A small, **standalone** control plane that answers *"what is a deploy doing right now?"* —
+health, version, recent pipeline runs and deploys, today's LLM cost, recent **error logs** (Loki)
+and Sentry issues, and current Grafana alerts — for **any** deploy (your local stack, prod over
+Tailscale, a drill). It's **target-agnostic** and **degrades gracefully**: a source that isn't
+wired for a target just reports `configured=false`.
+
+It lives in its own light package (`podcast_obs`) with **zero coupling** to the heavy
+`podcast_scraper` pipeline, so it runs cheaply as a plain process or a small container anywhere on
+the tailnet.
+
+## Layers
+
+| Layer | What | Entry point |
+| --- | --- | --- |
+| **Core** | probe/aggregate functions, one per backing system | `podcast_obs.sources.*` |
+| **CLI ("the basics")** | probe any deploy directly, scriptable, no MCP | `python -m podcast_obs <cmd>` |
+| **MCP server** | the same probes as agent tools | `python -m podcast_obs serve` |
+| **Docker** | the standalone container control plane | `docker/observability/` |
+
+## Install
+
+`httpx` + `PyYAML` are base deps; the agent-facing layer adds `mcp`:
+
+```bash
+pip install -e '.[observability]'   # in this repo
+```
+
+For a slim standalone deploy, the container installs only `httpx`/`PyYAML`/`mcp` (see Docker below).
+
+## Configure
+
+Target-agnostic. Either a single target from env vars, or multiple targets from YAML.
+
+**Env (single target):** prefix `PODCAST_OBS_`.
+
+| Var | Used by | Notes |
+| --- | --- | --- |
+| `PODCAST_OBS_API_BASE` | health/version/runs | e.g. `http://localhost:8080` or `https://prod-podcast.<tailnet>` |
+| `PODCAST_OBS_GITHUB_REPO` / `_GITHUB_TOKEN` | deploys | default repo `chipi/podcast_scraper` |
+| `PODCAST_OBS_SENTRY_ORG` / `_SENTRY_PROJECTS` / `_SENTRY_TOKEN` / `_SENTRY_ENV` | errors | projects CSV; env default `prod` |
+| `PODCAST_OBS_GRAFANA_URL` / `_GRAFANA_TOKEN` | alerts (+ Loki token) | Grafana stack URL |
+| `PODCAST_OBS_LOKI_URL` / `_LOKI_USER` | cost/logs | Loki push or query URL (suffix is normalised) |
+| `PODCAST_OBS_ENV_LABEL` | cost/logs | the deploy's Loki `env` label (default `prod`) |
+| `PODCAST_OBS_TIMEOUT` | all | per-request seconds (default 10) |
+
+**YAML (multi-target):** point `PODCAST_OBS_CONFIG` at a file. Secrets stay out of the file via
+`<field>_env:` indirection (the value is read from the named env var). See
+[`config/observability.example.yaml`](https://github.com/chipi/podcast_scraper/blob/main/config/observability.example.yaml):
+
+```yaml
+default_target: local
+targets:
+  local:
+    api_base: http://localhost:8080
+  prod:
+    api_base: https://prod-podcast.tail-xxxxx.ts.net
+    env_label: prod
+    github:
+      repo: chipi/podcast_scraper
+      token_env: PODCAST_OBS_GH_TOKEN
+    sentry:
+      org: your-org
+      projects: [api, pipeline]
+      token_env: PODCAST_OBS_SENTRY_TOKEN
+    grafana:
+      url: https://your-stack.grafana.net
+      token_env: PODCAST_OBS_GRAFANA_TOKEN
+      loki_url: https://logs-prod-xxx.grafana.net
+      loki_user: "123456"
+```
+
+### Tokens and scopes (read-only — the control plane never mutates)
+
+| Source | Credential | Scope / gotcha |
+| --- | --- | --- |
+| `prod_api` | none | Reachability only (tailnet-gated in prod). |
+| `github` | fine-grained PAT, or the `gh` CLI | **Actions: read**. |
+| `sentry` | a Sentry **auth token** | `project:read` / `event:read`. **NOT the DSN** — the staged `PROD_SENTRY_DSN_*` cannot query the API. |
+| `grafana` (alerts) | Grafana service-account token | alerting read. |
+| `loki` (cost/logs) | `loki_user` + a Grafana token as the basic-auth password | **`logs:read`** — the agent's `GRAFANA_CLOUD_API_KEY` is `logs:write`; querying needs a read-scoped token. |
+
+## CLI (the basics)
+
+```bash
+python -m podcast_obs summary    --target prod      # control-plane glance, all sources
+python -m podcast_obs health     --target local
+python -m podcast_obs version    --target prod
+python -m podcast_obs runs        --limit 5         # recent pipeline runs (/api/jobs)
+python -m podcast_obs deploys     --limit 5         # deploy-prod.yml runs + failure rate
+python -m podcast_obs cost-today                     # 24h LLM spend (Loki)
+python -m podcast_obs logs --service pipeline --window 6h --contains OOM
+python -m podcast_obs errors --window 24h            # Sentry issues
+python -m podcast_obs alerts                          # Grafana alerts
+```
+
+Every command prints a uniform JSON envelope — `{ok, source, data | error, configured}`. Exit code
+is `0` on success, `1` when the probe failed (unreachable / not configured), `2` on a config error.
+`summary` buckets sources into **live / unconfigured / failed**, so a local-only target still gives
+a useful glance (externals report `unconfigured`).
+
+The **`logs`** command is the signal Sentry misses: it reads raw container logs from Loki
+(error-ish by default), including stderr tracebacks from pipeline subprocesses and `ERROR`/`WARNING`
+lines the Sentry SDK never wrapped.
+
+## MCP server (agent-facing)
+
+Same probes, exposed as 9 tools (`prod_health`, `prod_version`, `prod_recent_runs`,
+`prod_recent_deploys`, `prod_cost_today`, `prod_recent_logs`, `prod_recent_errors`,
+`prod_recent_alerts`, `prod_summary`) — each takes an optional `target`.
+
+```bash
+python -m podcast_obs serve --transport stdio                       # local agent
+python -m podcast_obs serve --transport http --host 0.0.0.0 --port 8848   # networked control plane
+```
+
+Use **stdio** for a co-located agent; **sse / http** (streamable-http, default path `/mcp`) for a
+container other tailnet boxes can reach.
+
+## Docker (standalone control plane)
+
+A light image (`python:3.12-slim` + `httpx`/`PyYAML`/`mcp` + the package — no pipeline deps) you run
+on your MBP, an Orb, or a Mac mini in the tailnet.
+
+```bash
+docker build -f docker/observability/Dockerfile -t podcast-obs:latest .
+
+# one-shot probe
+docker run --rm -e PODCAST_OBS_API_BASE=https://prod-podcast.<tailnet> podcast-obs summary
+
+# the agent-facing control plane (MCP over http)
+docker run --rm -p 8848:8848 \
+  -v "$PWD/config/observability.yaml:/config/observability.yaml:ro" \
+  -e PODCAST_OBS_CONFIG=/config/observability.yaml podcast-obs
+```
+
+See [`docker/observability/docker-compose.example.yml`](https://github.com/chipi/podcast_scraper/blob/main/docker/observability/docker-compose.example.yml).
+To reach prod over Tailscale **and** be reachable by remote agents, run it on a tailnet host (host
+networking) or add a tailscale sidecar.
+
+## Task an agent to use it (with Grafana MCP and others)
+
+Register `podcast_obs` as an MCP server in your agent. Claude Code, local stdio:
+
+```json
+{
+  "mcpServers": {
+    "podcast-obs": {
+      "command": "python",
+      "args": ["-m", "podcast_obs", "serve", "--transport", "stdio"],
+      "env": { "PODCAST_OBS_CONFIG": "/path/to/observability.yaml" }
+    }
+  }
+}
+```
+
+Or a remote container over the tailnet:
+
+```json
+{
+  "mcpServers": {
+    "podcast-obs": { "url": "http://mac-mini.tail-xxxxx.ts.net:8848/mcp" }
+  }
+}
+```
+
+Add the **Grafana MCP** server alongside it the same way. Division of labour:
+
+- **`podcast_obs`** — the fast cross-source glance: health, version, deploys, cost-today, **raw
+  error logs**, Sentry issues, alerts. One call (`prod_summary`) tells you *what's off*.
+- **Grafana MCP** — deep drill-down: render a dashboard panel, query a specific metric over a range,
+  inspect an alert rule.
+
+Example you can hand an agent:
+
+> "Use `podcast-obs` `prod_summary` for prod. If cost-today is unusually high or there are recent
+> error logs, pull the relevant Grafana dashboard via the Grafana MCP and summarise the spike; if a
+> deploy failed, show its recent `prod_recent_logs` for the `pipeline` service."
+
+The agent gets a cheap, structured first look from `podcast_obs` and escalates to Grafana only when
+something needs investigation — no operator `ssh` or dashboard-clicking.
+
+## Validation
+
+- Unit tests: `tests/unit/podcast_obs/` (config, every source, summary, MCP wiring).
+- Live E2E: `tests/e2e_observability/` — asserts **shape + invariants** (not values, since live data
+  changes) and **self-skips** when a source is unconfigured/unreachable. Run with real network:
+
+  ```bash
+  .venv/bin/python -m pytest tests/e2e_observability/ -q --no-cov -p no:cacheprovider
+  ```
+
+  GitHub runs live via your `gh` token; the rest light up as you provide their read-scoped tokens.

--- a/docs/guides/OBSERVABILITY_CONTROL_PLANE.md
+++ b/docs/guides/OBSERVABILITY_CONTROL_PLANE.md
@@ -66,9 +66,10 @@ targets:
       token_env: PODCAST_OBS_SENTRY_TOKEN
     grafana:
       url: https://your-stack.grafana.net
-      token_env: PODCAST_OBS_GRAFANA_TOKEN
+      token_env: PODCAST_OBS_GRAFANA_TOKEN      # service-account token (glsa_) for alerting
       loki_url: https://logs-prod-xxx.grafana.net
       loki_user: "123456"
+      loki_token_env: PODCAST_OBS_LOKI_TOKEN    # access-policy token (glc_), logs:read
 ```
 
 ### Tokens and scopes (read-only — the control plane never mutates)
@@ -78,8 +79,8 @@ targets:
 | `prod_api` | none | Reachability only (tailnet-gated in prod). |
 | `github` | fine-grained PAT, or the `gh` CLI | **Actions: read**. |
 | `sentry` | a Sentry **auth token** | `project:read` / `event:read`. **NOT the DSN** — the staged `PROD_SENTRY_DSN_*` cannot query the API. |
-| `grafana` (alerts) | Grafana service-account token | alerting read. |
-| `loki` (cost/logs) | `loki_user` + a Grafana token as the basic-auth password | **`logs:read`** — the agent's `GRAFANA_CLOUD_API_KEY` is `logs:write`; querying needs a read-scoped token. |
+| `grafana` (alerts) | a Grafana **service-account** token (`glsa_`) | alerting read. Grafana-API only. |
+| `loki` (cost/logs) | `loki_user` + a Cloud **access-policy** token (`glc_`) | **`logs:read`**. A *different token type* from the alerting one — Grafana Cloud splits the data plane (Loki, `glc_`) from the Grafana API (`glsa_`). The agent's `GRAFANA_CLOUD_API_KEY` is `logs:write` and 401s. (Falls back to the grafana token for self-hosted setups where one token serves both.) |
 
 ## CLI (the basics)
 

--- a/docs/guides/OBSERVABILITY_CONTROL_PLANE.md
+++ b/docs/guides/OBSERVABILITY_CONTROL_PLANE.md
@@ -62,7 +62,7 @@ targets:
       token_env: PODCAST_OBS_GH_TOKEN
     sentry:
       org: your-org
-      projects: [api, pipeline]
+      projects: [api, pipeline, viewer]   # real slugs (Settings → Projects), not DSN names
       token_env: PODCAST_OBS_SENTRY_TOKEN
     grafana:
       url: https://your-stack.grafana.net
@@ -78,7 +78,7 @@ targets:
 | --- | --- | --- |
 | `prod_api` | none | Reachability only (tailnet-gated in prod). |
 | `github` | fine-grained PAT, or the `gh` CLI | **Actions: read**. |
-| `sentry` | a Sentry **auth token** | `project:read` / `event:read`. **NOT the DSN** — the staged `PROD_SENTRY_DSN_*` cannot query the API. |
+| `sentry` | a Sentry **auth token** | **Issue & Event: Read** (`event:read`) — `project:read` alone is not enough. **NOT the DSN** (the staged `PROD_SENTRY_DSN_*` can't query the API). `prod_recent_errors`/D2 also want **Release: Admin**. Note: project **slugs** ≠ DSN names (check Settings → Projects; e.g. `podcast-scraper-api`). |
 | `grafana` (alerts) | a Grafana **service-account** token (`glsa_`) | alerting read. Grafana-API only. |
 | `loki` (cost/logs) | `loki_user` + a Cloud **access-policy** token (`glc_`) | **`logs:read`**. A *different token type* from the alerting one — Grafana Cloud splits the data plane (Loki, `glc_`) from the Grafana API (`glsa_`). The agent's `GRAFANA_CLOUD_API_KEY` is `logs:write` and 401s. (Falls back to the grafana token for self-hosted setups where one token serves both.) |
 

--- a/docs/guides/PROD_RUNBOOK.md
+++ b/docs/guides/PROD_RUNBOOK.md
@@ -25,11 +25,14 @@ For day-to-day prod (not DR drill, not manual corpus restore): **preflight** (se
 `snapshot.tgz` is **not** part of this path; see [Disaster recovery](#disaster-recovery) and
 [STACK_CONTRACT.md](STACK_CONTRACT.md).
 
-> **For the prerequisites checklist** (Hetzner account + Tailscale credentials —
-> auth key + API access token on Free plan, see "Tailscale credentials" below
-> for the why — sops/age + GHA secrets), see
-> [#714](https://github.com/chipi/podcast_scraper/issues/714).
-> All commands below assume those are done.
+> **For the prerequisites checklist** (Hetzner account, Tailscale Free-plan credentials —
+> `TS_AUTHKEY` + `TS_API_KEY`, see "Tailscale credentials" below for the why — sops/age, runtime
+> service accounts, and GHA secrets), see
+> [Bootstrap prerequisites](BOOTSTRAP_PREREQUISITES.md). All commands below assume those are done.
+>
+> Historical: [#714](https://github.com/chipi/podcast_scraper/issues/714) was the original
+> prerequisites issue; it is **superseded** (it describes the Tailscale OAuth model, which the
+> Free-plan auth-key + API-key model replaced).
 
 ## Sections
 
@@ -55,6 +58,18 @@ For day-to-day prod (not DR drill, not manual corpus restore): **preflight** (se
 
 One-shot setup that takes prod from "nothing" to "viewer reachable on the
 tailnet". ~30–45 min wall.
+
+**Bootstrap sequence at a glance.** The subsections below are grouped by topic, not strict
+order — follow this sequence (each step links its section):
+
+1. Complete the [Bootstrap prerequisites](BOOTSTRAP_PREREQUISITES.md) (accounts + credentials).
+2. [Pre-bootstrap on your laptop](#pre-bootstrap-one-time-on-operators-laptop) — tools, age key, stage infra GHA secrets.
+3. [First `tofu apply`](#first-tofu-apply-operators-laptop) — provision the VPS; set `PROD_TAILNET_FQDN`.
+4. [Wait for cloud-init](#first-tofu-apply-operators-laptop) (a few minutes — see the note after apply) until the VPS is reachable on the tailnet.
+5. [Set up the CI deploy SSH key](#github-actions-ssh-to-prod-prod_ssh_private_key) (`PROD_SSH_PRIVATE_KEY`) — needs the VPS live.
+6. [Stage the runtime `PROD_*` secrets](#stage-env-workflow-staged-from-gh-secrets-841) in repo settings.
+7. [Trigger the first deploy](#trigger-the-first-deploy) — `deploy-prod.yml` renders `.env` and brings the stack up.
+8. [Smoke-validate](#smoke-validation).
 
 ### Pre-bootstrap (one-time, on operator's laptop)
 
@@ -155,7 +170,7 @@ so the workflow uses **`$SSH_DRILL_IDENTITY`** (prod workflows keep the default 
 
 1. SSH to the drill VPS with your **operator** key (only that key is present from cloud-init until you extend **`authorized_keys`**).
 2. Append **exactly one line** (contents of **`gha-prod-deploy.pub`**, or a drill-only CI public key) to **`deploy@`** **`~/.ssh/authorized_keys`** (modes **`700`** / **`600`**).
-3. Stage **`/srv/podcast-scraper/.env`**, then **`sudo rm /srv/podcast-scraper/.bootstrap-needs-env`** so Docker Compose can start (see cloud-init **`final_message`** on first boot).
+3. Ensure **`/srv/podcast-scraper/.env`** exists (drill workflows stage it, or restore it per the [Drill host `.env` checklist](DR_DRILL_RUNBOOK.md#drill-host-env-checklist-after-first-boot-or-restore)). The `podcast-scraper.service` unit's `ExecStartPre` refuses to start until `.env` is present (#844 positive check — the older `.bootstrap-needs-env` sentinel was removed).
 
 **GitHub secret** (can reuse the same PEM file as prod if the same public key is on drill **`deploy@`**):
 
@@ -185,9 +200,11 @@ ssh -o IdentitiesOnly=yes deploy@<your-drill-magicdns-host> 'echo ok'
 
 ```bash
 cd infra
-export HCLOUD_TOKEN=$(op read 'op://Personal/Hetzner Cloud/podcast-scraper-prod/api-token')
+# Retrieve the Hetzner token + Tailscale API key from your secrets store (pass,
+# an offline .env, `op read …` if you use 1Password — no specific manager required).
+export HCLOUD_TOKEN='<your Hetzner R/W API token>'
 export TF_VAR_hcloud_token="$HCLOUD_TOKEN"
-export TF_VAR_tailscale_api_key=$(op read 'op://Personal/Tailscale/podcast-scraper/api-key')
+export TF_VAR_tailscale_api_key='<your Tailscale Personal API access token>'
 export TF_VAR_tailscale_tailnet="tail-xxxxx.ts.net"   # your tailnet
 export TF_VAR_ssh_public_key="$(cat ~/.ssh/id_ed25519.pub)"
 
@@ -207,6 +224,18 @@ After apply, set the GHA variable:
 gh variable set PROD_TAILNET_FQDN --repo chipi/podcast_scraper \
   --body "prod-podcast.tail-xxxxx.ts.net"
 ```
+
+**Wait for cloud-init before the next step.** `tofu apply` returns once Hetzner creates the
+server, but the VPS then runs cloud-init for a few minutes (installs Docker + Tailscale, joins the
+tailnet, clones the repo, enables the systemd unit). Check readiness one of two ways:
+
+- the new machine shows **online** in the [Tailscale admin](https://login.tailscale.com/admin/machines), or
+- `ssh deploy@prod-podcast.<tailnet> 'echo ok'` succeeds (after you've added the CI key below; the
+  operator key from `tofu apply` works immediately).
+
+The stack itself stays **down** until the first `deploy-prod.yml` run stages `/srv/podcast-scraper/.env`
+— the `podcast-scraper.service` unit's `ExecStartPre` refuses to start without it (#844). That is
+**by design**, not a failure: provisioning a VPS does not bring up the app; the first deploy does.
 
 ### When the live hostname has a numeric suffix (`-1`, `-2`, …) {#tailscale-suffix-drift}
 
@@ -754,7 +783,7 @@ gh workflow run "Deploy to prod VPS" \
 
 ### Recovering `.env` after destroy
 
-`.env` is workflow-staged from GH Secrets (#841), so it auto-rebuilds on the next `deploy-prod.yml` or `prod-restore-corpus.yml` run. No manual step. If you've never staged the secrets before, follow [Stage `.env` (workflow-staged from GH Secrets)](#stage-env-workflow-staged-from-gh-secrets--841) one-time.
+`.env` is workflow-staged from GH Secrets (#841), so it auto-rebuilds on the next `deploy-prod.yml` or `prod-restore-corpus.yml` run. No manual step. If you've never staged the secrets before, follow [Stage `.env` (workflow-staged from GH Secrets)](#stage-env-workflow-staged-from-gh-secrets-841) one-time.
 
 ### State drift gotchas
 

--- a/docs/wip/OPERATOR_HANDOFF_NOTES_2026-06-21.md
+++ b/docs/wip/OPERATOR_HANDOFF_NOTES_2026-06-21.md
@@ -1,0 +1,152 @@
+# Operator handoff audit — gap notes (#805)
+
+**Date:** 2026-06-21 · **Method:** static fresh-eyes audit of the bootstrap path
+(not a live drill — see caveat). **Auditor:** agent walk of `PROD_RUNBOOK.md §First-time
+bootstrap`, `DR_DRILL_RUNBOOK.md`, `infra/deploy/deploy.sh`, cross-checked against the
+actual scripts and the (closed) prerequisites issue #714.
+
+**Premise under test (from #805):** *can a second person deploy/recover prod using only
+what's in this repo?* Each gap below is something that breaks that premise.
+
+> **Caveat — this is ~70% of #805.** A static audit catches repo-self-containment and
+> drift gaps. It does **not** catch live-only failures: token expiry at call time,
+> account/billing state, cloud-init timing, network reachability, Tailscale DNS latency.
+> Those need the live VPS drill (AC #1), which stays operator-owned.
+
+This file is transient (per #805 AC #4): delete once all gaps below are closed.
+
+---
+
+## Confirmed gaps (verified against the actual files)
+
+### G1 — Prerequisites checklist is not in the repo, and the pointer is stale  ★ bus-factor critical
+`PROD_RUNBOOK.md:28-32` says *"For the prerequisites checklist … see [#714]. All commands
+below assume those are done."* But:
+- **#714 is CLOSED** and lives outside the repo → fails the "only what's in this repo" test.
+- **#714 is stale.** It documents the Tailscale **OAuth** model (`TS_OAUTH_CLIENT_ID` +
+  `TS_OAUTH_CLIENT_SECRET`, Premium+). The current runbook (`:72-77`) uses the **Free-plan**
+  `TS_AUTHKEY` + `TS_API_KEY` workaround. A fresh operator following #714 sets up the wrong creds.
+- #714 also omits the runtime accounts entirely (6 LLM providers, Sentry org + 3 projects,
+  Grafana Cloud stack, backup-repo PAT) — those are "out of scope" in #714 but a fresh operator
+  still needs them.
+
+**Fix:** add a self-contained `docs/guides/BOOTSTRAP_PREREQUISITES.md` (accounts + credentials,
+corrected to the Free-plan Tailscale model, including runtime provider/Sentry/Grafana accounts).
+Repoint `PROD_RUNBOOK.md:28` to it; demote #714 to a historical reference.
+
+### G2 — Bootstrap sections are topical, not linearly ordered
+A fresh operator reading `§First-time bootstrap` top-to-bottom hits **"GitHub Actions SSH to
+prod"** (`:91`) and **"deploy to DR drill"** (`:138`) *before* **"First `tofu apply`"** (`:184`)
+— but you cannot SSH to a VPS that doesn't exist yet. There's no "do these in this order" map.
+
+**Fix:** add a numbered **"Bootstrap sequence at a glance"** ordered list at the top of
+`§First-time bootstrap` (prereqs → tofu apply → wait for cloud-init → set `PROD_TAILNET_FQDN` →
+CI SSH key → stage `.env` secrets → first deploy → smoke), each linking its section.
+
+### G3 — Secret retrieval hardcodes 1Password (`op read`)
+`PROD_RUNBOOK.md:188,190` use `op read 'op://Personal/…'`. The operator does not use 1Password,
+and a fresh operator may not either — the command fails with no fallback. (Same `op read`
+pattern is copied into #714's smoke test.)
+
+**Fix:** make retrieval password-manager-agnostic — placeholder `<your Hetzner API token>` /
+`<your Tailscale API key>` with a note "(from your secrets store; e.g. `op read …`, `pass`, env)".
+
+### G4 — No cloud-init readiness/wait guidance between `tofu apply` and first SSH
+**Verified.** `§First tofu apply` (`:184-209`) ends at the GHA-variable step. Nothing tells the
+operator that the VPS needs minutes of cloud-init before SSH/Tailscale work, or how to poll
+readiness. The only timing hint is "~30–45 min wall" at the very top (`:57`).
+
+Actual readiness mechanism (confirmed in `infra/cloud-init/prod.user-data`): cloud-init runs
+`tailscale up` (`:187`), clones the repo to `/srv/podcast-scraper` (`:194-196`), enables
+`podcast-scraper.service` (`:241`) — but the service's `ExecStartPre=/usr/bin/test -f .env`
+(`:97`) means the stack does **not** come up until `.env` exists, which `deploy-prod.yml` renders
+at first deploy. cloud-init prints a `final_message` (`:246`) after `$UPTIME` seconds.
+
+**Fix:** add a short readiness note after first apply — expected cloud-init duration + how to
+check (Tailscale machine online in admin, an `ssh deploy@… 'echo ok'` attempt). Make explicit
+that the stack stays down until the **first `deploy-prod.yml`** stages `.env` — that's by design,
+not a failure.
+
+### G7 — `#844` removed the `.bootstrap-needs-env` sentinel, but stale operator instructions remain  ★ correctness
+**Verified at code level.** `#841`/`#844` changed first-boot: `.env` is now workflow-staged
+(`deploy-prod.yml` renders it from GH Secrets) and the systemd unit gates on
+`ExecStartPre=/usr/bin/test -f /srv/podcast-scraper/.env` (`prod.user-data:97`). The
+`.bootstrap-needs-env` sentinel is gone — `write_files` no longer creates it (only the history
+comment at `prod.user-data:40-45` remains). **But four operator-facing references still describe
+the old flow:**
+- `infra/cloud-init/prod.user-data:246-249` — `final_message` tells the operator to *"stage
+  `.env`, then `sudo rm /srv/podcast-scraper/.bootstrap-needs-env && sudo systemctl restart`"*.
+  The `rm` targets a file that is never created; the "manually stage `.env`" step is superseded by
+  workflow staging (#841). **This is the message a fresh operator sees on the console first.**
+- `infra/cloud-init/prod.user-data:240` — comment "Enable systemd unit (will block on
+  `.bootstrap-needs-env`)" → the unit blocks on `test -f .env`, not the sentinel.
+- `infra/cloud-init/prod.user-data:190-193` — comment "write_files may already have created
+  `.bootstrap-needs-env`" → it no longer does.
+- `PROD_RUNBOOK.md:158` (drill section) — repeats *"stage `.env`, then `sudo rm
+  /srv/podcast-scraper/.bootstrap-needs-env` so Docker Compose can start"*.
+
+**Fix:** rewrite the `final_message` to the #841/#844 flow ("stage the 15 PROD_* secrets in repo
+settings, then run `deploy-prod.yml` — it renders `.env` and brings the stack up"); drop the
+sentinel `rm` from `PROD_RUNBOOK.md:158`; correct the two stale history comments (`:190`, `:240`)
+so they don't re-mislead. This is a cross-repo-consistency correctness fix, not just docs.
+
+### G5 — `deploy.sh` exit code 4 is undocumented in its own header
+`infra/deploy/deploy.sh:9-13` documents exit codes 0–3. The script also exits **4** on
+`DEPLOY_GIT_SHA`/`DEPLOY_IMAGE_SHA` validation failures (`:65,:72,:82`). An operator reading the
+header to interpret a failed deploy has no entry for 4.
+
+**Fix:** add exit 4 to the header comment block. (In-script, trivial.)
+
+---
+
+## Minor / optional (low ROI — note, don't necessarily fix this round)
+
+### G6 — `deploy.sh` defensive behaviors not reflected in the runbook narrative
+`deploy.sh` auto-creates `.env` and injects `PODCAST_DOCKER_PROJECT_DIR` /
+`PODCAST_CORPUS_HOST_PATH` if missing (`:26-40`), and auto-repairs
+`/usr/local/sbin/podcast-tailscale-serve.sh` from the repo (`:98-107`, `:131-146`, needs a
+sudoers `install` rule). Harmless belt-and-suspenders, but a fresh operator debugging `.env`
+or MagicDNS wouldn't know the deploy script self-heals these. Optional one-line note.
+
+---
+
+## Audit false-positives (claimed by the first-pass scan, but actually fine — do NOT "fix")
+
+- **`.sops.yaml` edit path** — already given explicitly at `PROD_RUNBOOK.md:68`
+  ("Copy the public key … into `infra/.sops.yaml`").
+- **`./tofu` wrapper location** — runbook already does `cd infra && ./tofu init` (`:187-194`);
+  it's unambiguously run from `infra/`. (Could add one line on *what* the wrapper does, but not a gap.)
+- **Per-secret "feature off if missing" mapping** — already documented in the
+  `§Environment variable reference` tables ("Notes if missing" column, `:1253+`). The
+  `§Stage .env` table (`:255`) could cross-link it, but the information exists.
+
+---
+
+## Disposition for #805
+
+- **AC #2 (notes file with itemized gaps):** this file. ✅
+- **AC #3 (gaps fixed via runbook PRs):** G1–G5 fixed in the same PR (see scope doc).
+- **AC #1 (live drill completed):** operator-owned. Either run later, or de-scope explicitly
+  with a one-liner in the issue (the AC permits "explicitly de-scoped"). **Decision pending.**
+- **AC #4 (delete this file once gaps close):** after G1–G5 merge + AC #1 resolved.
+- **AC #5 (cadence: repeat every 6 months / after major infra change):** add to the runbook's
+  maintenance notes.
+
+## Deferred — DR-drill validation of the cloud-init change
+
+The only functional file this PR touches is `infra/cloud-init/prod.user-data` (G7: `final_message`
+rewrite + 2 comments — cosmetic, no behavior change). Validate it via the DR drill **after this
+batch ships and `main` is stable** (operator decision, 2026-06-21 — not now):
+
+- **Cheap guard:** `drill-infra-plan` against the branch — `tofu validate`/`plan` renders the
+  `prod.user-data` templatefile and catches any breakage; **provisions no infra**.
+- **Full end-to-end (optional):** `drill-exercise` (`DRILL_FULL_CYCLE`) — boots a real drill VPS
+  from this cloud-init, deploys, always destroys (~€0.01, ~15-20 min).
+
+**Caveat (do not oversell):** the drill validates cloud-init **boot**, not the runbook prose.
+G1–G4 + the G7 runbook text are human-followability fixes — only the AC #1 human walk validates
+those. A green drill ≠ "the hardened runbook is followable." Local `mkdocs --strict` + `markdownlint`
++ `shellcheck` already passed for this PR; template render is the only unvalidated piece, and it's
+cosmetic.
+
+Source-of-truth scope: `docs/wip/V27-OBSERVABILITY-SCOPE-803-805-426_2026-06-21.md`.

--- a/docs/wip/V27-OBSERVABILITY-SCOPE-803-805-426_2026-06-21.md
+++ b/docs/wip/V27-OBSERVABILITY-SCOPE-803-805-426_2026-06-21.md
@@ -1,0 +1,167 @@
+# v2.7 observability close-out — scope for #803 / #805 / #426
+
+**Date:** 2026-06-21 · **Branch (current):** `feat/audio-waves-hardening` (will branch fresh per issue)
+**Goal:** value-focused scope to *close* three open v2.7 issues, mapped to current code shape.
+**Status:** analysis + agreed direction; awaiting go to implement.
+
+Direction locked with operator (2026-06-21):
+- **#803** — full solution, no drops. (#804 confirmed CLOSED/shipped → not a blocker.)
+- **#805** — static fresh-eyes audit + runbook-hardening PR; the **live drill stays operator-owned**.
+- **#426** — pivot from "rule-adherence metrics" to **Langfuse integration for AI metrics**, coexisting
+  with the existing custom cost/metrics solution ("own solution + Langfuse", not rip-and-replace).
+
+---
+
+## #803 — Deploy observability (Grafana + Sentry + MCP) — FULL build
+
+### Already in place (~60%)
+- Loki + Grafana Cloud shipping: `compose/grafana-agent.yaml`; 7 dashboards in `config/grafana/`.
+- Sentry SDK wired, `PODCAST_RELEASE` read at `src/podcast_scraper/utils/sentry_init.py:85`.
+- MCP server exists (FastMCP, 13 corpus tools, stdio launch via `podcast mcp --corpus`):
+  `src/podcast_scraper/mcp/server.py`.
+- API endpoints: `/api/health` (`server/routes/health.py`, returns code/corpus versions + feature flags),
+  `/api/jobs` (`server/routes/jobs.py`, `PipelineJobRecord`).
+- Cost data (#804): `emit_llm_cost_event()` → Loki (`workflow/cost_monitoring.py:49`);
+  `corpus_manifest.json.cost_rollup` (`{by_stage, total_cost_usd, run_count}`) on disk.
+- `PROD_GRAFANA_CLOUD_API_KEY` already a staged secret (`deploy-prod.yml`).
+
+### Gaps to close
+- **D1** — no structured `DEPLOY_EVENT` emission; no "Deploys" panel.
+- **D2** — `PODCAST_RELEASE` set but no Sentry release-boundary API call; `SENTRY_AUTH_TOKEN` not staged.
+- **D3** — 0 of 7 prod-state MCP tools.
+- **D4** — `PROD_RUNBOOK § Daily ops → Where to look first` exists (:469) but no deploy/MCP rows.
+
+### Scope (no drops)
+**D1 — deploy events + panel**
+- Emit a structured `DEPLOY_EVENT` JSON line (`status`, `sha`, `duration_ms`, `triggered_by`) from
+  `deploy-prod.yml` around the deploy step (capture start/end ts in workflow; `deploy.sh` doesn't time itself).
+- New dashboard `config/grafana/grafana-dashboard-deploy-observability.json`:
+  deploys/week, failure rate, p95 duration, MTTR — all Loki LogQL over `event_type="deploy_event"`.
+
+**D2 — Sentry release boundary**
+- New `deploy-prod.yml` step after successful deploy: create + finalize Sentry release `sha-<short>`,
+  attach a `deploys/` marker for env=prod (api/pipeline/viewer projects).
+- *Operator-gated:* stage `SENTRY_AUTH_TOKEN` secret; verify boundary appears after one real deploy.
+
+**D3 — prod-state MCP server (all 7 tools, separate from corpus MCP)**
+- New module `src/podcast_scraper/observability/` + `podcast observability` stdio entry (mirrors `podcast mcp`).
+  Kept separate because corpus MCP binds an immutable corpus dir; prod-monitor needs external-API egress.
+- Tools:
+  1. `prod_health()` → GET `/api/health` over `PROD_TAILNET_FQDN`.
+  2. `prod_deployed_version()` → `code_version` + `corpus_produced_by.git_sha` from health.
+  3. `prod_recent_pipeline_runs(limit)` → GET `/api/jobs`.
+  4. `prod_recent_deploys(limit)` → GitHub Actions REST (`deploy-prod.yml` runs). *Needs a read-only GH token.*
+  5. `prod_cost_today()` → Loki LogQL sum of `estimated_cost_usd` over 24h (`PROD_GRAFANA_CLOUD_API_KEY`,
+     already staged). Fallback: `corpus_manifest.cost_rollup`.
+  6. `prod_recent_errors(window)` → Sentry API (reuses `SENTRY_AUTH_TOKEN` from D2). env=prod.
+  7. `prod_recent_alerts(window)` → Grafana Cloud alerting API (`PROD_GRAFANA_CLOUD_API_KEY`).
+- Read-only only; no mutation tools. Reuses `providers/resilience/sockets.py` httpx client pattern.
+
+**D4 — docs**
+- PROD_RUNBOOK `Where to look first`: add "ask MCP" rows + example agent prompts; document the new panel.
+
+### Operator-gated handoff (not drops — the operator-side of any obs feature)
+1. Stage `SENTRY_AUTH_TOKEN` (Sentry org token).
+2. Provide a read-only GitHub token for `prod_recent_deploys` (fine-grained, Actions:read).
+3. Import the new Grafana dashboard JSON (dashboards are hand-imported today — existing pattern, not new debt).
+4. One live deploy to confirm D1 events + D2 release boundary render. (Can't be asserted working without it.)
+
+### Effort: M–L. Code-complete except the 4 operator-gated items above.
+
+---
+
+## #805 — Operator handoff dry-run (bus factor)
+
+### Reality
+- Three docs exist + are detailed: `PROD_RUNBOOK.md` (~2023 lines), `DR_DRILL_RUNBOOK.md` (~203),
+  `PROD_OPERATOR_CHEAT_SHEET.md` (~227). No prior handoff/dry-run notes exist — this is the first pass.
+- The issue's literal deliverable (provision drill VPS → deploy → validate → destroy) is **live infra**;
+  per operator standing rule this stays operator-owned. The issue's *real output* is "gap list → runbook PRs",
+  which a static audit produces.
+
+### Gaps the static audit already surfaced
+- **3 runbook clarity gaps:** no account-prereqs checklist; no "secret X missing → which feature turns off"
+  table; `.sops.yaml` edit path unstated; `./tofu` wrapper (not in PATH, run from `infra/`) unexplained;
+  cloud-init wait time vague.
+- **Script↔runbook drift** in `infra/deploy/deploy.sh`: `.env` auto-injection of
+  `PODCAST_DOCKER_PROJECT_DIR`/`PODCAST_CORPUS_HOST_PATH`, tailscale-serve auto-repair, exit-code 4 — undocumented.
+- **~25 implicit prerequisites:** 10 provider accounts (OpenAI/Anthropic/Gemini/Mistral/DeepSeek/Grok +
+  Sentry/Grafana), Hetzner+Tailscale setup, SSH keys, CLI tools (opentofu/sops/age/actionlint/shellcheck/gh).
+
+### Scope to close
+- Write `docs/wip/OPERATOR_HANDOFF_NOTES_2026-06-21.md` — itemized gaps, one TODO each (satisfies AC #2).
+- Runbook-hardening PR closing the doc gaps: add **Account-prerequisites checklist**, a
+  **secret failure-mode table**, `.sops.yaml`/`./tofu` clarifications, cloud-init wait guidance, and
+  reconcile the deploy.sh drift (satisfies AC #3 via runbook PRs).
+- **AC #1 (live drill) stays operator-owned:** operator runs it later, or we explicitly de-scope it in the
+  issue with a one-line rationale (the AC permits "explicitly de-scoped"). Notes file deleted when gaps close (AC #4).
+
+### Honest caveat
+Static audit ≠ live drill. It cannot catch timing/account-state/token-expiry/network failures. ~70% of the
+value; the live walk is the remaining ~30% and is the operator's to run.
+
+### Effort: S–M (docs only).
+
+---
+
+## #426 — pivot to Langfuse for AI metrics (own solution + Langfuse)
+
+### Reality of the original issue
+- `.cursorrules` slimmed 527→68 lines, now points to **AGENTS.md as canonical** (since 2026-05-21);
+  11 `.mdc` files under `.cursor/rules/` (issue said 6). Metrics path moved `.cursor/metrics/` → `.metrics/`.
+- `.metrics/rule-adherence.jsonl` is gitignored, **manual-only, never collected, no analysis tooling** —
+  dormant for 2 months. The issue body is ~80% a KPI/framework *reference* (SPACE/DORA/Copilot/SWE-bench).
+- Decision: **don't revive the unused JSONL pipeline**; pivot the ticket to Langfuse for LLM/AI metrics.
+
+### Architecture finding — integration is EASY (hybrid, ~80/20)
+- LLM calls are scattered across 8 providers (no base class/factory), BUT cost/metrics already funnel through
+  a **single choke point**: `ProviderCallMetrics` → `record_provider_call_cost()`
+  (`src/podcast_scraper/utils/provider_metrics.py:153`) → `emit_llm_cost_event()`
+  (`workflow/cost_monitoring.py:49`).
+- That choke point is the one place to add Langfuse spans → captures every LLM call with minimal scattered edits.
+- Config/feature-flag pattern to mirror: Sentry's "enable-only-when-secret-present" (`sentry_init.py:50`).
+- Prompts are file-based Jinja2 (`src/podcast_scraper/prompts/<provider>/<capability>/*.j2`); eval harness in
+  `scripts/eval/` + `data/eval/` silver/judges → future Langfuse prompt-mgmt + eval-scoring tie-in (phase 2).
+
+### "Own solution + Langfuse" — coexistence model
+- **Own solution stays:** Loki/Grafana cost pipeline (#804) + `corpus_manifest.cost_rollup` + Sentry cost alerts.
+  Source of truth for cost/ops, unchanged.
+- **Langfuse adds (AI-metrics lens):** per-call traces (prompt/completion/model/latency/tokens/cost),
+  grouped by run/episode/stage; quality/eval scores; guardrail outcomes (ADR-100 `triggered_guardrail`) as a
+  trace signal; prompt versioning. Both emit at the same choke point — no rip-and-replace.
+
+### Scope to close
+- Add `langfuse` optional dep (`pyproject.toml [project.optional-dependencies]`).
+- Config wiring: `langfuse_public_key` / `langfuse_secret_key` / `langfuse_base_url` (Sentry env pattern;
+  no-op when unset).
+- New `src/podcast_scraper/utils/langfuse_tracing.py`: `init_langfuse(cfg)` + `emit_langfuse_span(...)`
+  (optional import, silent no-op when disabled).
+- One hook in `record_provider_call_cost()` (covers all stages) + provider-init client ref (~1 line × 8).
+- Map run/episode/stage onto Langfuse trace/observation hierarchy so traces group like the pipeline does.
+- Docs: how to enable (set keys), what own-solution-vs-Langfuse each answers; reconcile #426's stale facts;
+  retire the dormant rule-adherence JSONL framing (note it as superseded, not deleted).
+- **Phase 2 (optional, flag now):** Langfuse prompt management + wiring the autoresearch eval scores as
+  Langfuse scores. Bigger; can be a follow-up if scope creeps.
+
+### Operator-gated handoff
+- Provide Langfuse keys (self-hosted `base_url` or Langfuse Cloud).
+- Decide self-hosted vs cloud (self-hosted = another homelab/Hetzner service to run).
+
+### Effort: M (core tracing). Phase-2 eval/prompt-mgmt: separate.
+
+---
+
+## Suggested execution order
+1. **#805** (docs-only, fastest, unblocks nothing else) — audit notes + runbook PR.
+2. **#803** (the meaty infra one) — D1/D2/D4 + the observability MCP module.
+3. **#426/Langfuse** (new integration) — core tracing at the choke point; phase-2 deferred.
+
+Each as its own branch off fresh `main` + its own PR. All three are v2.7 — closing them advances the milestone.
+
+## Decisions locked (operator, 2026-06-21)
+- **#803:** separate `podcast observability` stdio MCP server (NOT folded into corpus MCP).
+- **#426:** Langfuse integration built **host-agnostic** (`base_url` config) — Cloud vs self-hosted decided
+  at provisioning time, not a code constraint.
+- **#426:** **core tracing now, phase-2 later** — ship per-call traces at the choke point this round;
+  prompt management + autoresearch eval-score wiring deferred to a follow-up.
+- **Execution order:** #805 → #803 → #426. Each its own branch + PR off fresh `main`.

--- a/docs/wip/V27-OBSERVABILITY-SCOPE-803-805-426_2026-06-21.md
+++ b/docs/wip/V27-OBSERVABILITY-SCOPE-803-805-426_2026-06-21.md
@@ -179,6 +179,31 @@ value; the live walk is the remaining ~30% and is the operator's to run.
 
 Each as its own branch off fresh `main` + its own PR. All three are v2.7 — closing them advances the milestone.
 
+## Progress / resume point (2026-06-21)
+
+Branch `feat/v27-observability-batch` — **8 commits, working tree clean, NOT pushed**.
+
+**Done + live-validated:**
+- **#805** — runbook hardening committed (`f557797e`). DR-drill validation of the cloud-init
+  change deferred (see `OPERATOR_HANDOFF_NOTES_2026-06-21.md`).
+- **#803 control plane** — core (8 probes) + CLI + MCP (stdio/sse/http) + Docker (273MB image,
+  build verified) + guide + `.env.example` + make targets (`obs-test`/`obs-e2e`/`obs-docker-build`/
+  `obs-summary`/`obs-serve`). **Live loop CLOSED: all 8 sources green, `obs-e2e` 8/8 pass** against
+  real prod APIs. Loki/Grafana token-split bug found + fixed via live validation (`83f08550`).
+
+**Remaining on #803 (resume here):**
+- **D1** — emit a `DEPLOY_EVENT` JSON line (`status`/`sha`/`duration_ms`/`triggered_by`) from
+  `.github/workflows/deploy-prod.yml` around the deploy step (capture start/end ts in the workflow;
+  `deploy.sh` doesn't time itself), + a Loki panel `config/grafana/grafana-dashboard-deploy-observability.json`.
+- **D2** — Sentry release-boundary step in `deploy-prod.yml` after a successful deploy (create +
+  finalize release `sha-<short>`, env=prod). **Needs `SENTRY_AUTH_TOKEN` staged** — operator is
+  setting up the Internal Integration with **Release:Admin** (same token the control plane's `errors` uses).
+- **Viewer "Ops" view** — phase 2, human parity with the MCP.
+- Optional: a live `summary`/`obs-e2e` re-run already passes; no blocker.
+
+**To continue from home:** `git switch feat/v27-observability-batch`; `source .env` to get the
+`PODCAST_OBS_*` creds; `make obs-summary` to confirm 8/8 live. Then start D1 in `deploy-prod.yml`.
+
 ## Decisions locked (operator, 2026-06-21)
 - **#803:** separate `podcast observability` stdio MCP server (NOT folded into corpus MCP).
 - **#426:** Langfuse integration built **host-agnostic** (`base_url` config) — Cloud vs self-hosted decided

--- a/docs/wip/V27-OBSERVABILITY-SCOPE-803-805-426_2026-06-21.md
+++ b/docs/wip/V27-OBSERVABILITY-SCOPE-803-805-426_2026-06-21.md
@@ -191,15 +191,17 @@ Branch `feat/v27-observability-batch` — **8 commits, working tree clean, NOT p
   `obs-summary`/`obs-serve`). **Live loop CLOSED: all 8 sources green, `obs-e2e` 8/8 pass** against
   real prod APIs. Loki/Grafana token-split bug found + fixed via live validation (`83f08550`).
 
-**Remaining on #803 (resume here):**
+**Viewer "Ops" view — DONE** (`f135335a`): `GET /api/ops/summary` (wraps `podcast_obs` summary) +
+a new "Ops" tab in the viewer rendering a card per source (live/unconfigured/failed + a compact
+stat). Human parity with the MCP. vue-tsc strict build + vitest + backend tests + full mypy green.
+
+**Remaining on #803 (resume here) — only D1/D2 left:**
 - **D1** — emit a `DEPLOY_EVENT` JSON line (`status`/`sha`/`duration_ms`/`triggered_by`) from
   `.github/workflows/deploy-prod.yml` around the deploy step (capture start/end ts in the workflow;
   `deploy.sh` doesn't time itself), + a Loki panel `config/grafana/grafana-dashboard-deploy-observability.json`.
 - **D2** — Sentry release-boundary step in `deploy-prod.yml` after a successful deploy (create +
-  finalize release `sha-<short>`, env=prod). **Needs `SENTRY_AUTH_TOKEN` staged** — operator is
-  setting up the Internal Integration with **Release:Admin** (same token the control plane's `errors` uses).
-- **Viewer "Ops" view** — phase 2, human parity with the MCP.
-- Optional: a live `summary`/`obs-e2e` re-run already passes; no blocker.
+  finalize release `sha-<short>`, env=prod). **Needs `SENTRY_AUTH_TOKEN` staged** — the Internal
+  Integration with **Release:Admin** (same token the control plane's `errors` uses).
 
 **To continue from home:** `git switch feat/v27-observability-batch`; `source .env` to get the
 `PODCAST_OBS_*` creds; `make obs-summary` to confirm 8/8 live. Then start D1 in `deploy-prod.yml`.

--- a/docs/wip/V27-OBSERVABILITY-SCOPE-803-805-426_2026-06-21.md
+++ b/docs/wip/V27-OBSERVABILITY-SCOPE-803-805-426_2026-06-21.md
@@ -12,7 +12,28 @@ Direction locked with operator (2026-06-21):
 
 ---
 
-## #803 — Deploy observability (Grafana + Sentry + MCP) — FULL build
+## #803 — Prod observability **control plane** (Grafana + Sentry + CLI + MCP) — FULL build
+
+> **Reframe (2026-06-21, operator-confirmed; #803 body updated).** D3 grew from "an MCP server"
+> into a small **portable control plane**, layered so each layer works standalone:
+>
+> - **Core lib** `src/podcast_scraper/observability/` — **light-dep** (httpx + config; NOT torch/spacy)
+>   so it runs cheaply anywhere. Pure probe/aggregate functions: health, deployed version, recent
+>   deploys (GitHub API), recent pipeline runs (prod `/api/jobs`), cost-today (Loki/manifest),
+>   recent errors (Sentry API), recent alerts (Grafana API), + a `summary`.
+> - **CLI ("the basics")** — directly probeable/scriptable, no MCP needed.
+> - **MCP server** — thin wrapper over the core; **stdio for local dev, HTTP/SSE for the container**
+>   (so agents on other tailnet boxes can reach it).
+> - **Packaging** — a light `[observability]` extra + a **Docker image** the operator runs on the MBP /
+>   an Orb / a Mac mini in the tailnet = a **mini control plane**. Also runnable as a plain local process.
+> - **Surfaces:** MCP is the primary consumer; **Phase 2 (same ticket/branch):** a viewer "Ops" view
+>   for human parity, after the control plane works.
+> - **Guide** `docs/guides/OBSERVABILITY_CONTROL_PLANE.md` — run (local + Docker), configure, and the
+>   **agent orchestration recipe** (use alongside Grafana MCP + other MCPs).
+> - Cost duplication with #426/Langfuse accepted (explore + compare later).
+>
+> **Build order:** core+config → CLI → MCP (stdio+HTTP/SSE) → Docker → D1/D2 → viewer (phase 2) → guide.
+> The D1–D4 detail below still holds for the underlying probes/panels.
 
 ### Already in place (~60%)
 - Loki + Grafana Cloud shipping: `compose/grafana-agent.yaml`; 7 dashboards in `config/grafana/`.
@@ -164,4 +185,6 @@ Each as its own branch off fresh `main` + its own PR. All three are v2.7 — clo
   at provisioning time, not a code constraint.
 - **#426:** **core tracing now, phase-2 later** — ship per-call traces at the choke point this round;
   prompt management + autoresearch eval-score wiring deferred to a follow-up.
-- **Execution order:** #805 → #803 → #426. Each its own branch + PR off fresh `main`.
+- **Execution order:** #805 → #803 → #426, in that order, but **all on ONE branch**
+  (`feat/v27-observability-batch`), pushed once at the end as a single batch PR. No per-issue
+  branches. (#805 already committed on this branch.)

--- a/docs/wip/WIP_README.md
+++ b/docs/wip/WIP_README.md
@@ -16,6 +16,7 @@ WIP file is removed.
 
 | File | Description | Status |
 | ---- | ----------- | ------ |
+| `V27-OBSERVABILITY-SCOPE-803-805-426_2026-06-21.md` | Value-focused close-out scope for 3 v2.7 issues: #803 full deploy-observability build (deploy events + Grafana panel + Sentry release boundary + 7-tool prod-monitor MCP), #805 static handoff audit + runbook PR (live drill stays operator-owned), #426 pivot to Langfuse AI-metrics tracing coexisting with the existing cost/Loki solution. Awaiting go. | Active |
 | `PHASE1-OPEN-WEIGHT-LLM-LANDSCAPE-2026-06.md` | #928 reframe Phase 1: open-weight LLM landscape (≤35B) → 6-candidate tier-1 shortlist (Qwen3.5:35b incumbent + Qwen3-30B-A3B-Instruct-2507 + DeepSeek-R1-Distill-32B + Magistral 1.2 + Mistral Small 4 + gemini-2.5-flash-lite cloud anchor). Phase 2 eval → #1016. | Active |
 | `EVAL_1016_LANDSCAPE_2026_06.md` | #1016 Phase 2 per-stage eval (summary / GI / KG) of the 6-candidate cohort; dual-silver methodology (Opus 4.7 + Sonnet 4.6) + multi-vendor judge panel (Sonnet 4.6 + GPT-5.4). Promoted to `docs/guides/eval-reports/` when complete. | Active |
 | `EVAL_1016_metrics/vllm_metrics_*_phase2c.log` | Raw vLLM `/metrics` polls per candidate (input data for the canonical per-model param compendium, which lives at `autoresearch/PER_MODEL_OPTIMAL_PARAMS.md`) | Reference |

--- a/infra/cloud-init/prod.user-data
+++ b/infra/cloud-init/prod.user-data
@@ -187,10 +187,12 @@ runcmd:
   - tailscale up --auth-key='${tailscale_auth_key}' --hostname='${tailnet_hostname}' --advertise-tags='${tailscale_advertise_tags_cli}' --ssh=false
 
   # === Repo checkout to /srv/podcast-scraper ===
-  # ``write_files`` may already have created ``.bootstrap-needs-env`` under this
-  # directory, so ``git clone`` directly into ``/srv/podcast-scraper`` fails
-  # (non-empty destination) and the tree never appears — deploy workflows then
-  # see ``deploy.sh: No such file or directory`` while SSH auth still works.
+  # Clone-to-tmp + ``cp -a`` (not a direct ``git clone`` into ``/srv/podcast-scraper``)
+  # so a non-empty destination can't make the clone fail and leave the tree absent —
+  # deploy workflows would then see ``deploy.sh: No such file or directory`` while SSH
+  # auth still works. Kept defensively against any future ``write_files`` entry under
+  # ``/srv/podcast-scraper`` (the old ``.bootstrap-needs-env`` sentinel that originally
+  # motivated this was removed in #844).
   - install -d -o deploy -g deploy -m 0755 /srv/podcast-scraper
   - sudo -u deploy bash -c 'set -euo pipefail; t=/tmp/podcast-scraper-clone; rm -rf "$t"; git clone --branch main --depth 50 https://github.com/chipi/podcast_scraper.git "$t"; cp -a "$t"/. /srv/podcast-scraper/; rm -rf "$t"'
   - chown -R deploy:deploy /srv/podcast-scraper
@@ -237,7 +239,7 @@ runcmd:
   - systemctl daemon-reload
   - systemctl enable --now alloy
 %{ endif ~}
-  # === Enable systemd unit (will block on .bootstrap-needs-env) ===
+  # === Enable systemd unit (won't start until .env exists — ExecStartPre, #844) ===
   - systemctl enable podcast-scraper.service
   - systemctl start podcast-scraper.service || true
 
@@ -245,5 +247,8 @@ runcmd:
 
 final_message: |
   podcast-scraper-prod cloud-init complete after $UPTIME seconds.
-  Next step (operator): SSH in via Tailscale, stage /srv/podcast-scraper/.env,
-  then `sudo rm /srv/podcast-scraper/.bootstrap-needs-env && sudo systemctl restart podcast-scraper.service`.
+  The stack is intentionally DOWN: podcast-scraper.service refuses to start until
+  /srv/podcast-scraper/.env exists (ExecStartPre, #844).
+  Next step (operator): stage the PROD_* secrets in repo settings, then run
+  deploy-prod.yml — it renders /srv/podcast-scraper/.env from GH Secrets (#841)
+  and brings the stack up. No manual .env editing or SSH required.

--- a/infra/deploy/deploy.sh
+++ b/infra/deploy/deploy.sh
@@ -11,6 +11,8 @@
 #   1  pull failed
 #   2  compose up failed
 #   3  /api/health did not return 200 within the timeout
+#   4  DEPLOY_GIT_SHA / DEPLOY_IMAGE_SHA validation failed (format mismatch or
+#      git/image SHA disagree on the 7-char prefix)
 set -euo pipefail
 
 REPO_DIR=/srv/podcast-scraper

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - Stack contract (cross-surface audit): guides/STACK_CONTRACT.md
       - Corpus snapshot manifest and restore: guides/CORPUS_SNAPSHOT_MANIFEST_AND_RESTORE.md
       - Prod Operator Cheat Sheet: guides/PROD_OPERATOR_CHEAT_SHEET.md
+      - Observability control plane (#803): guides/OBSERVABILITY_CONTROL_PLANE.md
       - GHCR image retention (#802): operations/GHCR_RETENTION.md
       - DGX model catalog (RFC-089 / ADR-098): operations/DGX_MODEL_CATALOG.md
       - Polyglot repository layout: guides/POLYGLOT_REPO_GUIDE.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
       - Quick Reference: guides/QUICK_REFERENCE.md
       - Development Guide: guides/DEVELOPMENT_GUIDE.md
       - Release Playbook: guides/RELEASE_PLAYBOOK.md
+      - Bootstrap prerequisites (accounts + credentials): guides/BOOTSTRAP_PREREQUISITES.md
       - Prod Runbook (always-on VPS): guides/PROD_RUNBOOK.md
       - DGX Spark runbook (RFC-089): guides/DGX_RUNBOOK.md
       - Prod compat validation (#796/#797): guides/PROD_COMPAT_VALIDATION.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,16 @@ dependencies = [
 #   compare   — Streamlit compare UI (RFC-047)
 #   monitor   — py-spy + memray optional profiling (RFC-065; `--monitor` needs no extra)
 #   (FastAPI / uvicorn / metrics / scheduler for ``podcast serve`` live in [dev], not a separate extra.)
+#   observability — standalone prod control plane (#803, ``podcast_obs``). LIGHT by design.
+# Standalone prod observability control plane (#803). Intentionally LIGHT so it runs as a small
+# container anywhere on the tailnet — no torch/spaCy/pipeline deps. (httpx + PyYAML are already
+# base deps; listed here so a future slim ``podcast_obs``-only install is self-describing. The MCP
+# transport dep is added with the MCP slice.)
+observability = [
+  "httpx>=0.28.1,<1.0.0",
+  "PyYAML>=6.0.3,<7.0.0",
+]
+
 # Heavy ML dependencies - only install when needed
 ml = [
   "openai-whisper>=20231117",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,11 @@ dependencies = [
 #   observability — standalone prod control plane (#803, ``podcast_obs``). LIGHT by design.
 # Standalone prod observability control plane (#803). Intentionally LIGHT so it runs as a small
 # container anywhere on the tailnet — no torch/spaCy/pipeline deps. (httpx + PyYAML are already
-# base deps; listed here so a future slim ``podcast_obs``-only install is self-describing. The MCP
-# transport dep is added with the MCP slice.)
+# base deps; listed here so a future slim ``podcast_obs``-only install is self-describing.)
 observability = [
   "httpx>=0.28.1,<1.0.0",
   "PyYAML>=6.0.3,<7.0.0",
+  "mcp>=1.2.0,<2.0.0",  # FastMCP server for the agent-facing layer (stdio + sse/http)
 ]
 
 # Heavy ML dependencies - only install when needed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ ml = [
   # extractive QA: transformers 5 removed the ``question-answering`` pipeline task (CI preload).
   # CVE-2026-1839 (Trainer rng_state / torch.load): fixed in 5.0.0rc3+ only; pip-audit ignore in Makefile until 5.x stable.
   "transformers>=4.57.6,<5.0.0",
-  "sentencepiece>=0.1.99,<1.0.0",
+  "sentencepiece>=0.2.1,<1.0.0",
   # GIL evidence stack: SentenceTransformer + CrossEncoder (NLI); Docker .[ml] preload
   # v3+ CrossEncoder: pass local_files_only on constructor, not inside tokenizer/automodel kwargs
   "sentence-transformers>=5.4.1,<6.0.0",
@@ -121,7 +121,7 @@ llm = [
   # 1.x: ThinkingConfig.thinking_budget for gemini-2.5-flash (Issue #572); 0.x lacked the field
   "google-genai>=1.0.0,<2.0.0",
   "google-api-core>=2.30.3,<3.0.0",  # Required by google-genai for some operations
-  "anthropic>=0.101.0,<1.0.0",  # Anthropic API provider (Issue #106)
+  "anthropic>=0.111.0,<1.0.0",  # Anthropic API provider (Issue #106)
   # Mistral API provider (Issue #106). PyPI ``mistralai`` is quarantined (no installable
   # files on https://pypi.org/simple/mistralai/ as of 2026-05). Pin the official v2.4.5
   # tree (commit matches tag v2.4.5) until PyPI restores the project.
@@ -136,7 +136,7 @@ search = [
   "torch>=2.11.0,<3.0.0",
   # Pinned compatible with sentence-transformers 5.x — see [ml] for rationale.
   "transformers>=4.57.6,<5.0.0",
-  "sentencepiece>=0.1.99,<1.0.0",
+  "sentencepiece>=0.2.1,<1.0.0",
   "sentence-transformers>=5.4.1,<6.0.0",
   # RFC-090 two-tier hybrid backend: embedded vector + native FTS (BM25) in one store.
   "lancedb>=0.33.0,<1.0.0",
@@ -164,7 +164,7 @@ dev = [
   # Starlette TestClient (tests/conftest.py preload) requires httpx; not always
   # pulled as a transitive install in minimal CI venvs.
   "httpx>=0.28.1,<1.0.0",
-  "uvicorn[standard]>=0.48.0,<1.0.0",
+  "uvicorn[standard]>=0.49.0,<1.0.0",
   # Prometheus exporter for /metrics (gated on PODCAST_METRICS_ENABLED in app.py).
   "prometheus-fastapi-instrumentator>=8.0.0,<9.0.0",
   # In-process feed-sweep scheduler (#708); no-op unless ``scheduled_jobs:`` in viewer_operator.yaml.
@@ -190,12 +190,12 @@ dev = [
   # near-vestigial (CI/dashboard read radon directly; only local make complexity-track used it).
   "radon>=6.0.1,<6.1",
   "vulture>=2.16,<3.0.0",  # Dead code detection (RFC-031)
-  "interrogate>=1.5.0,<2.0.0",  # Docstring coverage (RFC-031)
+  "interrogate>=1.7.0,<2.0.0",  # Docstring coverage (RFC-031)
   "codespell>=2.4.2,<3.0.0",  # Spell checking (RFC-031)
   "jsonschema>=4.17.0,<5.0.0",  # Full JSON Schema validation for eval/GI/KG artifacts
   "pydeps>=3.0.2,<4.0.0",  # Module dependency visualization (RFC-038, #170)
   "pyan3==2.4.0",  # Call graph generation (Issue #425); 1.2.0 has CallGraphVisitor root bug
-  "code2flow>=2.5.0,<3.0.0",  # Flowcharts from code (Issue #425)
+  "code2flow>=2.5.1,<3.0.0",  # Flowcharts from code (Issue #425)
   # Diarization stack pins (RFC-058) — lazy-imported; keeps CI/dev venv aligned with [ml].
   # Must mirror the [ml] pin: pyannote 3.x is import-broken under torchaudio>=2.9
   # (AudioMetaData removed), which is exactly why [ml] moved to 4.x (#901).

--- a/scripts/ops/emit_deploy_event.sh
+++ b/scripts/ops/emit_deploy_event.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Push a structured deploy_event to Grafana Cloud Loki (#803 D1).
+#
+# The GHA runner's logs don't reach Loki (grafana-agent only scrapes the VPS containers), so
+# deploy-prod.yml pushes the deploy event directly here. Kept as a reusable script so it can be
+# exercised locally (against a `--env test` label) without a real prod deploy.
+#
+# Env (required): LOKI_PUSH_URL (…/loki/api/v1/push), LOKI_USER, LOKI_TOKEN (logs:write).
+# Args: --status S --sha SHA --duration-ms N --triggered-by WHO [--env ENV (default prod)]
+set -euo pipefail
+
+status=""
+sha=""
+duration_ms="0"
+triggered_by=""
+env_label="prod"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --status) status="$2"; shift 2 ;;
+    --sha) sha="$2"; shift 2 ;;
+    --duration-ms) duration_ms="$2"; shift 2 ;;
+    --triggered-by) triggered_by="$2"; shift 2 ;;
+    --env) env_label="$2"; shift 2 ;;
+    *) echo "emit_deploy_event: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+: "${LOKI_PUSH_URL:?LOKI_PUSH_URL is required}"
+: "${LOKI_USER:?LOKI_USER is required}"
+: "${LOKI_TOKEN:?LOKI_TOKEN is required}"
+
+# Normalise to the push endpoint — callers may pass the base host or a query URL.
+push_url="${LOKI_PUSH_URL%/}"
+push_url="${push_url%/loki/api/v1/push}"
+push_url="${push_url%/loki/api/v1/query_range}"
+push_url="${push_url%/loki/api/v1/query}"
+push_url="${push_url}/loki/api/v1/push"
+
+ts_ns="$(date +%s)000000000"
+
+# Build the Loki push payload with python so the JSON log line is escaped correctly inside the
+# stream value. Labels are low-cardinality ({app, env, event_type}); volatile fields (sha,
+# duration, status) live in the JSON line so the panel parses them with `| json`.
+payload="$(python3 - "$env_label" "$ts_ns" "$status" "$sha" "$duration_ms" "$triggered_by" <<'PY'
+import json
+import sys
+
+env, ts, status, sha, duration_ms, triggered_by = sys.argv[1:7]
+try:
+    duration = int(duration_ms)
+except ValueError:
+    duration = 0
+line = json.dumps(
+    {
+        "event_type": "deploy_event",
+        "status": status,
+        "sha": sha,
+        "duration_ms": duration,
+        "triggered_by": triggered_by,
+    }
+)
+print(
+    json.dumps(
+        {
+            "streams": [
+                {
+                    "stream": {"app": "podcast_scraper", "env": env, "event_type": "deploy_event"},
+                    "values": [[ts, line]],
+                }
+            ]
+        }
+    )
+)
+PY
+)"
+
+curl -fsS -u "$LOKI_USER:$LOKI_TOKEN" -H 'Content-Type: application/json' \
+  -X POST "$push_url" --data-binary "$payload"
+echo "emit_deploy_event: pushed status=$status sha=$sha duration_ms=$duration_ms env=$env_label"

--- a/scripts/ops/mark_sentry_release.sh
+++ b/scripts/ops/mark_sentry_release.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Create + finalize a Sentry release and mark a deploy for an environment (#803 D2).
+#
+# This draws the "release boundary" on the Sentry error timeline so "errors started after
+# sha-X" is visible. deploy-prod.yml calls it after a successful deploy; kept reusable so it can
+# be exercised manually with a throwaway version.
+#
+# Env (required): SENTRY_AUTH_TOKEN (org Internal Integration with Release: Admin).
+# Optional: SENTRY_API (default https://sentry.io/api/0).
+# Args: --org O --version V [--environment E (default prod)] [--projects a,b,c]
+set -euo pipefail
+
+org=""
+version=""
+environment="prod"
+projects=""
+api="${SENTRY_API:-https://sentry.io/api/0}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --org) org="$2"; shift 2 ;;
+    --version) version="$2"; shift 2 ;;
+    --environment) environment="$2"; shift 2 ;;
+    --projects) projects="$2"; shift 2 ;;
+    *) echo "mark_sentry_release: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+: "${SENTRY_AUTH_TOKEN:?SENTRY_AUTH_TOKEN is required}"
+if [ -z "$org" ] || [ -z "$version" ]; then
+  echo "mark_sentry_release: --org and --version are required" >&2
+  exit 2
+fi
+
+projects_json="$(python3 - "$projects" <<'PY'
+import json
+import sys
+
+print(json.dumps([p.strip() for p in sys.argv[1].split(",") if p.strip()]))
+PY
+)"
+
+released_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# 1. Create (or update) the release with its projects.
+curl -fsS -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" -H "Content-Type: application/json" \
+  -X POST "$api/organizations/$org/releases/" \
+  -d "{\"version\":\"$version\",\"projects\":$projects_json}" >/dev/null
+
+# 2. Finalize it (sets dateReleased).
+curl -fsS -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" -H "Content-Type: application/json" \
+  -X PUT "$api/organizations/$org/releases/$version/" \
+  -d "{\"dateReleased\":\"$released_at\"}" >/dev/null
+
+# 3. Mark a deploy for the environment — this is the boundary marker on the error timeline.
+curl -fsS -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" -H "Content-Type: application/json" \
+  -X POST "$api/organizations/$org/releases/$version/deploys/" \
+  -d "{\"environment\":\"$environment\"}" >/dev/null
+
+echo "mark_sentry_release: marked $version (env=$environment, projects=[$projects])"

--- a/src/podcast_obs/__init__.py
+++ b/src/podcast_obs/__init__.py
@@ -1,0 +1,19 @@
+"""podcast_obs — a light, standalone prod observability control plane (#803).
+
+Intentionally decoupled from the heavy ``podcast_scraper`` package: importing this
+package must NOT pull in the pipeline (torch/spacy/providers). It depends only on the
+standard library plus ``httpx`` (lazy) and ``PyYAML`` (lazy, config only), so it runs
+cheaply anywhere — a plain local process or a small Docker container on the tailnet.
+
+Layers:
+- core "basics" — :mod:`podcast_obs.sources` probe/aggregate functions + a plain CLI.
+- MCP server (added in a later slice) wraps the same core for agent clients.
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from .result import err, ok
+
+__all__ = ["__version__", "ok", "err"]

--- a/src/podcast_obs/__main__.py
+++ b/src/podcast_obs/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point so ``python -m podcast_obs …`` runs the control-plane CLI."""
+
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/podcast_obs/_http.py
+++ b/src/podcast_obs/_http.py
@@ -1,0 +1,31 @@
+"""Tiny HTTP helper. ``httpx`` is imported lazily so the package imports without it."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+
+def get_json(
+    url: str,
+    *,
+    headers: Optional[Mapping[str, str]] = None,
+    params: Optional[Mapping[str, Any]] = None,
+    auth: Optional[tuple[str, str]] = None,
+    timeout: float = 10.0,
+) -> Any:
+    """GET *url* and return parsed JSON; raise on a non-2xx response or transport error.
+
+    ``auth`` is a ``(username, password)`` pair for HTTP Basic (Grafana Cloud Loki query API);
+    bearer-token APIs (GitHub/Sentry/Grafana alerting) pass an ``Authorization`` header instead.
+    """
+    import httpx
+
+    resp = httpx.get(
+        url,
+        headers=dict(headers or {}),
+        params=dict(params or {}),
+        auth=auth,
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/src/podcast_obs/aggregate.py
+++ b/src/podcast_obs/aggregate.py
@@ -1,0 +1,59 @@
+"""``summary`` — the control-plane glance: fan out across every implemented source for a
+target, tolerating per-source failure, so a half-configured deploy still returns useful state.
+
+As later slices add sources (github/grafana/sentry), append them to ``_PROBES`` and they
+automatically join the summary and the CLI.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from .config import TargetConfig
+from .result import err, ok
+from .sources import github, grafana, loki, prod_api, sentry
+
+# (label, probe) — each probe takes a TargetConfig and returns a result envelope.
+# Sources whose credentials aren't set for a target return ``configured=False`` and land in the
+# "unconfigured" bucket, so a local-only target still gives a useful glance.
+_PROBES: list[tuple[str, Callable[[TargetConfig], dict]]] = [
+    ("health", prod_api.health),
+    ("version", prod_api.deployed_version),
+    ("runs", prod_api.recent_pipeline_runs),
+    ("deploys", github.recent_deploys),
+    ("cost", loki.cost_today),
+    ("logs", lambda target: loki.recent_logs(target, limit=5)),  # compact for the glance
+    ("errors", sentry.recent_errors),
+    ("alerts", grafana.recent_alerts),
+]
+
+
+def summary(target: TargetConfig) -> dict:
+    """Run every implemented probe against *target* and collect the envelopes by label."""
+    sources: dict[str, dict] = {}
+    for label, probe in _PROBES:
+        try:
+            sources[label] = probe(target)
+        except Exception as exc:  # noqa: BLE001 — a probe must never break the summary
+            sources[label] = err(f"summary.{label}", f"probe raised: {exc}")
+    live = sorted(label for label, res in sources.items() if res.get("ok"))
+    unconfigured = sorted(
+        label
+        for label, res in sources.items()
+        if not res.get("ok") and res.get("configured") is False
+    )
+    failed = sorted(
+        label
+        for label, res in sources.items()
+        if not res.get("ok") and res.get("configured") is not False
+    )
+    return ok(
+        "summary",
+        {
+            "target": target.name,
+            "live": live,
+            "unconfigured": unconfigured,
+            "failed": failed,
+            "sources": sources,
+        },
+    )

--- a/src/podcast_obs/cli.py
+++ b/src/podcast_obs/cli.py
@@ -1,0 +1,114 @@
+"""``python -m podcast_obs`` — the "basics" CLI: probe any deploy directly, no MCP needed.
+
+Examples::
+
+    python -m podcast_obs health  --target local
+    python -m podcast_obs runs    --target prod --limit 5
+    python -m podcast_obs summary --target prod
+
+Output is pretty JSON (scriptable). Exit code is 0 when the probe succeeded, 1 when it
+failed (e.g. unreachable or not configured), 2 on a usage/config error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Optional, Sequence
+
+from .aggregate import summary as _summary
+from .config import ObservabilityConfig, ObservabilityConfigError
+from .sources import github, grafana, loki, prod_api, sentry
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="podcast_obs",
+        description="Prod observability control plane (#803) — probe any deploy.",
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to a YAML config (else $PODCAST_OBS_CONFIG, else PODCAST_OBS_* env vars).",
+    )
+    parser.add_argument(
+        "--target",
+        default=None,
+        help="Named target to observe (default: the config's default_target).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("health", help="Full /api/health payload from the target deploy.")
+    sub.add_parser("version", help="Running code version + corpus stamp the deploy serves.")
+    runs = sub.add_parser("runs", help="Recent pipeline runs (/api/jobs), newest first.")
+    runs.add_argument("--limit", type=int, default=10, help="Max runs to return (default 10).")
+    deploys = sub.add_parser("deploys", help="Recent deploy-prod.yml runs (GitHub Actions).")
+    deploys.add_argument("--limit", type=int, default=10, help="Max deploys (default 10).")
+    sub.add_parser("cost-today", help="LLM spend over the last 24h (Loki).")
+    logs = sub.add_parser("logs", help="Recent container logs — error-ish by default (Loki).")
+    logs.add_argument("--level", default="error", help="'error' filters error-ish lines; else all.")
+    logs.add_argument(
+        "--service", default=None, help="Filter to one compose service (api/pipeline/…)."
+    )
+    logs.add_argument(
+        "--window", default="1h", help="Lookback window, e.g. 30m/1h/24h (default 1h)."
+    )
+    logs.add_argument("--limit", type=int, default=50, help="Max log lines (default 50).")
+    logs.add_argument("--contains", default=None, help="Also require this substring in the line.")
+    errors = sub.add_parser("errors", help="Recent unresolved Sentry issues for env=prod.")
+    errors.add_argument("--window", default="24h", help="statsPeriod, e.g. 24h/14d (default 24h).")
+    errors.add_argument(
+        "--limit", type=int, default=10, help="Max issues per project (default 10)."
+    )
+    alerts = sub.add_parser("alerts", help="Current Grafana alerts.")
+    alerts.add_argument("--limit", type=int, default=20, help="Max alerts (default 20).")
+    sub.add_parser("summary", help="Control-plane glance: every source for the target.")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        config = ObservabilityConfig.load(args.config)
+        target = config.target(args.target)
+    except ObservabilityConfigError as exc:
+        print(f"config error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.command == "health":
+        result = prod_api.health(target)
+    elif args.command == "version":
+        result = prod_api.deployed_version(target)
+    elif args.command == "runs":
+        result = prod_api.recent_pipeline_runs(target, limit=args.limit)
+    elif args.command == "deploys":
+        result = github.recent_deploys(target, limit=args.limit)
+    elif args.command == "cost-today":
+        result = loki.cost_today(target)
+    elif args.command == "logs":
+        result = loki.recent_logs(
+            target,
+            level=args.level,
+            service=args.service,
+            window=args.window,
+            limit=args.limit,
+            contains=args.contains,
+        )
+    elif args.command == "errors":
+        result = sentry.recent_errors(target, window=args.window, limit=args.limit)
+    elif args.command == "alerts":
+        result = grafana.recent_alerts(target, limit=args.limit)
+    elif args.command == "summary":
+        result = _summary(target)
+    else:  # pragma: no cover — argparse enforces the choices
+        parser.error(f"unknown command {args.command!r}")
+        return 2
+
+    print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/podcast_obs/cli.py
+++ b/src/podcast_obs/cli.py
@@ -63,6 +63,15 @@ def _build_parser() -> argparse.ArgumentParser:
     alerts = sub.add_parser("alerts", help="Current Grafana alerts.")
     alerts.add_argument("--limit", type=int, default=20, help="Max alerts (default 20).")
     sub.add_parser("summary", help="Control-plane glance: every source for the target.")
+    serve = sub.add_parser("serve", help="Run the MCP server (agent-facing) over the core.")
+    serve.add_argument(
+        "--transport",
+        choices=["stdio", "sse", "http"],
+        default="stdio",
+        help="stdio (local), or sse/http for a networked control plane (default stdio).",
+    )
+    serve.add_argument("--host", default="127.0.0.1", help="Bind host for sse/http.")
+    serve.add_argument("--port", type=int, default=8848, help="Bind port for sse/http.")
     return parser
 
 
@@ -102,6 +111,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         result = grafana.recent_alerts(target, limit=args.limit)
     elif args.command == "summary":
         result = _summary(target)
+    elif args.command == "serve":
+        from .mcp_server import run_server
+
+        transport = "streamable-http" if args.transport == "http" else args.transport
+        run_server(config, transport=transport, host=args.host, port=args.port)
+        return 0
     else:  # pragma: no cover — argparse enforces the choices
         parser.error(f"unknown command {args.command!r}")
         return 2

--- a/src/podcast_obs/config.py
+++ b/src/podcast_obs/config.py
@@ -41,9 +41,12 @@ class TargetConfig:
     sentry_token: Optional[str] = None
     sentry_environment: str = "prod"
     grafana_url: Optional[str] = None
-    grafana_token: Optional[str] = None
+    grafana_token: Optional[str] = None  # Grafana service-account token (alerting API)
     loki_url: Optional[str] = None
     loki_user: Optional[str] = None
+    loki_token: Optional[str] = (
+        None  # Loki access-policy token (logs:read); falls back to grafana_token
+    )
     env_label: str = "prod"  # the deploy's Loki/metrics ``env`` label (PODCAST_ENV)
     timeout: float = DEFAULT_TIMEOUT
 
@@ -96,6 +99,7 @@ class ObservabilityConfig:
             grafana_token=_env("GRAFANA_TOKEN"),
             loki_url=_env("LOKI_URL"),
             loki_user=_env("LOKI_USER"),
+            loki_token=_env("LOKI_TOKEN"),
             env_label=_env("ENV_LABEL") or "prod",
             timeout=_as_float(_env("TIMEOUT"), DEFAULT_TIMEOUT),
         )
@@ -169,6 +173,7 @@ def _target_from_yaml(name: str, spec: dict) -> TargetConfig:
         grafana_token=_secret(grafana, "token"),
         loki_url=grafana.get("loki_url"),
         loki_user=grafana.get("loki_user"),
+        loki_token=_secret(grafana, "loki_token"),
         env_label=spec.get("env_label") or "prod",
         timeout=timeout,
     )

--- a/src/podcast_obs/config.py
+++ b/src/podcast_obs/config.py
@@ -1,0 +1,174 @@
+"""Configuration for the observability control plane.
+
+Target-agnostic by design: you point the control plane at *any* deploy (your local stack,
+prod over Tailscale, a drill, another box) and it observes whatever's reachable. Two ways
+to configure:
+
+- **Env** (single target) — ``PODCAST_OBS_*`` vars. Ideal for a one-target container.
+- **YAML** (multi-target) — ``PODCAST_OBS_CONFIG=/path/to/config.yaml`` with a ``targets``
+  map, so ``--target local`` / ``--target prod`` switch between deploys on a dev box.
+
+Secrets in YAML use ``<field>_env: ENV_VAR_NAME`` indirection so tokens stay out of the file.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+ENV_PREFIX = "PODCAST_OBS_"
+DEFAULT_GITHUB_REPO = "chipi/podcast_scraper"
+DEFAULT_TIMEOUT = 10.0
+
+
+class ObservabilityConfigError(RuntimeError):
+    """Raised on a missing/unknown target or a required-but-unset field."""
+
+
+@dataclass(frozen=True)
+class TargetConfig:
+    """One deploy the control plane can observe. Only ``api_base`` is needed for the
+    credential-free probes (health/version/runs); the rest wire the external sources."""
+
+    name: str
+    api_base: Optional[str] = None
+    github_repo: Optional[str] = DEFAULT_GITHUB_REPO
+    github_token: Optional[str] = None
+    sentry_org: Optional[str] = None
+    sentry_projects: tuple[str, ...] = ()
+    sentry_token: Optional[str] = None
+    sentry_environment: str = "prod"
+    grafana_url: Optional[str] = None
+    grafana_token: Optional[str] = None
+    loki_url: Optional[str] = None
+    loki_user: Optional[str] = None
+    env_label: str = "prod"  # the deploy's Loki/metrics ``env`` label (PODCAST_ENV)
+    timeout: float = DEFAULT_TIMEOUT
+
+    def require(self, attr: str, hint: str) -> Any:
+        """Return ``attr``'s value or raise with a clear "not configured" message."""
+        value = getattr(self, attr, None)
+        if not value:
+            raise ObservabilityConfigError(f"target {self.name!r}: {attr} not configured ({hint})")
+        return value
+
+
+@dataclass(frozen=True)
+class ObservabilityConfig:
+    """A set of named targets plus the default one to use when ``--target`` is omitted."""
+
+    targets: dict[str, TargetConfig]
+    default_target: str
+
+    def target(self, name: Optional[str] = None) -> TargetConfig:
+        key = name or self.default_target
+        if key not in self.targets:
+            have = ", ".join(sorted(self.targets)) or "none"
+            raise ObservabilityConfigError(f"unknown target {key!r} (configured: {have})")
+        return self.targets[key]
+
+    # --- loaders -------------------------------------------------------------------
+
+    @classmethod
+    def load(cls, path: Optional[str | os.PathLike[str]] = None) -> "ObservabilityConfig":
+        """YAML if ``path``/``PODCAST_OBS_CONFIG`` is set, else a single target from env."""
+        path = path or os.environ.get(f"{ENV_PREFIX}CONFIG")
+        if path:
+            return cls.from_yaml(path)
+        return cls.from_env()
+
+    @classmethod
+    def from_env(cls) -> "ObservabilityConfig":
+        name = os.environ.get(f"{ENV_PREFIX}TARGET", "default")
+        projects = _split_csv(_env("SENTRY_PROJECTS"))
+        target = TargetConfig(
+            name=name,
+            api_base=_env("API_BASE"),
+            github_repo=_env("GITHUB_REPO") or DEFAULT_GITHUB_REPO,
+            github_token=_env("GITHUB_TOKEN"),
+            sentry_org=_env("SENTRY_ORG"),
+            sentry_projects=projects,
+            sentry_token=_env("SENTRY_TOKEN"),
+            sentry_environment=_env("SENTRY_ENV") or "prod",
+            grafana_url=_env("GRAFANA_URL"),
+            grafana_token=_env("GRAFANA_TOKEN"),
+            loki_url=_env("LOKI_URL"),
+            loki_user=_env("LOKI_USER"),
+            env_label=_env("ENV_LABEL") or "prod",
+            timeout=_as_float(_env("TIMEOUT"), DEFAULT_TIMEOUT),
+        )
+        return cls(targets={name: target}, default_target=name)
+
+    @classmethod
+    def from_yaml(cls, path: str | os.PathLike[str]) -> "ObservabilityConfig":
+        import yaml
+
+        raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+        targets_raw = raw.get("targets")
+        if not isinstance(targets_raw, dict) or not targets_raw:
+            raise ObservabilityConfigError(f"{path}: no 'targets' mapping found")
+        targets = {name: _target_from_yaml(name, spec or {}) for name, spec in targets_raw.items()}
+        default = raw.get("default_target") or next(iter(targets))
+        if default not in targets:
+            raise ObservabilityConfigError(f"{path}: default_target {default!r} not in targets")
+        return cls(targets=targets, default_target=default)
+
+
+# --- helpers -----------------------------------------------------------------------
+
+
+def _env(suffix: str) -> Optional[str]:
+    value = os.environ.get(f"{ENV_PREFIX}{suffix}")
+    return value if value else None
+
+
+def _split_csv(value: Optional[str]) -> tuple[str, ...]:
+    if not value:
+        return ()
+    return tuple(part.strip() for part in value.split(",") if part.strip())
+
+
+def _as_float(value: Optional[str], default: float) -> float:
+    try:
+        return float(value) if value else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _secret(spec: dict, key: str) -> Optional[str]:
+    """Resolve ``key`` from a literal value or ``<key>_env`` env-var indirection."""
+    if not isinstance(spec, dict):
+        return None
+    if spec.get(key):
+        return str(spec[key])
+    env_name = spec.get(f"{key}_env")
+    return os.environ.get(env_name) if env_name else None
+
+
+def _target_from_yaml(name: str, spec: dict) -> TargetConfig:
+    github = spec.get("github") or {}
+    sentry = spec.get("sentry") or {}
+    grafana = spec.get("grafana") or {}
+    projects = sentry.get("projects") or []
+    if isinstance(projects, str):
+        projects = _split_csv(projects)
+    raw_timeout = spec.get("timeout")
+    timeout = _as_float(str(raw_timeout) if raw_timeout else None, DEFAULT_TIMEOUT)
+    return TargetConfig(
+        name=name,
+        api_base=spec.get("api_base"),
+        github_repo=github.get("repo") or DEFAULT_GITHUB_REPO,
+        github_token=_secret(github, "token"),
+        sentry_org=sentry.get("org"),
+        sentry_projects=tuple(projects),
+        sentry_token=_secret(sentry, "token"),
+        sentry_environment=sentry.get("environment") or "prod",
+        grafana_url=grafana.get("url"),
+        grafana_token=_secret(grafana, "token"),
+        loki_url=grafana.get("loki_url"),
+        loki_user=grafana.get("loki_user"),
+        env_label=spec.get("env_label") or "prod",
+        timeout=timeout,
+    )

--- a/src/podcast_obs/mcp_server.py
+++ b/src/podcast_obs/mcp_server.py
@@ -1,0 +1,142 @@
+"""MCP wrapper over the control-plane core (#803) — Layer B.
+
+Exposes the same probes as MCP tools for agent clients (Claude Code, etc.). The core
+(:mod:`podcast_obs.sources`) is the single source of truth; this is a thin adapter.
+
+Transports:
+- ``stdio`` — local dev / a co-located agent.
+- ``sse`` / ``streamable-http`` — the containerised control plane, reachable over the tailnet,
+  so an agent on another box can query it.
+
+FastMCP is imported lazily inside :func:`build_server` so the core package (and its tests)
+import without the MCP SDK installed (it rides in the ``[observability]`` extra).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from .aggregate import summary as _summary
+from .config import ObservabilityConfig, ObservabilityConfigError, TargetConfig
+from .result import err
+from .sources import github, grafana, loki, prod_api, sentry
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8848
+
+_INSTRUCTIONS = (
+    "Read-only prod observability control plane. Tools answer 'what is a deploy doing right "
+    "now?' — health, version, recent pipeline runs and deploys, today's LLM cost, recent error "
+    "logs (Loki) and Sentry issues, and current Grafana alerts. Each tool takes an optional "
+    "`target` (a configured deploy name; omit for the default). Results are uniform envelopes: "
+    "{ok, source, data|error, configured}; configured=false means that source isn't wired for "
+    "the target. Compose with other MCP servers (e.g. Grafana) for deeper drill-down."
+)
+
+
+def _run(
+    config: ObservabilityConfig,
+    target: Optional[str],
+    probe: Callable[..., dict],
+    **kwargs: Any,
+) -> dict:
+    """Resolve *target* (or the default) and invoke *probe*; return a config-error envelope
+    instead of raising when the target is unknown."""
+    try:
+        resolved: TargetConfig = config.target(target)
+    except ObservabilityConfigError as exc:
+        return err("config", str(exc))
+    return probe(resolved, **kwargs)
+
+
+def _build_tools(config: ObservabilityConfig) -> list[Callable[..., dict]]:
+    """The MCP tool callables (closures over *config*). Returned for direct testing."""
+
+    def prod_health(target: Optional[str] = None) -> dict:
+        """Full /api/health for a deploy (status, code/corpus versions, feature flags)."""
+        return _run(config, target, prod_api.health)
+
+    def prod_version(target: Optional[str] = None) -> dict:
+        """The running code version and the corpus stamp (git sha) a deploy is serving."""
+        return _run(config, target, prod_api.deployed_version)
+
+    def prod_recent_runs(target: Optional[str] = None, limit: int = 10) -> dict:
+        """Recent pipeline runs (/api/jobs) for a deploy, newest first."""
+        return _run(config, target, prod_api.recent_pipeline_runs, limit=limit)
+
+    def prod_recent_deploys(target: Optional[str] = None, limit: int = 10) -> dict:
+        """Recent deploy-prod.yml runs (GitHub Actions) with conclusions + failure rate."""
+        return _run(config, target, github.recent_deploys, limit=limit)
+
+    def prod_cost_today(target: Optional[str] = None) -> dict:
+        """Estimated LLM spend over the last 24h for a deploy (from Loki cost events)."""
+        return _run(config, target, loki.cost_today)
+
+    def prod_recent_logs(
+        target: Optional[str] = None,
+        level: str = "error",
+        service: Optional[str] = None,
+        window: str = "1h",
+        limit: int = 50,
+        contains: Optional[str] = None,
+    ) -> dict:
+        """Recent container logs from Loki (error-ish by default) — what Sentry didn't capture."""
+        return _run(
+            config,
+            target,
+            loki.recent_logs,
+            level=level,
+            service=service,
+            window=window,
+            limit=limit,
+            contains=contains,
+        )
+
+    def prod_recent_errors(
+        target: Optional[str] = None, window: str = "24h", limit: int = 10
+    ) -> dict:
+        """Recent unresolved Sentry issues for a deploy's environment."""
+        return _run(config, target, sentry.recent_errors, window=window, limit=limit)
+
+    def prod_recent_alerts(target: Optional[str] = None, limit: int = 20) -> dict:
+        """Current Grafana alerts (alertname, severity, state, summary)."""
+        return _run(config, target, grafana.recent_alerts, limit=limit)
+
+    def prod_summary(target: Optional[str] = None) -> dict:
+        """One-call control-plane glance: every source for a deploy (live/unconfigured/failed)."""
+        return _run(config, target, _summary)
+
+    return [
+        prod_health,
+        prod_version,
+        prod_recent_runs,
+        prod_recent_deploys,
+        prod_cost_today,
+        prod_recent_logs,
+        prod_recent_errors,
+        prod_recent_alerts,
+        prod_summary,
+    ]
+
+
+def build_server(
+    config: ObservabilityConfig, *, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT
+) -> Any:
+    """Build a FastMCP server exposing the control-plane probes as tools."""
+    from mcp.server.fastmcp import FastMCP
+
+    server = FastMCP("podcast-obs", instructions=_INSTRUCTIONS, host=host, port=port)
+    for tool in _build_tools(config):
+        server.tool()(tool)
+    return server
+
+
+def run_server(
+    config: ObservabilityConfig,
+    *,
+    transport: str = "stdio",
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+) -> None:
+    """Build and run the MCP server over *transport* (stdio / sse / streamable-http)."""
+    build_server(config, host=host, port=port).run(transport=transport)

--- a/src/podcast_obs/result.py
+++ b/src/podcast_obs/result.py
@@ -1,0 +1,20 @@
+"""Uniform result envelope shared by every probe (core, CLI, and later MCP).
+
+Every source function returns one of these dicts so callers get a consistent shape and a
+half-configured control plane degrades gracefully: a source whose credentials are absent
+returns ``ok=False, configured=False`` with a clear "set X" message instead of raising.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def ok(source: str, data: Any, **extra: Any) -> dict:
+    """A successful probe result."""
+    return {"ok": True, "source": source, "data": data, **extra}
+
+
+def err(source: str, message: str, *, configured: bool = True, **extra: Any) -> dict:
+    """A failed probe result. ``configured=False`` means "not wired in this target"."""
+    return {"ok": False, "source": source, "error": message, "configured": configured, **extra}

--- a/src/podcast_obs/sources/__init__.py
+++ b/src/podcast_obs/sources/__init__.py
@@ -1,0 +1,11 @@
+"""Probe sources — one module per backing system.
+
+Each function takes a :class:`podcast_obs.config.TargetConfig` and returns a
+:func:`podcast_obs.result.ok`/:func:`~podcast_obs.result.err` envelope.
+
+- :mod:`podcast_obs.sources.prod_api` — the deploy's own ``/api`` (health/version/runs).
+  Credential-free: needs only ``api_base``, so it works against a local stack first.
+- (later slices) ``github`` (deploys), ``grafana`` (cost/alerts), ``sentry`` (errors).
+"""
+
+from __future__ import annotations

--- a/src/podcast_obs/sources/github.py
+++ b/src/podcast_obs/sources/github.py
@@ -60,7 +60,13 @@ def recent_deploys(target: TargetConfig, limit: int = 10) -> dict:
             "actor": (run.get("actor") or {}).get("login"),
             "event": run.get("event"),
             "created_at": run.get("created_at"),
-            "duration_s": _duration_s(run.get("run_started_at"), run.get("updated_at")),
+            # Only meaningful once the run has concluded — updated_at moves on re-runs/annotations,
+            # and is "started → now-ish" for in-progress runs.
+            "duration_s": (
+                _duration_s(run.get("run_started_at"), run.get("updated_at"))
+                if run.get("conclusion")
+                else None
+            ),
             "url": run.get("html_url"),
         }
         for run in runs[: max(limit, 0)]

--- a/src/podcast_obs/sources/github.py
+++ b/src/podcast_obs/sources/github.py
@@ -1,0 +1,71 @@
+"""Recent prod deploys from the GitHub Actions API (the ``deploy-prod.yml`` workflow runs).
+
+Needs a read-only token (fine-grained, Actions:read) — the control plane never triggers runs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from .._http import get_json
+from ..config import TargetConfig
+from ..result import err, ok
+
+_SOURCE = "github.deploys"
+_API = "https://api.github.com"
+_WORKFLOW = "deploy-prod.yml"
+_HEADERS_BASE = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+
+
+def _duration_s(started: Optional[str], ended: Optional[str]) -> Optional[float]:
+    if not started or not ended:
+        return None
+    try:
+        start = datetime.fromisoformat(started.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(ended.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return round((end - start).total_seconds(), 1)
+
+
+def recent_deploys(target: TargetConfig, limit: int = 10) -> dict:
+    """The last *limit* ``deploy-prod.yml`` runs (status/conclusion/sha/duration) + failure rate."""
+    if not target.github_token:
+        return err(
+            _SOURCE,
+            "github token not set (PODCAST_OBS_GITHUB_TOKEN; needs Actions:read)",
+            configured=False,
+        )
+    if not target.github_repo:
+        return err(_SOURCE, "github repo not set (PODCAST_OBS_GITHUB_REPO)", configured=False)
+    url = f"{_API}/repos/{target.github_repo}/actions/workflows/{_WORKFLOW}/runs"
+    headers = {**_HEADERS_BASE, "Authorization": f"Bearer {target.github_token}"}
+    try:
+        data = get_json(
+            url, headers=headers, params={"per_page": max(limit, 1)}, timeout=target.timeout
+        )
+    except Exception as exc:  # noqa: BLE001
+        return err(_SOURCE, f"GET {url} failed: {exc}")
+    runs = data.get("workflow_runs", []) if isinstance(data, dict) else []
+    deploys = [
+        {
+            "run_number": run.get("run_number"),
+            "status": run.get("status"),
+            "conclusion": run.get("conclusion"),
+            "sha": (run.get("head_sha") or "")[:7],
+            "actor": (run.get("actor") or {}).get("login"),
+            "event": run.get("event"),
+            "created_at": run.get("created_at"),
+            "duration_s": _duration_s(run.get("run_started_at"), run.get("updated_at")),
+            "url": run.get("html_url"),
+        }
+        for run in runs[: max(limit, 0)]
+    ]
+    concluded = [d for d in deploys if d["conclusion"]]
+    failed = [d for d in concluded if d["conclusion"] != "success"]
+    failure_rate = round(len(failed) / len(concluded), 3) if concluded else None
+    return ok(_SOURCE, {"count": len(deploys), "failure_rate": failure_rate, "deploys": deploys})

--- a/src/podcast_obs/sources/grafana.py
+++ b/src/podcast_obs/sources/grafana.py
@@ -1,0 +1,36 @@
+"""Current Grafana alerts (Grafana managed Alertmanager v2 API, bearer auth)."""
+
+from __future__ import annotations
+
+from .._http import get_json
+from ..config import TargetConfig
+from ..result import err, ok
+
+_SOURCE = "grafana.alerts"
+
+
+def recent_alerts(target: TargetConfig, limit: int = 20) -> dict:
+    """Active/recent Grafana alerts (alertname, severity, state, summary)."""
+    if not target.grafana_url or not target.grafana_token:
+        return err(
+            _SOURCE, "grafana not configured (grafana_url + grafana_token)", configured=False
+        )
+    url = f"{target.grafana_url.rstrip('/')}/api/alertmanager/grafana/api/v2/alerts"
+    headers = {"Authorization": f"Bearer {target.grafana_token}"}
+    try:
+        data = get_json(url, headers=headers, timeout=target.timeout)
+    except Exception as exc:  # noqa: BLE001
+        return err(_SOURCE, f"GET {url} failed: {exc}")
+    raw = data if isinstance(data, list) else []
+    alerts = [
+        {
+            "alertname": (alert.get("labels") or {}).get("alertname"),
+            "severity": (alert.get("labels") or {}).get("severity"),
+            "state": (alert.get("status") or {}).get("state"),
+            "startsAt": alert.get("startsAt"),
+            "summary": (alert.get("annotations") or {}).get("summary"),
+        }
+        for alert in raw[: max(limit, 0)]
+    ]
+    firing = sum(1 for alert in alerts if alert["state"] == "active")
+    return ok(_SOURCE, {"count": len(alerts), "firing": firing, "alerts": alerts})

--- a/src/podcast_obs/sources/loki.py
+++ b/src/podcast_obs/sources/loki.py
@@ -1,0 +1,161 @@
+"""Loki-backed probes (Grafana Cloud Loki query API, HTTP Basic auth).
+
+- ``cost_today`` — sums the #804 ``estimated_cost_usd`` of ``event_type="llm_cost"`` log events
+  over the last 24h (the ``{app="podcast_scraper", env=…}`` stream).
+- ``recent_logs`` — raw container logs (error-ish by default). This is the signal Sentry misses:
+  stderr tracebacks from pipeline subprocesses, ``ERROR``/``WARNING`` lines, crash output — things
+  the Sentry SDK never wrapped. Filterable by service / level / free text / window.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+from .._http import get_json
+from ..config import TargetConfig
+from ..result import err, ok
+
+_COST = "loki.cost"
+_LOGS = "loki.logs"
+_ERROR_FILTER = r'|~ "(?i)(error|critical|exception|traceback|fatal)"'
+_PATH_SUFFIXES = ("/loki/api/v1/push", "/loki/api/v1/query_range", "/loki/api/v1/query")
+_NOT_CONFIGURED = "loki not configured (loki_url + loki_user + grafana_token)"
+
+
+def _query_base(loki_url: Optional[str]) -> Optional[str]:
+    """Normalise a push/query URL to the Loki API base (strip the known endpoint suffix)."""
+    if not loki_url:
+        return None
+    base = loki_url.rstrip("/")
+    for suffix in _PATH_SUFFIXES:
+        if base.endswith(suffix):
+            base = base[: -len(suffix)]
+            break
+    return base.rstrip("/") or None
+
+
+def _creds(target: TargetConfig) -> Optional[tuple[str, str, str]]:
+    base = _query_base(target.loki_url)
+    if not base or not target.loki_user or not target.grafana_token:
+        return None
+    return base, target.loki_user, target.grafana_token
+
+
+def _parse_window_seconds(window: str, default: int = 3600) -> int:
+    try:
+        value, unit = int(window[:-1]), window[-1]
+    except (ValueError, IndexError):
+        return default
+    mult = {"s": 1, "m": 60, "h": 3600, "d": 86400}.get(unit)
+    return value * mult if mult else default
+
+
+def _ns_to_iso(ts_ns: str) -> Optional[str]:
+    try:
+        return datetime.fromtimestamp(int(ts_ns) / 1e9, tz=timezone.utc).isoformat()
+    except (ValueError, TypeError, OSError):
+        return None
+
+
+def cost_today(target: TargetConfig) -> dict:
+    """Sum of estimated LLM spend over the last 24h for the target's ``env``."""
+    creds = _creds(target)
+    if not creds:
+        return err(_COST, _NOT_CONFIGURED, configured=False)
+    base, user, token = creds
+    selector = f'{{app="podcast_scraper", env="{target.env_label}"}}'
+    query = (
+        f"sum(sum_over_time({selector} | json "
+        f'| event_type="llm_cost" | unwrap estimated_cost_usd [24h]))'
+    )
+    url = f"{base}/loki/api/v1/query"
+    try:
+        data = get_json(url, params={"query": query}, auth=(user, token), timeout=target.timeout)
+    except Exception as exc:  # noqa: BLE001
+        return err(_COST, f"loki query failed: {exc}")
+    return ok(
+        _COST,
+        {
+            "window": "24h",
+            "environment": target.env_label,
+            "estimated_cost_usd": _vector_value(data),
+        },
+    )
+
+
+def _vector_value(data: object) -> Optional[float]:
+    try:
+        result = data["data"]["result"]  # type: ignore[index]
+    except (KeyError, TypeError):
+        return None
+    if not result:
+        return 0.0  # no cost events in window is a real zero, not an error
+    try:
+        return round(float(result[0]["value"][1]), 6)
+    except (KeyError, IndexError, TypeError, ValueError):
+        return None
+
+
+def recent_logs(
+    target: TargetConfig,
+    *,
+    level: str = "error",
+    service: Optional[str] = None,
+    window: str = "1h",
+    limit: int = 50,
+    contains: Optional[str] = None,
+) -> dict:
+    """Recent container log lines (error-ish by default) — what Sentry didn't capture."""
+    creds = _creds(target)
+    if not creds:
+        return err(_LOGS, _NOT_CONFIGURED, configured=False)
+    base, user, token = creds
+    labels = ['app="podcast_scraper"', f'env="{target.env_label}"']
+    if service:
+        labels.append(f'service="{service}"')
+    pipeline = _ERROR_FILTER if level and level.lower() == "error" else ""
+    if contains:
+        pipeline += f' |= "{contains.replace(chr(34), chr(92) + chr(34))}"'
+    query = "{" + ", ".join(labels) + "}" + pipeline
+    end_ns = time.time_ns()
+    start_ns = end_ns - _parse_window_seconds(window) * 1_000_000_000
+    url = f"{base}/loki/api/v1/query_range"
+    params = {
+        "query": query,
+        "start": str(start_ns),
+        "end": str(end_ns),
+        "limit": str(max(limit, 1)),
+        "direction": "backward",
+    }
+    try:
+        data = get_json(url, params=params, auth=(user, token), timeout=target.timeout)
+    except Exception as exc:  # noqa: BLE001
+        return err(_LOGS, f"loki query_range failed: {exc}")
+    lines = _flatten_streams(data, limit)
+    return ok(
+        _LOGS,
+        {
+            "window": window,
+            "environment": target.env_label,
+            "level": level,
+            "service": service,
+            "count": len(lines),
+            "lines": lines,
+        },
+    )
+
+
+def _flatten_streams(data: object, limit: int) -> list[dict]:
+    try:
+        result = data["data"]["result"]  # type: ignore[index]
+    except (KeyError, TypeError):
+        return []
+    entries: list[dict] = []
+    for stream in result:
+        svc = (stream.get("stream") or {}).get("service")
+        for ts_ns, line in stream.get("values", []):
+            entries.append({"ts": _ns_to_iso(ts_ns), "ts_ns": ts_ns, "service": svc, "line": line})
+    entries.sort(key=lambda entry: entry["ts_ns"], reverse=True)
+    return entries[: max(limit, 0)]

--- a/src/podcast_obs/sources/loki.py
+++ b/src/podcast_obs/sources/loki.py
@@ -21,7 +21,7 @@ _COST = "loki.cost"
 _LOGS = "loki.logs"
 _ERROR_FILTER = r'|~ "(?i)(error|critical|exception|traceback|fatal)"'
 _PATH_SUFFIXES = ("/loki/api/v1/push", "/loki/api/v1/query_range", "/loki/api/v1/query")
-_NOT_CONFIGURED = "loki not configured (loki_url + loki_user + grafana_token)"
+_NOT_CONFIGURED = "loki not configured (loki_url + loki_user + loki_token [logs:read])"
 
 
 def _query_base(loki_url: Optional[str]) -> Optional[str]:
@@ -37,10 +37,14 @@ def _query_base(loki_url: Optional[str]) -> Optional[str]:
 
 
 def _creds(target: TargetConfig) -> Optional[tuple[str, str, str]]:
+    # Loki's data endpoint wants a Cloud access-policy token (logs:read), distinct from the
+    # Grafana service-account token used for the alerting API. Fall back to grafana_token for
+    # self-hosted setups where one token serves both.
     base = _query_base(target.loki_url)
-    if not base or not target.loki_user or not target.grafana_token:
+    token = target.loki_token or target.grafana_token
+    if not base or not target.loki_user or not token:
         return None
-    return base, target.loki_user, target.grafana_token
+    return base, target.loki_user, token
 
 
 def _parse_window_seconds(window: str, default: int = 3600) -> int:

--- a/src/podcast_obs/sources/loki.py
+++ b/src/podcast_obs/sources/loki.py
@@ -121,7 +121,9 @@ def recent_logs(
         labels.append(f'service="{service}"')
     pipeline = _ERROR_FILTER if level and level.lower() == "error" else ""
     if contains:
-        pipeline += f' |= "{contains.replace(chr(34), chr(92) + chr(34))}"'
+        # Escape backslashes BEFORE quotes so a trailing "\" can't break out of the LogQL string.
+        escaped = contains.replace(chr(92), chr(92) + chr(92)).replace(chr(34), chr(92) + chr(34))
+        pipeline += f' |= "{escaped}"'
     query = "{" + ", ".join(labels) + "}" + pipeline
     end_ns = time.time_ns()
     start_ns = end_ns - _parse_window_seconds(window) * 1_000_000_000

--- a/src/podcast_obs/sources/prod_api.py
+++ b/src/podcast_obs/sources/prod_api.py
@@ -1,0 +1,88 @@
+"""Probes against a deploy's own ``/api`` surface — credential-free (needs only ``api_base``).
+
+Works against any deploy: a local ``make serve`` stack (``http://localhost:8080``), prod over
+Tailscale (``https://prod-podcast.<tailnet>``), or a drill. These three are the "basics" you can
+observe before any external integration (GitHub/Sentry/Grafana) is wired.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .._http import get_json
+from ..config import TargetConfig
+from ..result import err, ok
+
+_NOT_CONFIGURED = "api_base not set (PODCAST_OBS_API_BASE or targets.<name>.api_base)"
+
+# Compact subset of PipelineJobRecord we surface for a run listing.
+_RUN_FIELDS = (
+    "job_id",
+    "status",
+    "created_at",
+    "started_at",
+    "ended_at",
+    "exit_code",
+    "command_type",
+    "error_reason",
+)
+
+
+def _base(target: TargetConfig) -> Optional[str]:
+    return target.api_base.rstrip("/") if target.api_base else None
+
+
+def health(target: TargetConfig) -> dict:
+    """GET ``{api_base}/api/health`` — full health payload (versions + feature flags)."""
+    base = _base(target)
+    if not base:
+        return err("prod_api.health", _NOT_CONFIGURED, configured=False)
+    url = f"{base}/api/health"
+    try:
+        data = get_json(url, timeout=target.timeout)
+    except Exception as exc:  # noqa: BLE001 — surface any transport/HTTP error as a result
+        return err("prod_api.health", f"GET {url} failed: {exc}")
+    return ok("prod_api.health", data)
+
+
+def deployed_version(target: TargetConfig) -> dict:
+    """The running code version + the corpus stamp it's serving (derived from health)."""
+    result = health(target)
+    if not result["ok"]:
+        return {**result, "source": "prod_api.version"}
+    data = result["data"] if isinstance(result["data"], dict) else {}
+    produced_by = data.get("corpus_produced_by") or {}
+    return ok(
+        "prod_api.version",
+        {
+            "status": data.get("status"),
+            "code_version": data.get("code_version"),
+            "corpus_code_version": data.get("corpus_code_version"),
+            "corpus_git_sha": produced_by.get("git_sha"),
+            "corpus_produced_at": produced_by.get("produced_at"),
+            "corpus_version_warning": data.get("corpus_version_warning"),
+        },
+    )
+
+
+def recent_pipeline_runs(target: TargetConfig, limit: int = 10) -> dict:
+    """GET ``{api_base}/api/jobs`` — the last *limit* pipeline jobs, newest first."""
+    base = _base(target)
+    if not base:
+        return err("prod_api.runs", _NOT_CONFIGURED, configured=False)
+    url = f"{base}/api/jobs"
+    try:
+        data = get_json(url, timeout=target.timeout)
+    except Exception as exc:  # noqa: BLE001
+        return err("prod_api.runs", f"GET {url} failed: {exc}")
+    jobs = data.get("jobs", []) if isinstance(data, dict) else []
+    newest_first = sorted(jobs, key=lambda job: job.get("created_at") or "", reverse=True)
+    runs = [{key: job.get(key) for key in _RUN_FIELDS} for job in newest_first[: max(limit, 0)]]
+    return ok(
+        "prod_api.runs",
+        {
+            "path": data.get("path") if isinstance(data, dict) else None,
+            "count": len(runs),
+            "runs": runs,
+        },
+    )

--- a/src/podcast_obs/sources/sentry.py
+++ b/src/podcast_obs/sources/sentry.py
@@ -48,12 +48,14 @@ def recent_errors(target: TargetConfig, window: str = "24h", limit: int = 10) ->
         ]
         total += len(items)
         projects.append({"project": project, "ok": True, "issues": items})
-    return ok(
-        _SOURCE,
-        {
-            "window": window,
-            "environment": target.sentry_environment,
-            "total_issues": total,
-            "projects": projects,
-        },
-    )
+    data = {
+        "window": window,
+        "environment": target.sentry_environment,
+        "total_issues": total,
+        "projects": projects,
+    }
+    # Don't report "live" when every configured project failed (e.g. wrong slugs / missing
+    # scope) — that's a misconfiguration, not a healthy zero.
+    if projects and not any(p["ok"] for p in projects):
+        return err(_SOURCE, "all configured Sentry projects failed (check slugs / token scopes)")
+    return ok(_SOURCE, data)

--- a/src/podcast_obs/sources/sentry.py
+++ b/src/podcast_obs/sources/sentry.py
@@ -1,0 +1,59 @@
+"""Recent unresolved Sentry issues for the deploy's environment (Sentry API, bearer auth).
+
+Complements :func:`podcast_obs.sources.loki.recent_logs`: Sentry holds SDK-captured exceptions;
+Loki holds everything the containers logged. Use both for a full error picture.
+"""
+
+from __future__ import annotations
+
+from .._http import get_json
+from ..config import TargetConfig
+from ..result import err, ok
+
+_SOURCE = "sentry.errors"
+_API = "https://sentry.io/api/0"
+
+
+def recent_errors(target: TargetConfig, window: str = "24h", limit: int = 10) -> dict:
+    """Top unresolved issues per Sentry project for ``environment=<target.sentry_environment>``."""
+    if not target.sentry_token:
+        return err(_SOURCE, "sentry token not set (PODCAST_OBS_SENTRY_TOKEN)", configured=False)
+    if not target.sentry_org or not target.sentry_projects:
+        return err(_SOURCE, "sentry org/projects not set", configured=False)
+    headers = {"Authorization": f"Bearer {target.sentry_token}"}
+    projects: list[dict] = []
+    total = 0
+    for project in target.sentry_projects:
+        url = f"{_API}/projects/{target.sentry_org}/{project}/issues/"
+        params = {
+            "query": f"is:unresolved environment:{target.sentry_environment}",
+            "statsPeriod": window,
+            "limit": max(limit, 1),
+        }
+        try:
+            issues = get_json(url, headers=headers, params=params, timeout=target.timeout)
+        except Exception as exc:  # noqa: BLE001
+            projects.append({"project": project, "ok": False, "error": str(exc)})
+            continue
+        items = [
+            {
+                "title": issue.get("title"),
+                "culprit": issue.get("culprit"),
+                "level": issue.get("level"),
+                "count": issue.get("count"),
+                "lastSeen": issue.get("lastSeen"),
+                "permalink": issue.get("permalink"),
+            }
+            for issue in (issues if isinstance(issues, list) else [])
+        ]
+        total += len(items)
+        projects.append({"project": project, "ok": True, "issues": items})
+    return ok(
+        _SOURCE,
+        {
+            "window": window,
+            "environment": target.sentry_environment,
+            "total_issues": total,
+            "projects": projects,
+        },
+    )

--- a/src/podcast_scraper/server/app.py
+++ b/src/podcast_scraper/server/app.py
@@ -35,6 +35,7 @@ from podcast_scraper.server.routes import (
     index_stats,
     jobs,
     operator_config,
+    ops,
     query_activity,
     relational,
     scheduled_jobs as scheduled_jobs_route,
@@ -192,6 +193,7 @@ def create_app(
     app.include_router(corpus_digest.router, prefix="/api")
     app.include_router(corpus_topic_clusters.router, prefix="/api")
     app.include_router(cil.router, prefix="/api")
+    app.include_router(ops.router, prefix="/api")
 
     resolved_output = Path(output_dir).expanduser().resolve() if output_dir is not None else None
     app.state.output_dir = resolved_output

--- a/src/podcast_scraper/server/routes/ops.py
+++ b/src/podcast_scraper/server/routes/ops.py
@@ -1,0 +1,36 @@
+"""GET /api/ops/summary — prod observability control-plane glance (#803).
+
+Returns the same cross-source summary the ``podcast_obs`` CLI/MCP produce, so the viewer's Ops
+view shows a human exactly what an agent sees. Reads ``PODCAST_OBS_*`` from the server env;
+defaults the observed target to *this* server so health/version/runs work with zero config,
+and the external sources (deploys / cost / logs / errors / alerts) light up when their read-scoped
+tokens are present. ``podcast_obs`` is light-dep and pulls no MCP SDK, so importing it is cheap.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["ops"])
+
+# The api container serves /api on 8000 (GH-745); observe ourselves when no target is configured.
+_LOCAL_API_BASE = "http://127.0.0.1:8000"
+# Keep the endpoint responsive: a configured-but-unreachable source shouldn't hang the dashboard.
+_WEB_TIMEOUT = 6.0
+
+
+@router.get("/ops/summary")
+async def ops_summary() -> dict:
+    """Cross-source prod-state summary (live / unconfigured / failed + per-source envelopes)."""
+    from podcast_obs.aggregate import summary as obs_summary
+    from podcast_obs.config import ObservabilityConfig
+
+    target = ObservabilityConfig.load().target()
+    overrides: dict = {"timeout": _WEB_TIMEOUT}
+    if not target.api_base:
+        overrides["api_base"] = _LOCAL_API_BASE
+    target = replace(target, **overrides)
+    data: dict = obs_summary(target)["data"]
+    return data

--- a/src/podcast_scraper/server/routes/ops.py
+++ b/src/podcast_scraper/server/routes/ops.py
@@ -18,11 +18,14 @@ router = APIRouter(tags=["ops"])
 # The api container serves /api on 8000 (GH-745); observe ourselves when no target is configured.
 _LOCAL_API_BASE = "http://127.0.0.1:8000"
 # Keep the endpoint responsive: a configured-but-unreachable source shouldn't hang the dashboard.
-_WEB_TIMEOUT = 6.0
+# summary() fans out to several backends sequentially, so keep the per-probe timeout tight.
+_WEB_TIMEOUT = 4.0
 
 
+# Deliberately a SYNC ``def`` (not ``async``): ``summary()`` makes blocking ``httpx`` calls, so
+# Starlette runs this handler in a threadpool — it must not block the event loop.
 @router.get("/ops/summary")
-async def ops_summary() -> dict:
+def ops_summary() -> dict:
     """Cross-source prod-state summary (live / unconfigured / failed + per-source envelopes)."""
     from podcast_obs.aggregate import summary as obs_summary
     from podcast_obs.config import ObservabilityConfig

--- a/tests/e2e/test_diarization_e2e.py
+++ b/tests/e2e/test_diarization_e2e.py
@@ -193,7 +193,8 @@ def test_default_path_transcribe_diarize_screenplay_into_graph() -> None:
     kg_entities = {
         (n.get("properties", {}).get("name") or n.get("label"))
         for n in kg.get("nodes", [])
-        if n.get("type") == "Entity"
+        # RFC-097 v2.0: speakers emit typed ``Person`` nodes (was legacy ``Entity``).
+        if n.get("type") == "Person"
     }
     # The diarized host + guest become graph entities.
     assert {"Maya", "Liam"}.issubset(kg_entities), f"KG entities missing Maya/Liam: {kg_entities}"

--- a/tests/e2e/test_full_pipeline_e2e.py
+++ b/tests/e2e/test_full_pipeline_e2e.py
@@ -816,13 +816,13 @@ class TestFullPipelineE2E:
             kg = json.load(f)
         kg_nodes = kg.get("nodes", [])
         topic_nodes = [n for n in kg_nodes if n.get("type") == "Topic"]
-        entity_nodes = [n for n in kg_nodes if n.get("type") == "Entity"]
         assert len(topic_nodes) > 0, "KG should have Topic nodes"
 
-        # 4. KG Person entities: host "Maya" with role=host
-        person_entities = [
-            n for n in entity_nodes if n.get("properties", {}).get("entity_kind") == "person"
-        ]
+        # 4. KG Person entities: host "Maya" with role=host.
+        # RFC-097 v2.0: persons emit typed ``Person`` nodes (was legacy ``Entity``
+        # + ``entity_kind=person``, both dropped by the v2 migration — the old
+        # filter silently matched nothing, making this a no-op).
+        person_entities = [n for n in kg_nodes if n.get("type") == "Person"]
         if person_entities:
             host_persons = [n for n in person_entities if n["properties"].get("role") == "host"]
             assert len(host_persons) > 0, (
@@ -881,10 +881,10 @@ class TestFullPipelineE2E:
         with open(kg_files[0], "r", encoding="utf-8") as f:
             kg = json.load(f)
 
-        entity_nodes = [n for n in kg.get("nodes", []) if n.get("type") == "Entity"]
-        person_entities = [
-            n for n in entity_nodes if n.get("properties", {}).get("entity_kind") == "person"
-        ]
+        # RFC-097 v2.0: persons emit typed ``Person`` nodes (was legacy ``Entity``
+        # + ``entity_kind=person``, both dropped by the v2 migration — the old
+        # filter silently matched nothing, making this a no-op).
+        person_entities = [n for n in kg.get("nodes", []) if n.get("type") == "Person"]
 
         guest_persons = [
             n for n in person_entities if n.get("properties", {}).get("role") == "guest"

--- a/tests/e2e_observability/test_control_plane_e2e.py
+++ b/tests/e2e_observability/test_control_plane_e2e.py
@@ -1,0 +1,125 @@
+"""Live E2E for the observability control plane (#803) — closes the loop against real APIs.
+
+Why a sibling dir (not ``tests/e2e/``): that suite's conftest blocks sockets and injects a
+pipeline ``e2e_server``; these tests need *real* network to GitHub/Sentry/Grafana/Loki and the
+target deploy. Run them explicitly (real sockets, no ``--disable-socket``)::
+
+    .venv/bin/python -m pytest tests/e2e_observability/ -q --no-cov -p no:cacheprovider
+
+**Non-determinism is handled by asserting shape + invariants, never values** (a deploy/cost/log
+list changes between runs). Each test **self-skips** when its source isn't configured
+(``configured=False``) or the target is unreachable — so the same file is safe to run anywhere:
+locally it uses whatever creds you have (GitHub via ``gh``, prod_api against a reachable deploy),
+skipping the rest until you provide tokens.
+
+Configuration (any of):
+- ``PODCAST_OBS_CONFIG`` (YAML) or ``PODCAST_OBS_*`` env vars — the normal control-plane config.
+- Otherwise a default target at ``http://localhost:8080`` (override with ``PODCAST_OBS_API_BASE``).
+- GitHub: ``PODCAST_OBS_GITHUB_TOKEN`` if set, else the authenticated ``gh`` CLI token.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+from podcast_obs import aggregate
+from podcast_obs.config import ObservabilityConfig, TargetConfig
+from podcast_obs.sources import github, grafana, loki, prod_api, sentry
+
+pytestmark = pytest.mark.e2e
+
+_ALL_LABELS = {"health", "version", "runs", "deploys", "cost", "logs", "errors", "alerts"}
+
+
+def _gh_cli_token() -> str | None:
+    """A read-only GitHub token from the authenticated ``gh`` CLI, if available."""
+    if not shutil.which("gh"):
+        return None
+    try:
+        out = subprocess.run(["gh", "auth", "token"], capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() or None if out.returncode == 0 else None
+
+
+def _live_target() -> TargetConfig:
+    if os.environ.get("PODCAST_OBS_CONFIG") or os.environ.get("PODCAST_OBS_API_BASE"):
+        target = ObservabilityConfig.load().target(os.environ.get("PODCAST_OBS_TARGET"))
+    else:
+        target = TargetConfig(name="e2e", api_base="http://localhost:8080")
+    if not target.github_token:
+        token = _gh_cli_token()
+        if token:
+            target = replace(target, github_token=token)
+    return target
+
+
+def _live_or_skip(result: dict, label: str) -> Any:
+    """Skip cleanly when not configured or unreachable; return the data when live."""
+    if not result["ok"] and result.get("configured") is False:
+        pytest.skip(f"{label}: not configured ({result['error']})")
+    if not result["ok"]:
+        pytest.skip(f"{label}: unreachable ({result['error']})")
+    return result["data"]
+
+
+def test_prod_api_health_live() -> None:
+    data = _live_or_skip(prod_api.health(_live_target()), "prod_api.health")
+    assert data.get("status") == "ok"
+    assert isinstance(data.get("code_version"), str)
+
+
+def test_prod_api_runs_live() -> None:
+    data = _live_or_skip(prod_api.recent_pipeline_runs(_live_target(), limit=5), "prod_api.runs")
+    assert isinstance(data["runs"], list)
+    for run in data["runs"]:
+        assert "job_id" in run and "status" in run
+
+
+def test_github_deploys_live() -> None:
+    data = _live_or_skip(github.recent_deploys(_live_target(), limit=5), "github.deploys")
+    assert isinstance(data["deploys"], list)
+    assert data["failure_rate"] is None or 0.0 <= data["failure_rate"] <= 1.0
+    for deploy in data["deploys"]:
+        assert {"run_number", "status", "conclusion", "sha"} <= set(deploy)
+        assert deploy["conclusion"] is None or isinstance(deploy["conclusion"], str)
+
+
+def test_loki_cost_today_live() -> None:
+    data = _live_or_skip(loki.cost_today(_live_target()), "loki.cost")
+    cost = data["estimated_cost_usd"]
+    assert cost is None or (isinstance(cost, (int, float)) and cost >= 0)
+
+
+def test_loki_recent_logs_live() -> None:
+    data = _live_or_skip(loki.recent_logs(_live_target(), window="1h", limit=10), "loki.logs")
+    assert isinstance(data["lines"], list)
+    for line in data["lines"]:
+        assert {"ts", "service", "line"} <= set(line)
+
+
+def test_grafana_alerts_live() -> None:
+    data = _live_or_skip(grafana.recent_alerts(_live_target(), limit=10), "grafana.alerts")
+    assert isinstance(data["alerts"], list)
+
+
+def test_sentry_errors_live() -> None:
+    data = _live_or_skip(
+        sentry.recent_errors(_live_target(), window="24h", limit=5), "sentry.errors"
+    )
+    assert isinstance(data["projects"], list)
+    assert data["total_issues"] >= 0
+
+
+def test_summary_structure_live() -> None:
+    # summary always returns ok=True; assert the label partition is complete and disjoint.
+    data = aggregate.summary(_live_target())["data"]
+    labels = set(data["live"]) | set(data["unconfigured"]) | set(data["failed"])
+    assert labels == _ALL_LABELS
+    assert len(labels) == len(data["live"]) + len(data["unconfigured"]) + len(data["failed"])

--- a/tests/integration/providers/test_speaker_flow_integration.py
+++ b/tests/integration/providers/test_speaker_flow_integration.py
@@ -110,7 +110,8 @@ def test_kg_person_injection_host_guest() -> None:
         existing_entity_keys=set(),
     )
 
-    persons = {n["id"]: n for n in nodes if n.get("type") == "Entity"}
+    # RFC-097 v2.0: persons emit typed ``Person`` nodes (was legacy ``Entity``).
+    persons = {n["id"]: n for n in nodes if n.get("type") == "Person"}
     assert "person:nora" in persons
     assert "person:daniel" in persons
     assert persons["person:nora"]["properties"]["role"] == "host"
@@ -137,7 +138,8 @@ def test_kg_person_injection_host_only() -> None:
         existing_entity_keys=set(),
     )
 
-    persons = [n for n in nodes if n.get("type") == "Entity"]
+    # RFC-097 v2.0: persons emit typed ``Person`` nodes (was legacy ``Entity``).
+    persons = [n for n in nodes if n.get("type") == "Person"]
     assert len(persons) == 1
     assert persons[0]["properties"]["name"] == "Alex Morgan"
     assert persons[0]["properties"]["role"] == "host"

--- a/tests/integration/server/test_ops.py
+++ b/tests/integration/server/test_ops.py
@@ -13,7 +13,11 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 from podcast_scraper.server.routes import ops  # noqa: E402
 
-pytestmark = [pytest.mark.integration]
+# critical_path so this viewer API route runs in the PR fast subset
+# (test-integration-fast = "integration and critical_path"), matching the
+# other test_viewer_*/test_server_* route tests — gives /api/ops/summary
+# PR-time regression + patch coverage.
+pytestmark = [pytest.mark.integration, pytest.mark.critical_path]
 
 
 def _client() -> TestClient:

--- a/tests/integration/server/test_ops.py
+++ b/tests/integration/server/test_ops.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 import os
 
 import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
-from podcast_scraper.server.routes import ops
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from podcast_scraper.server.routes import ops  # noqa: E402
+
+pytestmark = [pytest.mark.integration]
 
 
 def _client() -> TestClient:

--- a/tests/stack-test/operator-first-run.spec.ts
+++ b/tests/stack-test/operator-first-run.spec.ts
@@ -175,7 +175,10 @@ test.describe('Operator first-run UX from an empty corpus subdir (#693)', () => 
     // Open Configuration → Job Profile.
     await page.getByTestId('status-bar-sources-trigger').click()
     await expect(page.getByTestId('status-bar-sources-dialog')).toBeVisible()
-    await page.getByTestId('sources-dialog-tab-profile').click()
+    // Config dialog restructure (#1038): the old "profile" tab is now the
+    // "operator" tab with a "profile" sub-panel.
+    await page.getByTestId('sources-dialog-tab-operator').click()
+    await page.getByTestId('sources-dialog-operator-subtab-profile').click()
 
     const profileSelect = page.getByTestId('sources-dialog-profile-select')
     await expect(profileSelect).toBeVisible({ timeout: 30_000 })
@@ -194,7 +197,7 @@ test.describe('Operator first-run UX from an empty corpus subdir (#693)', () => 
         new URL(r.url()).pathname.endsWith('/api/operator-config'),
       { timeout: 60_000 },
     )
-    await page.getByTestId('sources-dialog-save-profile').click()
+    await page.getByTestId('sources-dialog-save-overrides').click()
     const put = await putPromise
     expect(put.ok(), `PUT status=${put.status()}`).toBeTruthy()
 

--- a/tests/stack-test/stack-jobs-flow.spec.ts
+++ b/tests/stack-test/stack-jobs-flow.spec.ts
@@ -45,9 +45,9 @@ const STACK_TEST_LIBRARY_TITLE_MARKERS = ['Building Trails', 'E2E Selection']
  *    (named volume). Seed lists ``STACK_TEST_SEED_FIRST_FEED_URL``;
  *    Playwright adds ``MOCK_FEED_EXTRA`` (asserted distinct).
  *
- * **Job profile (same dialog)** — **Job Profile** tab +
+ * **Job profile (same dialog)** — **Operator** tab → **Profile** sub-panel +
  * ``sources-dialog-profile-select`` + **Save (applies preset +
- * overrides on disk)** (``sources-dialog-save-profile``) →
+ * overrides on disk)** (``sources-dialog-save-overrides``) →
  * ``PUT /api/operator-config`` so ``<corpus>/viewer_operator.yaml``
  * gains merged ``profile:`` + overrides before **Run pipeline job**.
  * Preset: ``STACK_TEST_OPERATOR_PROFILE`` or default
@@ -653,7 +653,9 @@ test.describe('stack test — feeds UI + job + data', () => {
     stackTestProgress(
       `browser: Job Profile tab — select "${operatorProfile}" then Save (PUT /api/operator-config)`,
     )
-    await page.getByTestId('sources-dialog-tab-profile').click()
+    // Config dialog restructure (#1038): profile lives under the "operator" tab's profile sub-panel.
+    await page.getByTestId('sources-dialog-tab-operator').click()
+    await page.getByTestId('sources-dialog-operator-subtab-profile').click()
     const profileSelect = page.getByTestId('sources-dialog-profile-select')
     await expect(profileSelect).toBeVisible({ timeout: 30_000 })
     await profileSelect
@@ -676,7 +678,7 @@ test.describe('stack test — feeds UI + job + data', () => {
       },
       { timeout: 120_000 },
     )
-    await page.getByTestId('sources-dialog-save-profile').click()
+    await page.getByTestId('sources-dialog-save-overrides').click()
     const operatorPut = await operatorPutPromise
     expect(
       operatorPut.ok(),

--- a/tests/unit/podcast_obs/test_cli_and_summary.py
+++ b/tests/unit/podcast_obs/test_cli_and_summary.py
@@ -1,0 +1,76 @@
+"""summary aggregation buckets + CLI exit codes."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_obs import aggregate, cli
+from podcast_obs.config import TargetConfig
+from podcast_obs.sources import prod_api
+
+
+def _clear_obs_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    import os
+
+    for key in list(os.environ):
+        if key.startswith("PODCAST_OBS_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_summary_all_unconfigured_when_no_api_base() -> None:
+    result = aggregate.summary(TargetConfig(name="t"))
+    data = result["data"]
+    assert result["ok"] is True
+    assert data["live"] == []
+    assert set(data["unconfigured"]) == {
+        "health",
+        "version",
+        "runs",
+        "deploys",
+        "cost",
+        "logs",
+        "errors",
+        "alerts",
+    }
+    assert data["failed"] == []
+
+
+def test_summary_prod_api_live_externals_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    # api_base set (prod_api live) but no external tokens -> externals report not-configured.
+    monkeypatch.setattr(
+        prod_api, "get_json", lambda url, **_: {"status": "ok", "code_version": "1", "jobs": []}
+    )
+    data = aggregate.summary(TargetConfig(name="t", api_base="http://x"))["data"]
+    assert set(data["live"]) == {"health", "version", "runs"}
+    assert set(data["unconfigured"]) == {"deploys", "cost", "logs", "errors", "alerts"}
+    assert data["failed"] == []
+
+
+def test_cli_health_unreachable_returns_1(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    _clear_obs_env(monkeypatch)
+    monkeypatch.setenv("PODCAST_OBS_API_BASE", "http://localhost:9")
+    monkeypatch.setattr(
+        prod_api, "get_json", lambda url, **_: (_ for _ in ()).throw(RuntimeError("refused"))
+    )
+    rc = cli.main(["health"])
+    assert rc == 1
+    assert '"ok": false' in capsys.readouterr().out
+
+
+def test_cli_summary_reachable_returns_0(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    _clear_obs_env(monkeypatch)
+    monkeypatch.setenv("PODCAST_OBS_API_BASE", "http://x")
+    monkeypatch.setattr(
+        prod_api, "get_json", lambda url, **_: {"status": "ok", "code_version": "1", "jobs": []}
+    )
+    rc = cli.main(["summary"])
+    assert rc == 0
+    assert '"summary"' in capsys.readouterr().out
+
+
+def test_cli_config_error_returns_2(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_obs_env(monkeypatch)
+    monkeypatch.setenv("PODCAST_OBS_TARGET", "only")
+    # ask for a target that doesn't exist in the single-target env config
+    rc = cli.main(["--target", "nope", "health"])
+    assert rc == 2

--- a/tests/unit/podcast_obs/test_cli_and_summary.py
+++ b/tests/unit/podcast_obs/test_cli_and_summary.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from podcast_obs import aggregate, cli
+from podcast_obs import aggregate, cli, mcp_server
 from podcast_obs.config import TargetConfig
-from podcast_obs.sources import prod_api
+from podcast_obs.sources import loki, prod_api
 
 
 def _clear_obs_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -74,3 +74,59 @@ def test_cli_config_error_returns_2(monkeypatch: pytest.MonkeyPatch) -> None:
     # ask for a target that doesn't exist in the single-target env config
     rc = cli.main(["--target", "nope", "health"])
     assert rc == 2
+
+
+def test_summary_failed_bucket_from_raising_and_err(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raises(_t):
+        raise RuntimeError("kaboom")  # a probe that RAISES (not returns err) -> safety-net except
+
+    def errs(_t):
+        return {"ok": False, "source": "x", "configured": True, "error": "down"}
+
+    def lives(_t):
+        return {"ok": True, "source": "y", "data": {}}
+
+    monkeypatch.setattr(aggregate, "_PROBES", [("boom", raises), ("down", errs), ("up", lives)])
+    data = aggregate.summary(TargetConfig(name="t"))["data"]
+    assert set(data["failed"]) == {"boom", "down"}  # raising + configured-error both fail
+    assert data["live"] == ["up"]
+    assert data["unconfigured"] == []
+
+
+def test_cli_runs_passes_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_obs_env(monkeypatch)
+    monkeypatch.setenv("PODCAST_OBS_API_BASE", "http://x")
+    captured: dict = {}
+    monkeypatch.setattr(
+        prod_api,
+        "recent_pipeline_runs",
+        lambda t, limit=10: captured.update(limit=limit) or {"ok": True, "source": "r", "data": {}},
+    )
+    cli.main(["runs", "--limit", "3"])
+    assert captured["limit"] == 3
+
+
+def test_cli_logs_passes_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_obs_env(monkeypatch)
+    monkeypatch.setenv("PODCAST_OBS_API_BASE", "http://x")
+    captured: dict = {}
+    monkeypatch.setattr(
+        loki,
+        "recent_logs",
+        lambda t, **kw: captured.update(kw) or {"ok": True, "source": "logs", "data": {}},
+    )
+    cli.main(["logs", "--service", "api", "--contains", "OOM", "--window", "6h"])
+    assert captured["service"] == "api"
+    assert captured["contains"] == "OOM"
+    assert captured["window"] == "6h"
+
+
+def test_cli_serve_maps_http_to_streamable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_obs_env(monkeypatch)
+    monkeypatch.setenv("PODCAST_OBS_API_BASE", "http://x")
+    captured: dict = {}
+    monkeypatch.setattr(mcp_server, "run_server", lambda config, **kw: captured.update(kw))
+    rc = cli.main(["serve", "--transport", "http", "--port", "9000"])
+    assert rc == 0
+    assert captured["transport"] == "streamable-http"  # http -> streamable-http mapping
+    assert captured["port"] == 9000

--- a/tests/unit/podcast_obs/test_config.py
+++ b/tests/unit/podcast_obs/test_config.py
@@ -82,3 +82,58 @@ def test_from_yaml_without_targets_raises(tmp_path) -> None:
     config_path.write_text("unrelated: true\n", encoding="utf-8")
     with pytest.raises(ObservabilityConfigError):
         ObservabilityConfig.from_yaml(config_path)
+
+
+def test_from_yaml_default_target_not_in_targets_raises(tmp_path) -> None:
+    config_path = tmp_path / "obs.yaml"
+    config_path.write_text(
+        textwrap.dedent("""
+            default_target: ghost
+            targets:
+              local:
+                api_base: http://localhost:8080
+            """),
+        encoding="utf-8",
+    )
+    with pytest.raises(ObservabilityConfigError):
+        ObservabilityConfig.from_yaml(config_path)
+
+
+def test_from_env_external_source_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_obs_env(monkeypatch)
+    monkeypatch.setenv("PODCAST_OBS_TIMEOUT", "2.5")
+    monkeypatch.setenv("PODCAST_OBS_LOKI_TOKEN", "lt")
+    monkeypatch.setenv("PODCAST_OBS_SENTRY_PROJECTS", "a, b ,c")
+    monkeypatch.setenv("PODCAST_OBS_ENV_LABEL", "drill")
+    target = ObservabilityConfig.from_env().target()
+    assert target.timeout == 2.5
+    assert target.loki_token == "lt"
+    assert target.sentry_projects == ("a", "b", "c")  # CSV split + trimmed
+    assert target.env_label == "drill"
+
+
+def test_from_env_bad_timeout_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_obs_env(monkeypatch)
+    monkeypatch.setenv("PODCAST_OBS_TIMEOUT", "notanumber")
+    assert ObservabilityConfig.from_env().target().timeout == 10.0  # DEFAULT_TIMEOUT
+
+
+def test_from_yaml_inline_token_and_csv_projects(tmp_path) -> None:
+    config_path = tmp_path / "obs.yaml"
+    config_path.write_text(
+        textwrap.dedent("""
+            default_target: prod
+            targets:
+              prod:
+                api_base: https://prod.example
+                github:
+                  token: inline-gh-token
+                sentry:
+                  org: acme
+                  projects: "x,y,z"
+            """),
+        encoding="utf-8",
+    )
+    target = ObservabilityConfig.from_yaml(config_path).target("prod")
+    assert target.github_token == "inline-gh-token"  # literal (not _env) path
+    assert target.sentry_projects == ("x", "y", "z")  # string-form projects split

--- a/tests/unit/podcast_obs/test_config.py
+++ b/tests/unit/podcast_obs/test_config.py
@@ -1,0 +1,84 @@
+"""Config loading: env single-target, YAML multi-target, secret-env indirection."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from podcast_obs.config import (
+    DEFAULT_GITHUB_REPO,
+    ObservabilityConfig,
+    ObservabilityConfigError,
+    TargetConfig,
+)
+
+
+def _clear_obs_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    import os
+
+    for key in list(os.environ):
+        if key.startswith("PODCAST_OBS_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_from_env_single_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_obs_env(monkeypatch)
+    monkeypatch.setenv("PODCAST_OBS_TARGET", "local")
+    monkeypatch.setenv("PODCAST_OBS_API_BASE", "http://localhost:8080")
+    cfg = ObservabilityConfig.load()  # no PODCAST_OBS_CONFIG -> env path
+    target = cfg.target()
+    assert target.name == "local"
+    assert target.api_base == "http://localhost:8080"
+    assert target.github_repo == DEFAULT_GITHUB_REPO
+
+
+def test_unknown_target_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_obs_env(monkeypatch)
+    cfg = ObservabilityConfig.from_env()
+    with pytest.raises(ObservabilityConfigError):
+        cfg.target("does-not-exist")
+
+
+def test_require_missing_field() -> None:
+    target = TargetConfig(name="t")
+    with pytest.raises(ObservabilityConfigError):
+        target.require("sentry_token", "set a Sentry token")
+
+
+def test_from_yaml_multitarget_and_secret_env(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_GH_TOKEN", "gh-secret-value")
+    config_path = tmp_path / "obs.yaml"
+    config_path.write_text(
+        textwrap.dedent("""
+            default_target: prod
+            targets:
+              local:
+                api_base: http://localhost:8080
+              prod:
+                api_base: https://prod-podcast.example.ts.net
+                github:
+                  repo: chipi/podcast_scraper
+                  token_env: MY_GH_TOKEN
+                sentry:
+                  org: acme
+                  projects: [api, pipeline]
+                  environment: prod
+            """),
+        encoding="utf-8",
+    )
+    cfg = ObservabilityConfig.from_yaml(config_path)
+    assert cfg.default_target == "prod"
+    assert set(cfg.targets) == {"local", "prod"}
+    prod = cfg.target("prod")
+    assert prod.github_token == "gh-secret-value"  # resolved via token_env indirection
+    assert prod.sentry_projects == ("api", "pipeline")
+    local_base = cfg.target("local").api_base
+    assert local_base is not None and local_base.endswith(":8080")
+
+
+def test_from_yaml_without_targets_raises(tmp_path) -> None:
+    config_path = tmp_path / "bad.yaml"
+    config_path.write_text("unrelated: true\n", encoding="utf-8")
+    with pytest.raises(ObservabilityConfigError):
+        ObservabilityConfig.from_yaml(config_path)

--- a/tests/unit/podcast_obs/test_external_sources.py
+++ b/tests/unit/podcast_obs/test_external_sources.py
@@ -185,3 +185,15 @@ def test_errors_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
     data = sentry.recent_errors(target)["data"]
     assert data["total_issues"] == 1
     assert data["projects"][0]["issues"][0]["title"] == "KeyError: x"
+
+
+def test_errors_all_projects_failing_is_not_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(url, **_):
+        raise RuntimeError("404 not found")
+
+    monkeypatch.setattr(sentry, "get_json", boom)
+    target = _t(sentry_token="x", sentry_org="acme", sentry_projects=("nope", "alsonope"))
+    result = sentry.recent_errors(target)
+    assert result["ok"] is False  # not a healthy zero — all projects failed
+    assert result["configured"] is True
+    assert "all configured" in result["error"]

--- a/tests/unit/podcast_obs/test_external_sources.py
+++ b/tests/unit/podcast_obs/test_external_sources.py
@@ -65,6 +65,38 @@ def test_cost_not_configured() -> None:
     assert loki.cost_today(_t())["configured"] is False
 
 
+def test_loki_prefers_loki_token_over_grafana(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+    monkeypatch.setattr(
+        loki,
+        "get_json",
+        lambda url, **kw: captured.update(auth=kw.get("auth")) or {"data": {"result": []}},
+    )
+    target = _t(
+        loki_url="https://x.net/loki/api/v1/push",
+        loki_user="u",
+        loki_token="READ",
+        grafana_token="WRITE",
+    )
+    loki.cost_today(target)
+    assert captured["auth"] == (
+        "u",
+        "READ",
+    )  # access-policy token wins over the service-account one
+
+
+def test_loki_falls_back_to_grafana_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+    monkeypatch.setattr(
+        loki,
+        "get_json",
+        lambda url, **kw: captured.update(auth=kw.get("auth")) or {"data": {"result": []}},
+    )
+    target = _t(loki_url="https://x.net/loki/api/v1/push", loki_user="u", grafana_token="ONLY")
+    loki.cost_today(target)
+    assert captured["auth"] == ("u", "ONLY")
+
+
 def test_cost_value(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         loki, "get_json", lambda url, **_: {"data": {"result": [{"value": [0, "0.5142"]}]}}

--- a/tests/unit/podcast_obs/test_external_sources.py
+++ b/tests/unit/podcast_obs/test_external_sources.py
@@ -1,0 +1,155 @@
+"""github / loki / grafana / sentry sources: not-configured + success parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_obs.config import TargetConfig
+from podcast_obs.sources import github, grafana, loki, sentry
+
+
+def _t(**kw) -> TargetConfig:
+    return TargetConfig(name="t", **kw)
+
+
+# --- github.recent_deploys ---------------------------------------------------------
+
+
+def test_deploys_not_configured() -> None:
+    assert github.recent_deploys(_t())["configured"] is False
+
+
+def test_deploys_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "workflow_runs": [
+            {
+                "run_number": 5,
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "abcdef1234567",
+                "actor": {"login": "chipi"},
+                "event": "workflow_dispatch",
+                "created_at": "2026-06-01T00:00:00Z",
+                "run_started_at": "2026-06-01T00:00:00Z",
+                "updated_at": "2026-06-01T00:02:00Z",
+                "html_url": "https://gh/run/5",
+            },
+            {
+                "run_number": 4,
+                "status": "completed",
+                "conclusion": "failure",
+                "head_sha": "0000000",
+            },
+        ]
+    }
+    monkeypatch.setattr(github, "get_json", lambda url, **_: payload)
+    data = github.recent_deploys(_t(github_token="x"), limit=10)["data"]
+    assert data["count"] == 2
+    assert data["deploys"][0]["sha"] == "abcdef1"  # truncated to 7
+    assert data["deploys"][0]["duration_s"] == 120.0
+    assert data["failure_rate"] == 0.5  # 1 of 2 concluded failed
+
+
+# --- loki.cost_today / recent_logs -------------------------------------------------
+
+
+def _loki_target() -> TargetConfig:
+    return _t(
+        loki_url="https://logs.example.net/loki/api/v1/push",
+        loki_user="12345",
+        grafana_token="tok",
+    )
+
+
+def test_cost_not_configured() -> None:
+    assert loki.cost_today(_t())["configured"] is False
+
+
+def test_cost_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        loki, "get_json", lambda url, **_: {"data": {"result": [{"value": [0, "0.5142"]}]}}
+    )
+    data = loki.cost_today(_loki_target())["data"]
+    assert data["estimated_cost_usd"] == 0.5142
+
+
+def test_cost_empty_is_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(loki, "get_json", lambda url, **_: {"data": {"result": []}})
+    assert loki.cost_today(_loki_target())["data"]["estimated_cost_usd"] == 0.0
+
+
+def test_logs_parsing_newest_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "data": {
+            "result": [
+                {
+                    "stream": {"service": "pipeline"},
+                    "values": [
+                        ["1717200000000000000", "ERROR older"],
+                        ["1717200002000000000", "ERROR newer"],
+                    ],
+                }
+            ]
+        }
+    }
+    monkeypatch.setattr(loki, "get_json", lambda url, **_: payload)
+    data = loki.recent_logs(_loki_target(), window="1h", limit=10)["data"]
+    assert data["count"] == 2
+    assert data["lines"][0]["line"] == "ERROR newer"  # newest first
+    assert data["lines"][0]["service"] == "pipeline"
+
+
+def test_loki_query_base_strips_push_suffix() -> None:
+    assert loki._query_base("https://x.net/loki/api/v1/push") == "https://x.net"
+
+
+# --- grafana.recent_alerts ---------------------------------------------------------
+
+
+def test_alerts_not_configured() -> None:
+    assert grafana.recent_alerts(_t())["configured"] is False
+
+
+def test_alerts_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [
+        {
+            "labels": {"alertname": "HighCost", "severity": "warning"},
+            "status": {"state": "active"},
+            "startsAt": "2026-06-01T00:00:00Z",
+            "annotations": {"summary": "spend spiking"},
+        }
+    ]
+    monkeypatch.setattr(grafana, "get_json", lambda url, **_: payload)
+    data = grafana.recent_alerts(_t(grafana_url="https://g.net", grafana_token="tok"))["data"]
+    assert data["count"] == 1
+    assert data["firing"] == 1
+    assert data["alerts"][0]["alertname"] == "HighCost"
+
+
+# --- sentry.recent_errors ----------------------------------------------------------
+
+
+def test_errors_not_configured_without_token() -> None:
+    assert sentry.recent_errors(_t())["configured"] is False
+
+
+def test_errors_not_configured_without_org() -> None:
+    assert sentry.recent_errors(_t(sentry_token="x"))["configured"] is False
+
+
+def test_errors_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    issues = [
+        {
+            "title": "KeyError: x",
+            "culprit": "mod.fn",
+            "level": "error",
+            "count": "3",
+            "lastSeen": "2026-06-01T00:00:00Z",
+            "permalink": "https://sentry/x",
+        }
+    ]
+    monkeypatch.setattr(sentry, "get_json", lambda url, **_: issues)
+    target = _t(sentry_token="x", sentry_org="acme", sentry_projects=("api",))
+    data = sentry.recent_errors(target)["data"]
+    assert data["total_issues"] == 1
+    assert data["projects"][0]["issues"][0]["title"] == "KeyError: x"

--- a/tests/unit/podcast_obs/test_external_sources.py
+++ b/tests/unit/podcast_obs/test_external_sources.py
@@ -197,3 +197,110 @@ def test_errors_all_projects_failing_is_not_ok(monkeypatch: pytest.MonkeyPatch) 
     assert result["ok"] is False  # not a healthy zero — all projects failed
     assert result["configured"] is True
     assert "all configured" in result["error"]
+
+
+# --- loki helpers: window parsing, URL base, malformed payloads (regression guards) -----
+
+
+@pytest.mark.parametrize(
+    ("window", "expected"),
+    [
+        ("30m", 1800),
+        ("2h", 7200),
+        ("1d", 86400),
+        ("45s", 45),
+        ("", 3600),
+        ("abc", 3600),
+        ("10x", 3600),
+    ],
+)
+def test_parse_window_seconds(window: str, expected: int) -> None:
+    assert loki._parse_window_seconds(window) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://x.net/loki/api/v1/push",
+        "https://x.net/loki/api/v1/query",
+        "https://x.net/loki/api/v1/query_range",
+        "https://x.net/",
+        "https://x.net",
+    ],
+)
+def test_query_base_normalises_to_host(url: str) -> None:
+    assert loki._query_base(url) == "https://x.net"
+
+
+def test_query_base_none() -> None:
+    assert loki._query_base(None) is None
+
+
+def test_cost_malformed_payload_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(loki, "get_json", lambda url, **_: {"unexpected": True})
+    assert loki.cost_today(_loki_target())["data"]["estimated_cost_usd"] is None
+
+
+def test_logs_malformed_payload_is_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(loki, "get_json", lambda url, **_: {})
+    assert loki.recent_logs(_loki_target())["data"]["lines"] == []
+
+
+def test_logs_query_construction(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+    monkeypatch.setattr(
+        loki,
+        "get_json",
+        lambda url, **kw: captured.update(params=kw.get("params")) or {"data": {"result": []}},
+    )
+    loki.recent_logs(_loki_target(), level="error", service="api", contains='a"b\\c')
+    query = captured["params"]["query"]
+    assert 'service="api"' in query  # service label injected
+    assert "(error|critical|exception|traceback|fatal)" in query  # error filter present
+    assert r'|= "a\"b\\c"' in query  # quote AND backslash escaped (C2 regression guard)
+
+
+def test_logs_level_all_skips_error_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+    monkeypatch.setattr(
+        loki,
+        "get_json",
+        lambda url, **kw: captured.update(params=kw.get("params")) or {"data": {"result": []}},
+    )
+    loki.recent_logs(_loki_target(), level="all")
+    assert "exception" not in captured["params"]["query"]  # no error filter when level != error
+
+
+def test_deploys_duration_none_for_in_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "workflow_runs": [
+            {
+                "run_number": 9,
+                "status": "in_progress",
+                "conclusion": None,  # not concluded -> duration_s must be None
+                "head_sha": "abc1234",
+                "run_started_at": "2026-06-01T00:00:00Z",
+                "updated_at": "2026-06-01T00:05:00Z",
+            }
+        ]
+    }
+    monkeypatch.setattr(github, "get_json", lambda url, **_: payload)
+    data = github.recent_deploys(_t(github_token="x"))["data"]
+    assert data["deploys"][0]["duration_s"] is None  # C3 regression guard
+    assert data["failure_rate"] is None  # nothing concluded
+
+
+def test_deploys_duration_bad_iso_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "workflow_runs": [
+            {
+                "run_number": 8,
+                "conclusion": "success",
+                "head_sha": "abc1234",
+                "run_started_at": "garbage",
+                "updated_at": "2026-06-01T00:05:00Z",
+            }
+        ]
+    }
+    monkeypatch.setattr(github, "get_json", lambda url, **_: payload)
+    assert github.recent_deploys(_t(github_token="x"))["data"]["deploys"][0]["duration_s"] is None

--- a/tests/unit/podcast_obs/test_mcp_server.py
+++ b/tests/unit/podcast_obs/test_mcp_server.py
@@ -1,0 +1,62 @@
+"""MCP wrapper: tool table wiring, target resolution, and build smoke."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_obs import mcp_server
+from podcast_obs.config import ObservabilityConfig, TargetConfig
+from podcast_obs.sources import prod_api
+
+
+def _config(**target_kw) -> ObservabilityConfig:
+    target = TargetConfig(name="local", **target_kw)
+    return ObservabilityConfig(targets={"local": target}, default_target="local")
+
+
+def test_tool_table_names_and_count() -> None:
+    tools = mcp_server._build_tools(_config())
+    names = [fn.__name__ for fn in tools]
+    assert names == [
+        "prod_health",
+        "prod_version",
+        "prod_recent_runs",
+        "prod_recent_deploys",
+        "prod_cost_today",
+        "prod_recent_logs",
+        "prod_recent_errors",
+        "prod_recent_alerts",
+        "prod_summary",
+    ]
+    # every tool carries a docstring (FastMCP uses it as the tool description)
+    assert all(fn.__doc__ for fn in tools)
+
+
+def test_tool_dispatches_to_core(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        prod_api, "get_json", lambda url, **_: {"status": "ok", "code_version": "1"}
+    )
+    tools = {fn.__name__: fn for fn in mcp_server._build_tools(_config(api_base="http://x"))}
+    result = tools["prod_health"]()
+    assert result["ok"] is True
+    assert result["data"]["status"] == "ok"
+
+
+def test_tool_unknown_target_returns_config_error() -> None:
+    tools = {fn.__name__: fn for fn in mcp_server._build_tools(_config(api_base="http://x"))}
+    result = tools["prod_health"](target="does-not-exist")
+    assert result["ok"] is False
+    assert result["source"] == "config"
+
+
+def test_tool_default_target_used_when_omitted() -> None:
+    # No api_base -> prod_api.health reports not-configured, proving the default target resolved.
+    tools = {fn.__name__: fn for fn in mcp_server._build_tools(_config())}
+    result = tools["prod_health"]()
+    assert result["configured"] is False
+
+
+def test_build_server_registers_tools() -> None:
+    server = mcp_server.build_server(_config(api_base="http://x"))
+    assert server is not None
+    assert server.name == "podcast-obs"

--- a/tests/unit/podcast_obs/test_prod_api.py
+++ b/tests/unit/podcast_obs/test_prod_api.py
@@ -1,0 +1,84 @@
+"""prod_api probes: not-configured, success, transport error, parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from podcast_obs.config import TargetConfig
+from podcast_obs.sources import prod_api
+
+_HEALTH = {
+    "status": "ok",
+    "code_version": "2.6.0",
+    "corpus_code_version": "2.6.0",
+    "corpus_produced_by": {"git_sha": "abc1234", "produced_at": "2026-06-01T00:00:00Z"},
+    "corpus_version_warning": None,
+}
+
+
+def _target(**kw) -> TargetConfig:
+    return TargetConfig(name="t", **kw)
+
+
+def test_health_not_configured() -> None:
+    result = prod_api.health(_target())
+    assert result["ok"] is False
+    assert result["configured"] is False
+
+
+def test_health_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prod_api, "get_json", lambda url, **_: _HEALTH)
+    result = prod_api.health(_target(api_base="http://x"))
+    assert result["ok"] is True
+    assert result["data"]["status"] == "ok"
+
+
+def test_health_transport_error_is_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(url, **_):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(prod_api, "get_json", boom)
+    result = prod_api.health(_target(api_base="http://x"))
+    assert result["ok"] is False
+    assert result["configured"] is True  # configured, just unreachable
+    assert "connection refused" in result["error"]
+
+
+def test_deployed_version_derives_from_health(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prod_api, "get_json", lambda url, **_: _HEALTH)
+    data = prod_api.deployed_version(_target(api_base="http://x"))["data"]
+    assert data["code_version"] == "2.6.0"
+    assert data["corpus_git_sha"] == "abc1234"
+    assert data["corpus_produced_at"] == "2026-06-01T00:00:00Z"
+
+
+def test_deployed_version_propagates_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        prod_api, "get_json", lambda url, **_: (_ for _ in ()).throw(RuntimeError("x"))
+    )
+    result = prod_api.deployed_version(_target(api_base="http://x"))
+    assert result["ok"] is False
+    assert result["source"] == "prod_api.version"
+
+
+def test_recent_runs_sorted_newest_first_and_limited(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "path": "/corpus",
+        "jobs": [
+            {"job_id": "a", "status": "completed", "created_at": "2026-01-01T00:00:00Z"},
+            {"job_id": "b", "status": "running", "created_at": "2026-03-01T00:00:00Z"},
+            {"job_id": "c", "status": "completed", "created_at": "2026-02-01T00:00:00Z"},
+        ],
+    }
+    monkeypatch.setattr(prod_api, "get_json", lambda url, **_: payload)
+    result = prod_api.recent_pipeline_runs(_target(api_base="http://x"), limit=2)
+    ids = [run["job_id"] for run in result["data"]["runs"]]
+    assert ids == ["b", "c"]  # newest first, limited to 2
+    assert result["data"]["count"] == 2
+    assert result["data"]["path"] == "/corpus"
+
+
+def test_recent_runs_not_configured() -> None:
+    result = prod_api.recent_pipeline_runs(_target())
+    assert result["ok"] is False
+    assert result["configured"] is False

--- a/tests/unit/podcast_scraper/server/test_ops.py
+++ b/tests/unit/podcast_scraper/server/test_ops.py
@@ -67,4 +67,17 @@ def test_ops_summary_defaults_target_to_local_server(monkeypatch: pytest.MonkeyP
     resp = _client().get("/api/ops/summary")
     assert resp.status_code == 200
     assert captured["api_base"] == "http://127.0.0.1:8000"  # defaulted to this server
-    assert captured["timeout"] == 6.0  # responsive web timeout override
+    assert captured["timeout"] == 4.0  # responsive web timeout override
+
+
+def test_ops_summary_real_fanout_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No mock of summary: the real route -> podcast_obs fan-out runs. api_base defaults to the
+    # local server (nothing listening) -> prod_api probes fail; external sources unconfigured.
+    # Validates the route never 500s/hangs and returns the partitioned buckets.
+    _clear_obs_env(monkeypatch)
+    resp = _client().get("/api/ops/summary")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert {"target", "live", "unconfigured", "failed", "sources"} <= body.keys()
+    assert "deploys" in body["unconfigured"]  # no github token -> not configured
+    assert "health" not in body["unconfigured"]  # api_base defaulted -> configured (live or failed)

--- a/tests/unit/podcast_scraper/server/test_ops.py
+++ b/tests/unit/podcast_scraper/server/test_ops.py
@@ -1,0 +1,70 @@
+"""GET /api/ops/summary — wraps the podcast_obs control-plane summary."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from podcast_scraper.server.routes import ops
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(ops.router, prefix="/api")
+    return TestClient(app)
+
+
+def _clear_obs_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in list(os.environ):
+        if key.startswith("PODCAST_OBS_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_ops_summary_returns_control_plane_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_obs_env(monkeypatch)
+    fake = {
+        "ok": True,
+        "source": "summary",
+        "data": {
+            "target": "default",
+            "live": ["health"],
+            "unconfigured": ["cost"],
+            "failed": [],
+            "sources": {
+                "health": {"ok": True, "source": "prod_api.health", "data": {"status": "ok"}}
+            },
+        },
+    }
+    monkeypatch.setattr("podcast_obs.aggregate.summary", lambda target: fake)
+    resp = _client().get("/api/ops/summary")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert {"target", "live", "unconfigured", "failed", "sources"} <= body.keys()
+    assert body["live"] == ["health"]
+
+
+def test_ops_summary_defaults_target_to_local_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_obs_env(monkeypatch)
+    captured: dict = {}
+
+    def fake_summary(target):
+        captured["api_base"] = target.api_base
+        captured["timeout"] = target.timeout
+        return {
+            "data": {
+                "target": target.name,
+                "live": [],
+                "unconfigured": [],
+                "failed": [],
+                "sources": {},
+            }
+        }
+
+    monkeypatch.setattr("podcast_obs.aggregate.summary", fake_summary)
+    resp = _client().get("/api/ops/summary")
+    assert resp.status_code == 200
+    assert captured["api_base"] == "http://127.0.0.1:8000"  # defaulted to this server
+    assert captured["timeout"] == 6.0  # responsive web timeout override

--- a/web/gi-kg-viewer/src/App.vue
+++ b/web/gi-kg-viewer/src/App.vue
@@ -7,6 +7,7 @@ import DashboardView from './components/dashboard/DashboardView.vue'
 import DigestView from './components/digest/DigestView.vue'
 import GraphTabPanel from './components/graph/GraphTabPanel.vue'
 import LibraryView from './components/library/LibraryView.vue'
+import OpsView from './components/ops/OpsView.vue'
 import LeftPanel from './components/shell/LeftPanel.vue'
 import StatusBar from './components/shell/StatusBar.vue'
 import SubjectRail from './components/shell/SubjectRail.vue'
@@ -68,7 +69,7 @@ const graphExpansion = useGraphExpansionStore()
 const graphHandoff = useGraphHandoffStore()
 const graphNav = useGraphNavigationStore()
 
-const mainTab = ref<'digest' | 'library' | 'graph' | 'dashboard'>('digest')
+const mainTab = ref<'digest' | 'library' | 'graph' | 'dashboard' | 'ops'>('digest')
 const leftPanelRef = ref<{ focusQuery: () => void } | null>(null)
 const graphCanvasRef = ref<{
   clearInteractionState: (opts?: { skipRedraw?: boolean }) => void
@@ -607,6 +608,19 @@ watch(
             >
               Dashboard
             </button>
+            <button
+              type="button"
+              class="rounded px-3 py-1"
+              :class="
+                mainTab === 'ops'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-elevated-foreground hover:bg-overlay'
+              "
+              data-testid="main-tab-ops"
+              @click="mainTab = 'ops'"
+            >
+              Ops
+            </button>
           </nav>
           <button
             type="button"
@@ -770,6 +784,12 @@ watch(
               @open-library="mainTab = 'library'"
               @open-digest="mainTab = 'digest'"
             />
+          </div>
+          <div
+            v-if="mainTab === 'ops'"
+            class="h-full min-h-0 max-w-full flex-1 overflow-x-hidden overflow-y-auto p-3"
+          >
+            <OpsView />
           </div>
           <keep-alive>
             <GraphTabPanel

--- a/web/gi-kg-viewer/src/api/opsApi.test.ts
+++ b/web/gi-kg-viewer/src/api/opsApi.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchOpsSummary } from './opsApi'
+
+function mockFetch(ok: boolean, body: unknown, text = ''): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok,
+      status: ok ? 200 : 500,
+      text: async () => text,
+      json: async () => body,
+    })) as unknown as typeof fetch,
+  )
+}
+
+describe('opsApi', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('GETs /api/ops/summary and returns the summary', async () => {
+    const payload = {
+      target: 'default',
+      live: ['health'],
+      unconfigured: ['cost'],
+      failed: [],
+      sources: { health: { ok: true, source: 'prod_api.health', data: { status: 'ok' } } },
+    }
+    mockFetch(true, payload)
+    const result = await fetchOpsSummary()
+    expect(result.live).toEqual(['health'])
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/ops/summary',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('throws the response text on a non-2xx', async () => {
+    mockFetch(false, {}, 'boom')
+    await expect(fetchOpsSummary()).rejects.toThrow('boom')
+  })
+})

--- a/web/gi-kg-viewer/src/api/opsApi.ts
+++ b/web/gi-kg-viewer/src/api/opsApi.ts
@@ -1,0 +1,32 @@
+import { fetchWithTimeout } from './httpClient'
+
+/** One source's result from the control plane: a uniform {ok, ...} envelope (#803). */
+export interface OpsSourceEnvelope {
+  ok: boolean
+  source: string
+  configured?: boolean
+  error?: string
+  data?: unknown
+}
+
+/** GET /api/ops/summary — the podcast_obs control-plane glance (same data the MCP exposes). */
+export interface OpsSummary {
+  target: string
+  live: string[]
+  unconfigured: string[]
+  failed: string[]
+  sources: Record<string, OpsSourceEnvelope>
+}
+
+export async function fetchOpsSummary(): Promise<OpsSummary> {
+  // Slightly longer timeout than the default: the endpoint fans out to several backends.
+  const res = await fetchWithTimeout('/api/ops/summary', undefined, {
+    timeoutMs: 20_000,
+    timeoutDetail: 'ops',
+  })
+  if (!res.ok) {
+    const t = await res.text()
+    throw new Error(t.trim() || `HTTP ${res.status}`)
+  }
+  return (await res.json()) as OpsSummary
+}

--- a/web/gi-kg-viewer/src/components/ops/OpsView.test.ts
+++ b/web/gi-kg-viewer/src/components/ops/OpsView.test.ts
@@ -42,4 +42,46 @@ describe('OpsView', () => {
     await flushPromises()
     expect(w.get('[data-testid="ops-error"]').text()).toContain('Network error')
   })
+
+  it('shows a loading state before data arrives', async () => {
+    fetchOpsSummary.mockImplementation(() => new Promise(() => {})) // never resolves
+    const w = mount(OpsView)
+    await flushPromises() // let onMounted's refresh() flip loading=true and re-render
+    expect(w.find('[data-testid="ops-loading"]').exists()).toBe(true)
+  })
+
+  it('formats per-source summary lines', async () => {
+    fetchOpsSummary.mockResolvedValue({
+      target: 'prod',
+      live: ['deploys', 'cost', 'errors', 'alerts'],
+      unconfigured: [],
+      failed: [],
+      sources: {
+        deploys: { ok: true, source: 'github.deploys', data: { count: 2, failure_rate: 0.5 } },
+        cost: { ok: true, source: 'loki.cost', data: { estimated_cost_usd: 0.5142 } },
+        errors: { ok: true, source: 'sentry.errors', data: { total_issues: 3 } },
+        alerts: { ok: true, source: 'grafana.alerts', data: { firing: 1, count: 4 } },
+      },
+    })
+    const w = mount(OpsView)
+    await flushPromises()
+    const text = w.text()
+    expect(text).toContain('2 deploys · 50% fail')
+    expect(text).toContain('$0.5142 (24h)')
+    expect(text).toContain('3 unresolved')
+    expect(text).toContain('1 firing / 4')
+  })
+
+  it("renders 'n/a' when cost is null", async () => {
+    fetchOpsSummary.mockResolvedValue({
+      target: 'prod',
+      live: ['cost'],
+      unconfigured: [],
+      failed: [],
+      sources: { cost: { ok: true, source: 'loki.cost', data: { estimated_cost_usd: null } } },
+    })
+    const w = mount(OpsView)
+    await flushPromises()
+    expect(w.get('[data-testid="ops-source-cost"]').text()).toContain('n/a')
+  })
 })

--- a/web/gi-kg-viewer/src/components/ops/OpsView.test.ts
+++ b/web/gi-kg-viewer/src/components/ops/OpsView.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const fetchOpsSummary = vi.fn()
+vi.mock('../../api/opsApi', () => ({
+  fetchOpsSummary: (...a: unknown[]) => fetchOpsSummary(...a),
+}))
+
+import OpsView from './OpsView.vue'
+
+afterEach(() => {
+  fetchOpsSummary.mockReset()
+})
+
+describe('OpsView', () => {
+  it('renders source cards with the right bucket status + summary line', async () => {
+    fetchOpsSummary.mockResolvedValue({
+      target: 'default',
+      live: ['health'],
+      unconfigured: ['cost'],
+      failed: ['alerts'],
+      sources: {
+        health: { ok: true, source: 'prod_api.health', data: { status: 'ok' } },
+        cost: { ok: false, source: 'loki.cost', configured: false, error: 'not set' },
+        alerts: { ok: false, source: 'grafana.alerts', configured: true, error: '401' },
+      },
+    })
+    const w = mount(OpsView)
+    await flushPromises()
+    expect(w.get('[data-testid="ops-source-health"]').exists()).toBe(true)
+    expect(w.get('[data-testid="ops-status-health"]').text()).toBe('live')
+    expect(w.get('[data-testid="ops-status-cost"]').text()).toBe('unconfigured')
+    expect(w.get('[data-testid="ops-status-alerts"]').text()).toBe('failed')
+    expect(w.text()).toContain('status: ok')
+    expect(w.text()).toContain('not configured') // cost: configured=false summary
+  })
+
+  it('shows an error when the fetch fails', async () => {
+    fetchOpsSummary.mockRejectedValue(new Error('Network error'))
+    const w = mount(OpsView)
+    await flushPromises()
+    expect(w.get('[data-testid="ops-error"]').text()).toContain('Network error')
+  })
+})

--- a/web/gi-kg-viewer/src/components/ops/OpsView.vue
+++ b/web/gi-kg-viewer/src/components/ops/OpsView.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+import { fetchOpsSummary, type OpsSourceEnvelope, type OpsSummary } from '../../api/opsApi'
+
+// Render order — matches the control plane's source list (#803).
+const SOURCE_ORDER = [
+  'health',
+  'version',
+  'runs',
+  'deploys',
+  'cost',
+  'logs',
+  'errors',
+  'alerts',
+] as const
+
+const data = ref<OpsSummary | null>(null)
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+type Bucket = 'live' | 'unconfigured' | 'failed'
+
+function bucketOf(name: string): Bucket {
+  const d = data.value
+  if (!d) return 'failed'
+  if (d.live.includes(name)) return 'live'
+  if (d.unconfigured.includes(name)) return 'unconfigured'
+  return 'failed'
+}
+
+const asRecord = (v: unknown): Record<string, unknown> =>
+  v && typeof v === 'object' ? (v as Record<string, unknown>) : {}
+const str = (v: unknown): string => (v == null ? '?' : String(v))
+const num = (v: unknown): number => (typeof v === 'number' ? v : 0)
+
+/** A compact, per-source one-liner — the "cool stat" for each card. */
+function summaryLine(name: string, env: OpsSourceEnvelope | undefined): string {
+  if (!env) return '—'
+  if (!env.ok) return env.configured === false ? 'not configured' : (env.error ?? 'error')
+  const d = asRecord(env.data)
+  switch (name) {
+    case 'health':
+      return `status: ${str(d.status)}`
+    case 'version':
+      return `${str(d.code_version)} · corpus ${str(d.corpus_git_sha)}`
+    case 'runs':
+      return `${num(d.count)} recent runs`
+    case 'deploys':
+      return d.failure_rate == null
+        ? `${num(d.count)} deploys`
+        : `${num(d.count)} deploys · ${Math.round(num(d.failure_rate) * 100)}% fail`
+    case 'cost':
+      return d.estimated_cost_usd == null ? 'n/a' : `$${num(d.estimated_cost_usd).toFixed(4)} (24h)`
+    case 'logs':
+      return `${num(d.count)} error lines (1h)`
+    case 'errors':
+      return `${num(d.total_issues)} unresolved`
+    case 'alerts':
+      return `${num(d.firing)} firing / ${num(d.count)}`
+    default:
+      return 'ok'
+  }
+}
+
+async function refresh(): Promise<void> {
+  loading.value = true
+  error.value = null
+  try {
+    data.value = await fetchOpsSummary()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  void refresh()
+})
+</script>
+
+<template>
+  <div class="space-y-3" data-testid="ops-view">
+    <div class="flex items-center justify-between">
+      <h2 class="text-sm font-semibold text-surface-foreground">Prod ops</h2>
+      <button
+        type="button"
+        class="rounded border border-border px-2 py-1 text-xs hover:bg-overlay disabled:opacity-50"
+        data-testid="ops-refresh"
+        :disabled="loading"
+        @click="refresh"
+      >
+        {{ loading ? 'Refreshing…' : 'Refresh' }}
+      </button>
+    </div>
+
+    <p v-if="loading && !data" class="text-xs text-muted" data-testid="ops-loading">Loading…</p>
+    <p v-if="error" class="text-xs text-danger" data-testid="ops-error">{{ error }}</p>
+
+    <div v-if="data" class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
+      <div
+        v-for="name in SOURCE_ORDER"
+        :key="name"
+        class="rounded-sm border border-border bg-elevated p-3"
+        :data-testid="`ops-source-${name}`"
+      >
+        <div class="flex items-center justify-between">
+          <span class="text-xs font-medium text-surface-foreground">{{ name }}</span>
+          <span
+            class="text-xs font-semibold"
+            :class="{
+              'text-success': bucketOf(name) === 'live',
+              'text-muted': bucketOf(name) === 'unconfigured',
+              'text-danger': bucketOf(name) === 'failed',
+            }"
+            :data-testid="`ops-status-${name}`"
+          >
+            {{ bucketOf(name) }}
+          </span>
+        </div>
+        <p class="mt-1 text-xs text-muted">{{ summaryLine(name, data.sources[name]) }}</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/gi-kg-viewer/src/components/shell/SubjectRail.vue
+++ b/web/gi-kg-viewer/src/components/shell/SubjectRail.vue
@@ -11,7 +11,7 @@ import { useGraphNavigationStore } from '../../stores/graphNavigation'
 import { useSubjectStore } from '../../stores/subject'
 
 const props = defineProps<{
-  mainTab: 'digest' | 'library' | 'graph' | 'dashboard'
+  mainTab: 'digest' | 'library' | 'graph' | 'dashboard' | 'ops'
 }>()
 
 const subject = useSubjectStore()


### PR DESCRIPTION
## What

v2.7 observability batch — two issues plus three pieces of branch hygiene, on one branch:

- **#803 — Prod observability control plane** (reframed from "a Grafana panel + MCP" into a small, portable control plane).
- **#805 — Operator handoff hardening** (bus-factor): make the first-time-bootstrap path followable from the repo alone.
- **main-CI hotfix** — restore main's red `Python application` workflow (a KG test-contract regression from #1036).
- **stack-test fix** — restore the 4 always-failing `ci-ui-full` firefox specs (testid drift from #1038).
- **deps** — fold in the 6 open Dependabot bumps (#1040–1045).

## #803 — `podcast_obs`, a standalone prod control plane

Answers *"what is a deploy doing right now?"* — health, version, recent pipeline runs + deploys, today's LLM cost, recent **error logs** (Loki), Sentry issues, and Grafana alerts — for **any** deploy (local / prod over Tailscale / drill). Target-agnostic; degrades gracefully (a source whose creds are absent reports `configured=false`).

**Layers** (a new top-level `podcast_obs` package with *zero* coupling to the heavy pipeline import, so it runs cheaply anywhere):

- **Core** — 8 probe/aggregate functions across 5 sources (`prod_api`, `github`, `loki`, `grafana`, `sentry`) + a `summary` glance.
- **CLI** — `python -m podcast_obs <health|version|runs|deploys|cost-today|logs|errors|alerts|summary>`; scriptable, no MCP needed.
- **MCP server** — the same probes as 9 agent tools; `stdio` (local) + `sse`/`streamable-http` (the containerized control plane, reachable over the tailnet).
- **Docker** — a 273 MB image (`python:3.12-slim` + httpx/PyYAML/mcp only) you run on the MBP / an Orb / a Mac mini in the tailnet.
- **Viewer "Ops" view** — `GET /api/ops/summary` wraps the same core; a new viewer tab renders a card per source so a human sees what the agent sees (human parity).
- **D1** — `deploy-prod.yml` pushes a structured `DEPLOY_EVENT` to Loki (success + failure) + a Grafana "Deploys" dashboard.
- **D2** — `deploy-prod.yml` marks a Sentry release boundary after a green deploy.
- Guide: `docs/guides/OBSERVABILITY_CONTROL_PLANE.md` (run local + Docker, config, token scopes, and the recipe to task an agent to use it alongside the Grafana MCP).

## #805 — bootstrap hardening

Static fresh-eyes audit of the bootstrap path → a self-contained `docs/guides/BOOTSTRAP_PREREQUISITES.md` (Free-plan Tailscale model, not the stale OAuth #714), a "bootstrap sequence at a glance", password-manager-agnostic secret retrieval, a cloud-init readiness note, the #844 `.bootstrap-needs-env`→`test -f .env` drift fixed (cloud-init `final_message` + runbook), and `deploy.sh` exit-code-4 documented.

## Validated

- **Whole control plane live-validated** against real prod backends: `python -m podcast_obs summary` → **8/8 sources live**; live E2E (`tests/e2e_observability/`, shape+invariant, self-skipping) **8/8**.
- **D1** — pushed a test `deploy_event` and queried it back; the dashboard's exact LogQL returned the right counts. **No prod deploy needed.**
- **D2** — created + finalized + deploy-marked a throwaway Sentry release, then deleted it.
- Closing the loop caught a real design bug (Loki `glc_` access-policy vs Grafana `glsa_` service-account token split) and a fresh-eyes code review caught 3 more (event-loop block on the ops route, LogQL backslash injection, GitHub `duration_s` semantics) — all fixed, with regression tests.
- `make docs`, full-project `mypy`, `flake8`/`black`/`isort`, `actionlint` (workflow), `shellcheck` (scripts), `vue-tsc` strict + `vitest`, and the new unit/route tests all green.

## main-CI hotfix — KG person-injection (`Python application` red on main)

Main's `Python application` workflow was red (`test-integration`, `test-e2e`, `coverage-unified`). Root cause was **not** this branch: #1036 (RFC-097 ontology v2) replaced legacy `Entity(kind=person)` nodes with typed `Person`/`Organization` nodes (`kind` is now the node *type*, not a property). The integration/e2e suite only runs on main pushes, so #1036 merged green on its PR gate and reddened main post-merge. The production code is correct; **stale test assertions** were updated to the v2 contract:

- `test_speaker_flow_integration.py` — host/guest + host-only person injection filter `type=="Person"` (were matching nothing → `'person:nora' in {}`).
- `test_diarization_e2e.py` — Maya/Liam KG entities filter `type=="Person"` (was `…missing Maya/Liam: set()`).
- `test_full_pipeline_e2e.py` — two blocks filtered `type=="Entity"` **and** the removed `entity_kind` property, so they passed *vacuously*; restored to `type=="Person"` so person-role coverage is real again.

## stack-test fix — the 4 always-failing `ci-ui-full` firefox specs

`ci-ui-full` had 4 firefox failures locally **and on main**. Real cause (caught after a wrong first guess of "environmental"): #1038 restructured the Config dialog — the profile tab became an **operator** tab with a **profile** sub-panel, and `sources-dialog-save-profile` → `sources-dialog-save-overrides`. The stack-test specs still drove the old testids, hanging on elements that no longer exist. Updated `operator-first-run.spec.ts` + `stack-jobs-flow.spec.ts` to the #1038 testids. The Python gate (`ci-fast`) and viewer unit + component suite (incl. the new Ops tab) pass.

## deps — Dependabot #1040–1045

Folded the 6 open Dependabot PRs into this branch (one-branch policy) instead of merging separately: `actions/checkout` v6→v7 (all 61 usages), `interrogate` ≥1.7.0, `anthropic` ≥0.111.0, `sentencepiece` ≥0.2.1, `code2flow` ≥2.5.1, `uvicorn[standard]` ≥0.49.0. Validated: all pins resolve + install at the new minimums; anthropic provider imports + 21 provider tests pass under 0.111; `actionlint` clean. Those 6 PRs are closed in favour of this one.

## Operator follow-ups (deploy-time, not code)

- D2 workflow: set GH `vars.SENTRY_ORG`, `vars.SENTRY_PROJECTS` (`podcast-scraper-api,podcast-scraper-pipeline,podcast-scraper-viewer`), `secrets.SENTRY_AUTH_TOKEN` (Internal Integration: Issue & Event: Read + Release: Admin).
- Import `config/grafana/grafana-dashboard-deploy-observability.json` into the `podcast-scraper` Grafana folder.
- The first real deploy then emits the first `DEPLOY_EVENT` + Sentry release boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
