### PR TITLE
fix(#1202): main-only test-e2e + acceptance SIGSEGV after RFC-106 merge

### DIFF
--- a/scripts/acceptance/run_acceptance_tests.py
+++ b/scripts/acceptance/run_acceptance_tests.py
@@ -836,7 +836,10 @@ def modify_config_for_fixtures(
             os.environ["DEEPGRAM_API_KEY"] = "test-dummy-key-for-bulk-tests"
         if "ANTHROPIC_API_KEY" not in os.environ:
             # Prefix must satisfy AnthropicProvider key-format check (sk-ant-…).
-            os.environ["ANTHROPIC_API_KEY"] = "sk-ant-api03-acceptance-ci-dummy-key"
+            # Dummy CI value, not a real secret; the sk-ant-api03- shape trips the scanner.
+            os.environ["ANTHROPIC_API_KEY"] = (
+                "sk-ant-api03-acceptance-ci-dummy-key"  # noqa: secret-scan
+            )
 
     # Effective feed URLs: fixture replacement or YAML (session-wide mode is in main()).
     feed_list = config_dict.get("feeds") or config_dict.get("rss_urls")
@@ -1814,6 +1817,23 @@ def _extract_episodes_from_index_json(index_json_path: Path) -> int:
     return 0
 
 
+# Native math thread-pool caps for the per-config pipeline subprocesses. This mirrors the api
+# container's Dockerfile ENV (commit 5e9d33bb): the acceptance job runs the same in-process
+# torch/BERT embedding + LanceDB hybrid search (whose score-normalize calls native pyarrow.compute)
+# NATIVELY on the runner, where the container ENV never reaches it. With no caps the pools each size
+# to the full CPU count, so torch/OpenMP + BLAS + pyarrow's C++ pool oversubscribe and the native
+# layers race — an intermittent hard SIGSEGV (exit_code -11) in the multi-feed rows that do the most
+# embedding. Must be set in the child's env BEFORE it imports (pools initialise at import time), so
+# we inject here at spawn rather than via runtime set_num_threads(). setdefault leaves an explicit
+# operator override untouched; the tiny fixture corpora make single-threaded native math a non-issue
+# for wall time.
+def _acceptance_subprocess_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for var in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS"):
+        env.setdefault(var, "1")
+    return env
+
+
 def _execute_process_with_streaming(
     cmd: list[str],
     stdout_path: Path,
@@ -1842,7 +1862,7 @@ def _execute_process_with_streaming(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env=os.environ.copy(),
+        env=_acceptance_subprocess_env(),
         text=True,
         bufsize=1,  # Line buffered
     )
@@ -1944,7 +1964,7 @@ def _execute_process_without_streaming(
             cmd,
             stdout=stdout_file,
             stderr=stderr_file,
-            env=os.environ.copy(),
+            env=_acceptance_subprocess_env(),
         )
 
         # Monitor resources continuously

--- a/tests/e2e/test_cloud_guardrails_fallback_e2e.py
+++ b/tests/e2e/test_cloud_guardrails_fallback_e2e.py
@@ -68,7 +68,7 @@ def _openai_primary_with_anthropic_fallback(e2e_server):
     primary.initialize()
     wrapped = FallbackAwareSummarizationProvider(
         primary=primary,
-        fallback_provider_name="anthropic",
+        fallback_provider_names="anthropic",
         cfg=cfg,
     )
     return wrapped
@@ -96,7 +96,7 @@ def _gemini_primary_with_openai_fallback(e2e_server):
     primary.initialize()
     wrapped = FallbackAwareSummarizationProvider(
         primary=primary,
-        fallback_provider_name="openai",
+        fallback_provider_names="openai",
         cfg=cfg,
     )
     return wrapped


### PR DESCRIPTION
## What

Fixes the two failures that turned `main`'s `Python application` workflow red after #1202 merged. Both
are in jobs that **only run on `main`, not on PRs** (PRs run the `-fast` variants), which is why #1202's
green PR CI didn't catch them.

## 1. `test-e2e` — regression from #1202 (mine)

RFC-106 (#1198) renamed `FallbackAwareSummarizationProvider`'s constructor param
`fallback_provider_name` → `fallback_provider_names` (`Union[str, Sequence[str]]`). Production callers
and the unit test were updated; the full-suite e2e test `test_cloud_guardrails_fallback_e2e.py` still
passed the old singular kwarg → `TypeError`. That test runs only in the main-only `test-e2e` job
(`test-e2e-fast` skips it), so it slipped through.

**Fix:** update the two call sites to `fallback_provider_names`. Verified — both previously-failing tests
pass locally.

## 2. `test-acceptance-fixtures` — pre-existing intermittent SIGSEGV

The acceptance matrix died with `exit_code=-11` (SIGSEGV) on the `fast_cloud_balanced_multi` row (10
episodes → the most torch/BERT embedding + LanceDB hybrid search). Same root cause the api-container fix
`5e9d33bb` diagnosed with a full fault traceback: with no native-thread caps, torch/OpenMP + BLAS +
pyarrow.compute (LanceDB score-normalize) oversubscribe the CPU and the native layers race → hard SIGSEGV.

`5e9d33bb` set `OMP/OPENBLAS/MKL_NUM_THREADS=1` as **Dockerfile ENV** — but the acceptance job runs the
same in-process stack **natively on the runner**, where the container ENV never reaches it (it failed on
`5e9d33bb` itself, before #1202). `src/.../workflow/stages/setup.py:71` deliberately doesn't set these.

**Fix:** inject the same caps into the env of each per-config subprocess at spawn (both `Popen` sites in
`run_acceptance_tests.py`), so the child imports with the pools already capped (a runtime
`set_num_threads()` is too late — pools initialise at import). `setdefault` respects an explicit operator
override. Also annotated a pre-existing dummy CI Anthropic key with `# noqa: secret-scan` (the
`sk-ant-api03-` shape is a scanner false positive, not a real secret).

## Validation

- The two `test_cloud_guardrails_fallback_e2e.py` tests: pass locally.
- Full acceptance fast matrix with the caps: **all 4 configs `exit_code=0`** (incl. the multi row that
  crashed in CI); `vector_index=indexed` on the single rows.
- `flake8` + full-project `mypy` (pre-commit) clean.

### Not verified locally

The SIGSEGV is an intermittent CPU-oversubscription crash specific to the CI runner; it does not
reproduce on macOS, so a clean local matrix is **consistent with** the fix but not proof. CI going — and
staying — green is the real confirmation.

Follows up #1202 / #1198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
