### PR TITLE
fix(ci): main CI regressions from #1190/#1195 (download-args, circuit-breaker, MPS)

### DIFF
--- a/src/podcast_scraper/workflow/stages/summarization.py
+++ b/src/podcast_scraper/workflow/stages/summarization.py
@@ -63,7 +63,11 @@ def _collect_episodes_for_summarization(
     if download_args is None:
         download_args = []
     for args in download_args:
-        episode_obj, _, _, _, _, _, _, detected_names = args
+        # Index access, not a fixed-arity unpack: the download-args tuple carries
+        # guests at [7] + stated names at [8] (processing.prepare_episode_download_args);
+        # matches how processing.py / transcription.py read args[7].
+        episode_obj = args[0]
+        detected_names = args[7]
         episode_to_detected_names[episode_obj.idx] = detected_names
 
     episodes_to_summarize = []

--- a/tests/e2e/test_cloud_circuit_breaker_e2e.py
+++ b/tests/e2e/test_cloud_circuit_breaker_e2e.py
@@ -105,9 +105,10 @@ class TestPerProviderCircuitBreakerE2E:
         assert s["trips_total"] >= 1
         assert s["cooldown_seconds_total"] > 0
 
-    def test_breaker_disabled_by_default(self, e2e_server):
-        """Without ``llm_circuit_breaker_enabled=True``, the breaker stays
-        unwired — the existing soft retry/backoff path is unchanged."""
+    def test_breaker_when_explicitly_disabled(self, e2e_server):
+        """With ``llm_circuit_breaker_enabled=False`` the breaker stays unwired —
+        the existing soft retry/backoff path is unchanged and no trips are
+        recorded. (The default is now ON per ADR-113, so this must be explicit.)"""
         from podcast_scraper.providers.openai.openai_provider import OpenAIProvider
         from tests.e2e.fixtures.e2e_http_server import E2EHTTPRequestHandler
 
@@ -119,7 +120,7 @@ class TestPerProviderCircuitBreakerE2E:
                 "openai_api_base": e2e_server.urls.openai_api_base(),
                 "summary_provider": "openai",
                 "generate_summaries": True,
-                # breaker NOT enabled
+                "llm_circuit_breaker_enabled": False,  # default is ON (ADR-113)
             }
         )
         p = OpenAIProvider(cfg)

--- a/tests/integration/workflow/test_mps_exclusive_integration.py
+++ b/tests/integration/workflow/test_mps_exclusive_integration.py
@@ -315,14 +315,11 @@ class TestMPSExclusiveFallbackWarning(unittest.TestCase):
         mock_sum._reduce_model = None
         type(mock_sum).__name__ = "MLProvider"
 
-        with self.assertLogs(
-            "podcast_scraper.workflow.orchestration", level=logging.WARNING
-        ) as caplog:
-            result = _both_providers_use_mps(cfg, mock_tx, mock_sum)
-
-        # The result depends on whether MPS is actually available on this
-        # test host — on CI Linux runners it's False, on Mac dev it's True.
-        # We assert on the log-line contract in both cases.
+        # Result + logging depend on whether MPS is actually available — True on
+        # Mac dev, False on CI Linux runners. ``assertLogs`` REQUIRES at least one
+        # matching record, and the WARNING is guarded on ``is_available()``, so only
+        # wrap the call in ``assertLogs`` when MPS is available; otherwise the call
+        # logs nothing and asserting logs would (wrongly) fail the test.
         try:
             import torch
 
@@ -331,13 +328,16 @@ class TestMPSExclusiveFallbackWarning(unittest.TestCase):
             mps_avail = False
 
         if mps_avail:
+            with self.assertLogs(
+                "podcast_scraper.workflow.orchestration", level=logging.WARNING
+            ) as caplog:
+                result = _both_providers_use_mps(cfg, mock_tx, mock_sum)
             self.assertTrue(result)
             self.assertTrue(
                 any("MPS-exclusive check" in msg for msg in caplog.output),
                 f"expected observable-fallback WARNING; got {caplog.output}",
             )
         else:
-            # On non-MPS hosts the fallback still evaluates but doesn't log
-            # (the branch guards on is_available()). We can only test the
-            # positive path when MPS is available — record the skip reason.
+            # On non-MPS hosts the fallback evaluates to False and logs nothing.
+            result = _both_providers_use_mps(cfg, mock_tx, mock_sum)
             self.assertFalse(result)


### PR DESCRIPTION
## Why

Main has been **red on the full integration/e2e suite since #1190 (07-16 09:48) and #1195 (07-16 15:14)** — that suite runs only on push to `main` (path-filtered off PRs), so both epics landed red and it surfaced when the suite next ran. Last green was `84b17ab` (07-11). This PR fixes the 3 **mechanical** regressions; the remaining 3 are ML-quality (see below).

## Fixes (verified locally)

- **`summarization._collect_episodes_for_summarization`** — the download-args tuple grew to 9 (`stated` names added at `[8]` by #1190); the fixed-arity 8-unpack broke with `too many values to unpack`. Switched to index access (`args[0]`/`args[7]`) as `processing.py`/`transcription.py` already do. → fixes `test_resume_e2e` + the acceptance-fast matrix.
- **circuit-breaker e2e** — `llm_circuit_breaker_enabled` default flipped to `True` (ADR-113); the "disabled by default" test now disables it explicitly (renamed `test_breaker_when_explicitly_disabled`).
- **MPS fallback-warning test** — `assertLogs(WARNING)` was unconditional, but the warning only fires when MPS is available → the Linux CI runner (no MPS) failed on zero records. Wrapped `assertLogs` in the MPS-available branch only. Both branches verified.

Gets **`test-integration`** + **`test-acceptance-fixtures`** green.

## Still red (NOT in this PR — need the speaker-epic owner)

Three `test-e2e` failures are **#1190 speaker/person-quality ML regressions** (reproduce locally, in `roster.py`/`resolution.py` which `feat/speaker-person-quality` owns):
- `test_diarization_e2e` — guest `Liam` no longer maps to a voice (`got ['Maya', 'SPEAKER_01']`).
- `test_v5_parity_regression` ×2 — fresh ML/QA capture differs from the committed `v5_post` baselines.

These aren't mechanical: the diarization one needs a real speaker-resolution fix, and the v5-parity ones need a decision — real regression vs. intended change → **regenerate the eval baselines** (which are the regression guard, so not something to regen blindly). Flagged for whoever's driving #1190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)