### PR TITLE
fix(test): correct kg_person_roles e2e assertion (main red post-#1047)

### DIFF
--- a/tests/e2e/test_full_pipeline_e2e.py
+++ b/tests/e2e/test_full_pipeline_e2e.py
@@ -886,13 +886,20 @@ class TestFullPipelineE2E:
         # filter silently matched nothing, making this a no-op).
         person_entities = [n for n in kg.get("nodes", []) if n.get("type") == "Person"]
 
-        guest_persons = [
-            n for n in person_entities if n.get("properties", {}).get("role") == "guest"
+        # p01 "Singletrack Sessions" (tests/fixtures/FIXTURES_SPEC.md): host **Maya**,
+        # e01 "Building Trails That Last" has **guest Liam** — this is NOT a solo show.
+        # The test's purpose (docstring) is that the RSS author carries role=host; a
+        # guest is expected, not an error. (The prior ``len(guest_persons) == 0``
+        # assertion was wrong and only ever "passed" while the v2-stale filter above
+        # matched nothing — un-vacuuming it surfaced the contradiction.)
+        host_persons = [n for n in person_entities if n.get("properties", {}).get("role") == "host"]
+        roster = [
+            (n["properties"].get("name"), n["properties"].get("role")) for n in person_entities
         ]
-        assert len(guest_persons) == 0, (
-            f"Solo show should have NO guest Person entities, got: "
-            f"{[n['properties']['name'] for n in guest_persons]}"
-        )
+        assert host_persons, f"expected a host Person for RSS author Maya, got: {roster}"
+        assert any(
+            "maya" in (n["properties"].get("name") or "").lower() for n in host_persons
+        ), f"RSS author Maya should be the host, got roster: {roster}"
 
     @pytest.mark.critical_path
     def test_pipeline_handles_rss_feed_404(self):


### PR DESCRIPTION
## What

Hotfix for main's red `Python application` workflow (`test-e2e`) after #1047 merged.

## Root cause — test bug, not a pipeline regression

#1047 un-vacuumed `test_pipeline_kg_person_roles_correct`: the filter went from the v2-stale `type=='Entity'` + `entity_kind=='person'` (which matched **nothing** after the RFC-097 ontology-v2 migration) to real `type=='Person'`. That surfaced a latent contradiction in the assertion:

- the assert claimed *"Solo show should have NO guest Person entities"*
- but the fixture is **not** solo — `FIXTURES_SPEC.md`: **p01 'Singletrack Sessions' → host Maya, e01 'Building Trails That Last' guest Liam**

So the pipeline detecting `Liam Verbeek` as a guest is **correct**. The `len(guest_persons) == 0` assertion was wrong and only ever passed while the filter was vacuous (always `[]`). The test's own docstring even says *"Maya Koster host, Liam guest"*.

## Fix

Replace the wrong assertion with the test's documented intent — the RSS author (Maya) carries `role=host` — and don't assert against the (expected) guest. Robust to NER guest-name variance.

## Why it slipped #1047's gate

The full `test-e2e` suite runs **only on main pushes**; PRs run `-fast` only, and this test is `@slow` (not `critical_path`). Same blind spot for this PR — so I validated **locally against the real pipeline**: `1 passed in 28.18s` (models cached, full p01 run, not skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)