### PR TITLE
hotfix(#382): main CI green — test-integration + test-e2e drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,10 @@ data/eval/materialized/*
 # (see docs/wip/POST_RFC097_DEV_PROD_REMOVAL.md).
 data/eval/runs/*
 !data/eval/runs/_PRE_FIX_NOTE.md
+# Shipped parity reports referenced by regression tests must be tracked, or the
+# tests fail with "shipped parity report missing" in CI. Add new exceptions
+# here whenever a `tests/e2e/test_*_parity_regression.py` grows a new fixture.
+!data/eval/runs/v5_parity_2026-07-05.json
 
 # Generated eval configs (scripts/eval/pipeline_validate.py auto-writes here)
 data/eval/configs/_pipeline_validate/

--- a/data/eval/runs/v5_parity_2026-07-05.json
+++ b/data/eval/runs/v5_parity_2026-07-05.json
@@ -1,0 +1,184 @@
+{
+  "issue": "#382",
+  "phase": "7 — v5 parity gate",
+  "summarizer": {
+    "n_pairs": 5,
+    "shared_episode_ids": [
+      "p01_e01",
+      "p02_e01",
+      "p03_e01",
+      "p04_e01",
+      "p05_e01"
+    ],
+    "rouge_l_by_episode": {
+      "p01_e01": 1.0,
+      "p02_e01": 1.0,
+      "p03_e01": 1.0,
+      "p04_e01": 1.0,
+      "p05_e01": 1.0
+    },
+    "min_rouge_l": 1.0,
+    "mean_rouge_l": 1.0,
+    "threshold": 0.95,
+    "pass": true
+  },
+  "qa": {
+    "n_pairs": 8,
+    "shared_ids": [
+      "p01_e01_q1_guest",
+      "p01_e01_q2_topic",
+      "p02_e01_q1_guest",
+      "p02_e01_q2_topic",
+      "p03_e01_q1_guest",
+      "p04_e01_q1_guest",
+      "p05_e01_q1_guest",
+      "p05_e01_q2_topic"
+    ],
+    "offset_matches": 6,
+    "offset_match_rate": 0.75,
+    "text_matches": 7,
+    "text_match_rate": 0.875,
+    "score_delta_mean_abs": 0.23210947491801906,
+    "text_match_threshold": 0.85,
+    "pass": true,
+    "per_pair": [
+      {
+        "id": "p01_e01_q1_guest",
+        "offset_match": true,
+        "text_match": true,
+        "pre": {
+          "start": 80,
+          "end": 84,
+          "score": 0.22783757420256734,
+          "text": "Liam"
+        },
+        "post": {
+          "start": 80,
+          "end": 84,
+          "score": 0.5002691223281608,
+          "text": "Liam"
+        }
+      },
+      {
+        "id": "p01_e01_q2_topic",
+        "offset_match": false,
+        "text_match": true,
+        "pre": {
+          "start": 6658,
+          "end": 6700,
+          "score": 0.6659633815288544,
+          "text": "The bike should feel quiet and predictable"
+        },
+        "post": {
+          "start": 10041,
+          "end": 10083,
+          "score": 0.7865901766525706,
+          "text": "The bike should feel quiet and predictable"
+        }
+      },
+      {
+        "id": "p02_e01_q1_guest",
+        "offset_match": true,
+        "text_match": true,
+        "pre": {
+          "start": 86,
+          "end": 92,
+          "score": 0.3745296001434326,
+          "text": "Priya\n"
+        },
+        "post": {
+          "start": 86,
+          "end": 92,
+          "score": 0.48320206334869453,
+          "text": "Priya\n"
+        }
+      },
+      {
+        "id": "p02_e01_q2_topic",
+        "offset_match": true,
+        "text_match": true,
+        "pre": {
+          "start": 10285,
+          "end": 10290,
+          "score": 0.22917506098747253,
+          "text": "speed"
+        },
+        "post": {
+          "start": 10285,
+          "end": 10290,
+          "score": 0.5598397525135034,
+          "text": "speed"
+        }
+      },
+      {
+        "id": "p03_e01_q1_guest",
+        "offset_match": true,
+        "text_match": true,
+        "pre": {
+          "start": 77,
+          "end": 83,
+          "score": 0.20231792330741882,
+          "text": "Marco\n"
+        },
+        "post": {
+          "start": 77,
+          "end": 83,
+          "score": 0.5102675052145835,
+          "text": "Marco\n"
+        }
+      },
+      {
+        "id": "p04_e01_q1_guest",
+        "offset_match": true,
+        "text_match": true,
+        "pre": {
+          "start": 80,
+          "end": 84,
+          "score": 0.42092859745025635,
+          "text": "Ava\n"
+        },
+        "post": {
+          "start": 80,
+          "end": 84,
+          "score": 0.710972777854356,
+          "text": "Ava\n"
+        }
+      },
+      {
+        "id": "p05_e01_q1_guest",
+        "offset_match": true,
+        "text_match": true,
+        "pre": {
+          "start": 86,
+          "end": 92,
+          "score": 0.18110454027919332,
+          "text": "Daniel"
+        },
+        "post": {
+          "start": 86,
+          "end": 92,
+          "score": 0.4063777099583212,
+          "text": "Daniel"
+        }
+      },
+      {
+        "id": "p05_e01_q2_topic",
+        "offset_match": false,
+        "text_match": false,
+        "pre": {
+          "start": 1141,
+          "end": 1156,
+          "score": 0.33493591204751283,
+          "text": "Index investing"
+        },
+        "post": {
+          "start": 312,
+          "end": 329,
+          "score": 0.5361492814206708,
+          "text": "people care about"
+        }
+      }
+    ]
+  },
+  "overall_pass": true
+}

--- a/tests/integration/providers/test_summarizer_security_integration.py
+++ b/tests/integration/providers/test_summarizer_security_integration.py
@@ -442,10 +442,13 @@ class TestMemoryCleanup(unittest.TestCase):
         # Unload model
         summarizer.unload_model(model)
 
-        # Verify model is unloaded
+        # Verify model is unloaded. Post-#382 the ``pipeline`` attribute is a
+        # bool sentinel (True when loaded, False when unloaded) — pipeline()
+        # was retired for BART/LED so there's no Pipeline object to null out.
+        # See summarizer.SummaryModel line 943 for the type contract.
         self.assertIsNone(model.model)
         self.assertIsNone(model.tokenizer)
-        self.assertIsNone(model.pipeline)
+        self.assertFalse(model.pipeline)
 
     def test_unload_model_with_none(self):
         """Test that unload_model() handles None gracefully."""


### PR DESCRIPTION
## Summary

Two real failures on `main` after #1145 (#382) merged. Docs deploy on the same run was a **transient GH Pages infra flake** (`Deployment failed, try again later`) and just needs a rerun — no code change for that one.

## Fixes

### 1. `test-integration` — `TestMemoryCleanup::test_unload_model_sets_to_none`

**Was:** `AssertionError: False is not None`
**Cause:** Post-#382 `SummaryModel.pipeline` is a `bool` sentinel (`True` when loaded, `False` when unloaded) — `pipeline("summarization")` was retired for BART/LED so there's no `Pipeline` object to null out. Contract is documented at `summarizer.py:943`. The test still asserted `assertIsNone(model.pipeline)` from the pre-#382 world.

**Fix:** `assertFalse(model.pipeline)` — matches the new contract while still catching a stale-True leak after unload.

### 2. `test-e2e` — `test_v5_parity_regression.test_shipped_parity_report_still_passes`

**Was:** `AssertionError: shipped parity report missing`
**Cause:** `.gitignore` line 196 (`data/eval/runs/*`) prevented the parity report at `data/eval/runs/v5_parity_2026-07-05.json` from ever reaching the remote. The test docstring literally says "The frozen parity report committed at Phase 7 must still pass its own thresholds" — the file was supposed to be tracked, and my #382 close-out never verified it survived `.gitignore`.

**Fix:** Added `!data/eval/runs/v5_parity_2026-07-05.json` exception (mirrors the existing `!data/eval/runs/_PRE_FIX_NOTE.md` pattern) and committed the file with `git add -f`. Also added a `.gitignore` comment reminding future authors to add a new exception whenever a `tests/e2e/test_*_parity_regression.py` grows a new fixture.

## Verified locally

- `pytest tests/integration/providers/test_summarizer_security_integration.py::TestMemoryCleanup::test_unload_model_sets_to_none` — 1 passed.
- JSON parity report loads + parses cleanly.
- Pre-commit clean (black/isort/flake8/mypy/JSON validation all pass).

## Test plan

- [ ] `test-integration` job green on this PR
- [ ] `test-e2e` job green on this PR
- [ ] After merge: `gh run rerun` the failing MkDocs Deploy on `main` (transient)

Closes: N/A — flowed from #1145 (#382)