### PR TITLE
feat(secrets): Option A tmpfs secret delivery + go-live plan (#1250)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -163,6 +163,9 @@ jobs:
         if: steps.preflight.outputs.skip != 'true'
         env:
           SSH_TARGET: deploy@${{ steps.ts_host.outputs.resolved_fqdn }}
+          # ADR-115 Option A (#1250): when '1', drop the LLM keys + DSNs from .env
+          # (delivered as tmpfs files instead). Default empty = today's behaviour.
+          PODCAST_SECRETS_VIA_FILES:    ${{ vars.PODCAST_SECRETS_VIA_FILES }}
           # LLM provider keys
           PROD_OPENAI_API_KEY:          ${{ secrets.PROD_OPENAI_API_KEY }}
           PROD_ANTHROPIC_API_KEY:       ${{ secrets.PROD_ANTHROPIC_API_KEY }}
@@ -197,16 +200,22 @@ jobs:
             printf '%s=%s\n' PODCAST_ENV                 prod
             printf '%s=%s\n' PODCAST_AVAILABLE_PROFILES  cloud_balanced,cloud_thin
             printf '%s=%s\n' PODCAST_DEFAULT_PROFILE     cloud_balanced
-            # LLM provider keys
-            printf '%s=%s\n' OPENAI_API_KEY     "$PROD_OPENAI_API_KEY"
-            printf '%s=%s\n' ANTHROPIC_API_KEY  "$PROD_ANTHROPIC_API_KEY"
-            printf '%s=%s\n' GEMINI_API_KEY     "$PROD_GEMINI_API_KEY"
-            printf '%s=%s\n' MISTRAL_API_KEY    "$PROD_MISTRAL_API_KEY"
-            printf '%s=%s\n' DEEPSEEK_API_KEY   "$PROD_DEEPSEEK_API_KEY"
-            printf '%s=%s\n' GROK_API_KEY       "$PROD_GROK_API_KEY"
-            # Sentry
-            printf '%s=%s\n' PODCAST_SENTRY_DSN_API      "$PROD_SENTRY_DSN_API"
-            printf '%s=%s\n' PODCAST_SENTRY_DSN_PIPELINE "$PROD_SENTRY_DSN_PIPELINE"
+            # LLM provider keys + Sentry DSNs. Under ADR-115 Option A (#1250,
+            # PODCAST_SECRETS_VIA_FILES=1) these are delivered as tmpfs FILES and
+            # the shim exports them, so they are DROPPED from the plaintext .env
+            # (no secrets at rest on disk). Flag off = today's env behaviour.
+            if [ "${PODCAST_SECRETS_VIA_FILES:-}" != "1" ]; then
+              printf '%s=%s\n' OPENAI_API_KEY     "$PROD_OPENAI_API_KEY"
+              printf '%s=%s\n' ANTHROPIC_API_KEY  "$PROD_ANTHROPIC_API_KEY"
+              printf '%s=%s\n' GEMINI_API_KEY     "$PROD_GEMINI_API_KEY"
+              printf '%s=%s\n' MISTRAL_API_KEY    "$PROD_MISTRAL_API_KEY"
+              printf '%s=%s\n' DEEPSEEK_API_KEY   "$PROD_DEEPSEEK_API_KEY"
+              printf '%s=%s\n' GROK_API_KEY       "$PROD_GROK_API_KEY"
+              printf '%s=%s\n' PODCAST_SENTRY_DSN_API      "$PROD_SENTRY_DSN_API"
+              printf '%s=%s\n' PODCAST_SENTRY_DSN_PIPELINE "$PROD_SENTRY_DSN_PIPELINE"
+            fi
+            # Viewer DSN is a build-time FRONTEND var (baked into the viewer image),
+            # not a runtime container secret — always keep it in .env.
             printf '%s=%s\n' VITE_SENTRY_DSN_VIEWER      "$PROD_SENTRY_DSN_VIEWER"
             # Grafana Cloud
             printf '%s=%s\n' GRAFANA_CLOUD_API_KEY   "$PROD_GRAFANA_CLOUD_API_KEY"
@@ -227,6 +236,50 @@ jobs:
              chmod 600 .env; \
              chown deploy:deploy .env; \
              test -f .bootstrap-needs-env && rm -f .bootstrap-needs-env || true"
+
+      - name: Stage tmpfs secret files (ADR-115 Option A, #1250)
+        # When PODCAST_SECRETS_VIA_FILES=1, write the provider keys + Sentry DSNs
+        # to HOST tmpfs /dev/shm/podcast-secrets/ (RAM, never disk). The secrets
+        # overlay (deploy.sh adds it when the flag is on) mounts them as files and
+        # the shim exports them. Atomic: build the dir on the runner in /dev/shm,
+        # scp, then swap into place so a partial upload is never mounted.
+        if: steps.preflight.outputs.skip != 'true' && vars.PODCAST_SECRETS_VIA_FILES == '1'
+        env:
+          SSH_TARGET: deploy@${{ steps.ts_host.outputs.resolved_fqdn }}
+          PROD_OPENAI_API_KEY:      ${{ secrets.PROD_OPENAI_API_KEY }}
+          PROD_ANTHROPIC_API_KEY:   ${{ secrets.PROD_ANTHROPIC_API_KEY }}
+          PROD_GEMINI_API_KEY:      ${{ secrets.PROD_GEMINI_API_KEY }}
+          PROD_MISTRAL_API_KEY:     ${{ secrets.PROD_MISTRAL_API_KEY }}
+          PROD_DEEPSEEK_API_KEY:    ${{ secrets.PROD_DEEPSEEK_API_KEY }}
+          PROD_GROK_API_KEY:        ${{ secrets.PROD_GROK_API_KEY }}
+          PROD_SENTRY_DSN_API:      ${{ secrets.PROD_SENTRY_DSN_API }}
+          PROD_SENTRY_DSN_PIPELINE: ${{ secrets.PROD_SENTRY_DSN_PIPELINE }}
+        run: |
+          set -euo pipefail
+          STAGE=$(mktemp -d -p /dev/shm secstage.XXXXXX)
+          trap 'rm -rf "$STAGE"' EXIT
+          # File name = the lowercase secret name the overlay + shim expect.
+          printf '%s' "$PROD_OPENAI_API_KEY"      > "$STAGE/openai_api_key"
+          printf '%s' "$PROD_ANTHROPIC_API_KEY"   > "$STAGE/anthropic_api_key"
+          printf '%s' "$PROD_GEMINI_API_KEY"      > "$STAGE/gemini_api_key"
+          printf '%s' "$PROD_MISTRAL_API_KEY"     > "$STAGE/mistral_api_key"
+          printf '%s' "$PROD_DEEPSEEK_API_KEY"    > "$STAGE/deepseek_api_key"
+          printf '%s' "$PROD_GROK_API_KEY"        > "$STAGE/grok_api_key"
+          printf '%s' "$PROD_SENTRY_DSN_API"      > "$STAGE/podcast_sentry_dsn_api"
+          printf '%s' "$PROD_SENTRY_DSN_PIPELINE" > "$STAGE/podcast_sentry_dsn_pipeline"
+          chmod 400 "$STAGE"/*
+          ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+            "rm -rf /dev/shm/podcast-secrets.staged && mkdir -p /dev/shm/podcast-secrets.staged && chmod 700 /dev/shm/podcast-secrets.staged"
+          scp -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+            "$STAGE"/* "${SSH_TARGET}:/dev/shm/podcast-secrets.staged/"
+          ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+            "set -euo pipefail; chmod 400 /dev/shm/podcast-secrets.staged/*; \
+             rm -rf /dev/shm/podcast-secrets; \
+             mv /dev/shm/podcast-secrets.staged /dev/shm/podcast-secrets; \
+             chmod 700 /dev/shm/podcast-secrets"
 
       - name: Wire PODCAST_RELEASE into host .env (#721 — Sentry release grouping)
         # Idempotent: prior PODCAST_RELEASE=... line is removed before the new
@@ -280,10 +333,12 @@ jobs:
           SHA_SHORT:  ${{ steps.sha.outputs.short }}
           GIT_REF:    ${{ steps.sha.outputs.git_ref }}
           SSH_TARGET: deploy@${{ steps.ts_host.outputs.resolved_fqdn }}
+          # ADR-115 Option A (#1250): deploy.sh joins the secrets overlay when '1'.
+          VIA_FILES:  ${{ vars.PODCAST_SECRETS_VIA_FILES }}
         run: |
           ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
-            "DEPLOY_GIT_SHA='${GIT_REF}' DEPLOY_IMAGE_SHA='${SHA_SHORT}' /srv/podcast-scraper/infra/deploy/deploy.sh"
+            "DEPLOY_GIT_SHA='${GIT_REF}' DEPLOY_IMAGE_SHA='${SHA_SHORT}' PODCAST_SECRETS_VIA_FILES='${VIA_FILES}' /srv/podcast-scraper/infra/deploy/deploy.sh"
 
       - name: External /api/health probe over Tailscale (#720)
         # Belt-and-suspenders: deploy.sh already hit /api/health inside the api

--- a/compose/docker-compose.secrets.yml
+++ b/compose/docker-compose.secrets.yml
@@ -1,22 +1,18 @@
-# ADR-115 cutover overlay — file-mounted secrets instead of env-injected keys.
+# ADR-115 cutover overlay (Option A, #1250) — file-mounted secrets, not env keys.
 #
 # Layer ON TOP of stack + prod (+ vps-prod) to mount the provider keys +
-# Sentry DSNs (decrypted by decrypt-secrets.sh into /run/secrets/podcast) as
-# files into the api + pipeline-llm containers. The baked-in secret shim
-# (docker/secrets-shim.sh) then exports them as the UPPERCASE env vars the app
-# reads. The env lines in docker-compose.prod.yml stay (they resolve empty once
-# the host .env drops the keys); the shim overrides them from the files.
+# Sentry DSNs into the api + pipeline-llm containers. Under Option A the SOURCE
+# files live in HOST tmpfs at /dev/shm/podcast-secrets/ (RAM, never disk),
+# written by deploy-prod.yml from GH Actions Secrets — no sops, no ciphertext in
+# this public repo (ADR-115 Addendum). Compose mounts each to /run/secrets/<name>
+# in the container; the baked-in shim (docker/secrets-shim.sh) exports them as the
+# UPPERCASE env vars the app reads. The env lines in docker-compose.prod.yml stay
+# (they resolve empty once the host .env drops the keys); the shim overrides them.
 #
-#   docker compose -f compose/docker-compose.stack.yml \
-#     -f compose/docker-compose.prod.yml \
-#     -f compose/docker-compose.vps-prod.yml \
-#     -f compose/docker-compose.secrets.yml up -d
-#
-# ⚠ CUTOVER GATE: do NOT add this overlay to the deploy -f chain until the box
-# has the decrypted files present (/run/secrets/podcast/*) — compose
-# ``secrets: file:`` errors at ``up`` if the source is absent. Sequence:
-# operator stages the age key + commits prod.enc.yaml → deploy stages key +
-# runs decrypt-secrets.sh → THEN this overlay joins the deploy -f chain.
+# ⚠ CUTOVER GATE: this overlay only joins the deploy -f chain when
+# PODCAST_SECRETS_VIA_FILES=1 (deploy.sh) AND deploy-prod has written
+# /dev/shm/podcast-secrets/* — compose ``secrets: file:`` errors at ``up`` if the
+# source is absent, so the flag + the delivery step are coupled by design.
 services:
   api:
     secrets:
@@ -41,18 +37,18 @@ services:
 
 secrets:
   openai_api_key:
-    file: /run/secrets/podcast/openai_api_key
+    file: /dev/shm/podcast-secrets/openai_api_key
   gemini_api_key:
-    file: /run/secrets/podcast/gemini_api_key
+    file: /dev/shm/podcast-secrets/gemini_api_key
   anthropic_api_key:
-    file: /run/secrets/podcast/anthropic_api_key
+    file: /dev/shm/podcast-secrets/anthropic_api_key
   mistral_api_key:
-    file: /run/secrets/podcast/mistral_api_key
+    file: /dev/shm/podcast-secrets/mistral_api_key
   deepseek_api_key:
-    file: /run/secrets/podcast/deepseek_api_key
+    file: /dev/shm/podcast-secrets/deepseek_api_key
   grok_api_key:
-    file: /run/secrets/podcast/grok_api_key
+    file: /dev/shm/podcast-secrets/grok_api_key
   podcast_sentry_dsn_api:
-    file: /run/secrets/podcast/podcast_sentry_dsn_api
+    file: /dev/shm/podcast-secrets/podcast_sentry_dsn_api
   podcast_sentry_dsn_pipeline:
-    file: /run/secrets/podcast/podcast_sentry_dsn_pipeline
+    file: /dev/shm/podcast-secrets/podcast_sentry_dsn_pipeline

--- a/docs/adr/ADR-115-multi-tenant-secret-delivery-sops-tmpfs-files.md
+++ b/docs/adr/ADR-115-multi-tenant-secret-delivery-sops-tmpfs-files.md
@@ -110,3 +110,46 @@ pattern; the `.env` render is replaced by decrypt-to-tmpfs + file mounts.
   path (against the vanilla/no-lock ethos) + a bootstrap token still on the box. Rejected as primary.
 - **systemd-creds** — vanilla + encrypted, but Hetzner VMs likely lack a vTPM (key on disk
   anyway) and it bridges awkwardly into compose. Kept as a possible wrapper for the age key.
+
+## Addendum (2026-07-21) — this repo is PUBLIC → Option A first (#1250)
+
+The original design commits `infra/secrets/<env>.enc.yaml` **in the tenant's repo**. That
+silently assumed a *private* repo. **`podcast_scraper` is public**, and committing sops
+ciphertext to a public repo is a weaker posture: the ciphertext is public and permanent
+(every clone/fork/archive forever), so if the age key ever leaks, all committed secrets are
+retroactively decryptable from history — and one accidental un-encrypted commit leaks
+plaintext irrevocably. So for the podcast tenant we adopt **Option A** now and defer the
+sops-in-git model to the private-infra move ([#1251](https://github.com/chipi/podcast_scraper/issues/1251)).
+
+**Option A (public-repo-safe):** keep **GH Actions Secrets** as the private source of truth
+(already renders `.env` today). Adopt only the ADR's **runtime-delivery half** — deliver
+secrets as **files in RAM (tmpfs)**, mounted into the containers; the baked-in
+`docker/secrets-shim.sh` exports them as the env vars the app reads. **No ciphertext is
+committed to this public repo.** Delivery is **flag-gated** (`PODCAST_SECRETS_VIA_FILES`,
+default off = today's `.env` behaviour); flipping it on the box is the cutover, with the
+loud check "expected secret files present + non-empty before `compose up`" so a missing key
+fails the deploy rather than silently booting.
+
+- **Kept from the ADR:** shim + tmpfs-file delivery, "no plaintext at rest on disk", the
+  cutover gate. **Dropped for Option A:** committing `prod.enc.yaml` to this public repo, the
+  `infra/secrets/*.yaml` sops recipient rule.
+- **Not yet done (C2, [#1252](https://github.com/chipi/podcast_scraper/issues/1252)):** the app
+  still reads the secrets from **env** (the shim populates env from files). Removing the
+  runtime-env exposure (app reads `*_FILE` at point of use) is the paired follow-up — the
+  residual only matters *after* a box compromise.
+
+### Rotation runbook (Option A)
+
+Any container secret (LLM key, GlitchTip DSN) — rotate = **update the GH Secret + redeploy**:
+
+```bash
+gh secret set PROD_OPENAI_API_KEY --repo chipi/podcast_scraper   # paste new value
+# run deploy-prod (PROD_DEPLOY) → writes the new value to the tmpfs file → containers restart
+```
+
+- No `sops`, no touching the box by hand, no re-keying. Deploy re-renders the tmpfs files
+  from GH Secrets every time.
+- **Grafana push token** rotates the same way but is a **CI/workstation** secret (used by
+  `push-grafana-dashboards.sh`), **not** a container secret — it is *not* in the tmpfs set.
+- Under the future private-infra model (#1251) with sops, rotation becomes
+  `sops edit infra/secrets/prod.enc.yaml` + commit (private) + redeploy.

--- a/docs/wip/GOAL1-GO-LIVE-PLAN.md
+++ b/docs/wip/GOAL1-GO-LIVE-PLAN.md
@@ -100,9 +100,9 @@ channels are provisioned as code (homelab `backend/grafana/provisioning/alerting
 | 3.1 | Walk the [THREAT_MODEL pre-public gate](../security/THREAT_MODEL.md#pre-public-gate--run-before-any-new-public-vhost) checklist — **pre-walked** in [GOAL1-PHASE3-PREP.md](GOAL1-PHASE3-PREP.md) (substrate items done; open: orrery cap_drop / digest-pin / rollback rehearsal) | 🤝 |
 | 3.2 | Sign off: orrery clears it (static, no `docker.sock`, no keys) | 🧑 |
 | 3.3 | ✅ **Folded into `apply-edge.sh`** (1.1) — the metadata-egress guard (script + unit + `enable --now` + live `iptables -C DOCKER-USER` re-assert) is applied by `apply-edge.sh §3` and asserted by `verify-edge.sh §3`. Nothing separate to run; converges when 1.2 runs. (review 2026-07-17 H8 / T-07) | 🤝 |
-| 3.4 | **Complete the ADR-115 secrets cutover** (T-08) — 6 LLM keys still plaintext container env; steps in [GOAL1-PHASE3-PREP.md](GOAL1-PHASE3-PREP.md) §3.4 (age key → `prod.enc.yaml` → decrypt on box → add `-f docker-compose.secrets.yml` → drop keys from `.env`). Blocks public exposure of the **api** (not orrery). (review M26 / #1162) | 🧑 |
+| 3.4 | **Secrets cutover — ADR-115 Option A** (#1250, T-08). Code shipped + flag-gated (`PODCAST_SECRETS_VIA_FILES`): deploy writes the 6 LLM keys + 2 GlitchTip DSNs to host tmpfs `/dev/shm/podcast-secrets/` (RAM), the shim exports them, and they are DROPPED from the plaintext `.env` — no secrets at rest on disk, no ciphertext in this public repo. **Cutover = set the repo Variable `PODCAST_SECRETS_VIA_FILES=1` → run deploy-prod → verify LLM+error paths → confirm `.env` has no keys.** Gates **Phase 4** — opening the firewall exposes the whole box, so every on-box secret must be off-plaintext first (not just the api). C2 (remove runtime-env exposure) = #1252; sops/private-repo model = #1251. | 🤝 |
 
-**No firewall opens until 3.2 is signed off.**
+**No firewall opens until 3.2 is signed off AND 3.4 is cut over (verified `.env` carries no plaintext secrets).**
 
 ### Phase 4 — Open the firewall (the exposure moment)
 
@@ -160,7 +160,10 @@ check → flip `audio_storage_backend=remote` → e2e (`archive pull` / reproces
 ## Status update (2026-07-20)
 
 - **Order confirmed: orrery goes public first** (pilot tenant); the podcast **api**
-  follows and additionally needs the 3.4 secrets cutover before it can be exposed.
+  follows. Correction: the **3.4 secrets cutover gates the firewall (Phase 4) for
+  both** — opening the box exposes its on-disk secrets regardless of which vhost is
+  served — so it happens before exposure, not only before the api. Code shipped
+  (#1250, flag-gated); cutover = flip the repo Variable at go-live.
 - **DR-drill blocker cleared** — `verify-backup-restore` is green (run 2026-07-19).
   The earlier SIGSEGV pause no longer applies; Phase 0.2 can pass.
 - **Observability done on self-hosted rails** (Phase 2 above) — replaced the

--- a/infra/.sops.yaml
+++ b/infra/.sops.yaml
@@ -10,10 +10,7 @@ creation_rules:
     # The matching PRIVATE key lives in your password manager (operator's choice).
     age: 'age1yerjgvcm5trle7xl7jkmt53dp290y2fr9rt5zjpljzeyv0nkr5qqffhm00'
 
-  # ADR-115 app secrets (infra/secrets/*.yaml). Encrypt to the VPS age recipient
-  # — the box holds the matching PRIVATE key at /etc/vps-secrets/age.key so it can
-  # decrypt at deploy. This is DISTINCT from the tfstate key above (whose private
-  # key stays in the operator's password manager and never touches the box).
-  # OPERATOR: replace the placeholder with the VPS recipient public key.
-  - path_regex: 'infra/secrets/.*\.yaml$'
-    age: 'age1PLACEHOLDER0vps0recipient0replace0with0age0keygen0public0key00000'
+  # NOTE: no app-secrets rule here on purpose. This repo is PUBLIC, so we do NOT
+  # commit sops-encrypted app secrets to it (ADR-115 Addendum / Option A, #1250):
+  # prod secrets come from GH Actions Secrets → tmpfs files at deploy, never git.
+  # The sops-in-git app-secrets model returns with the private-infra move (#1251).

--- a/infra/deploy/deploy.sh
+++ b/infra/deploy/deploy.sh
@@ -20,6 +20,22 @@ REPO_DIR=/srv/podcast-scraper
 # top of the stack + prod overlays. Codespaces deliberately omits it.
 STACK_FILES=(-f compose/docker-compose.stack.yml -f compose/docker-compose.prod.yml -f compose/docker-compose.vps-prod.yml)
 
+# ADR-115 Option A (#1250): file-mounted secrets. Flag-gated (default off = the
+# current .env behaviour). When on, deploy-prod has written the secret files to
+# host tmpfs /dev/shm/podcast-secrets/; join the secrets overlay so they mount as
+# files + the shim exports them. Fail LOUD if the flag is set but the delivery
+# step did not run — never boot silently without the provider keys (the
+# /api/health probe does not exercise LLM calls, so it would not catch it).
+if [ "${PODCAST_SECRETS_VIA_FILES:-}" = "1" ]; then
+  if [ ! -d /dev/shm/podcast-secrets ] || [ -z "$(ls -A /dev/shm/podcast-secrets 2>/dev/null)" ]; then
+    echo "ERROR: PODCAST_SECRETS_VIA_FILES=1 but /dev/shm/podcast-secrets/ is empty/missing." >&2
+    echo "       The deploy-prod tmpfs-secret-delivery step must run before deploy.sh." >&2
+    exit 5
+  fi
+  STACK_FILES+=(-f compose/docker-compose.secrets.yml)
+  echo "[$(date -u +%FT%TZ)] secrets: file-mounted from /dev/shm/podcast-secrets ($(ls -1 /dev/shm/podcast-secrets | wc -l | tr -d ' ') files)"
+fi
+
 cd "$REPO_DIR"
 
 # ``docker-compose.prod.yml`` requires ``PODCAST_DOCKER_PROJECT_DIR`` for api


### PR DESCRIPTION
Bundles the go-live secret-handling work into one PR/CI run.

## What's in it
- **#1250 — Option A secret delivery** (public-repo-safe). GH Actions Secrets stay
  the private source of truth; runtime delivery moves off plaintext `.env` to
  RAM-backed tmpfs files that the baked-in shim exports. **Flag-gated**
  (`PODCAST_SECRETS_VIA_FILES`, a repo Variable; default off = today's behaviour,
  zero risk to current deploys). When on: deploy writes the 6 LLM keys + 2 GlitchTip
  DSNs to `/dev/shm/podcast-secrets/`, drops them from `.env`, and `deploy.sh` joins
  the secrets overlay + fails loud if the delivery step didn't run.
- **Plan fix**: Phase 3.4 is now Option A (not the old sops flow) and gates the
  **firewall (Phase 4)** for both tenants — opening the box exposes its on-disk
  secrets regardless of vhost.
- ADR-115 addendum: the public-repo decision + the rotation runbook (`gh secret set`
  → redeploy). `.sops.yaml` app-secrets rule removed (no ciphertext in this public repo).

## Validation
YAML + actionlint + shellcheck + markdown + `make docs` all green (pre-commit).
No Python/app changes. Compose overlay merges cleanly (`stack+secrets: valid`).

## Cutover (at go-live, before the firewall opens)
Set `PODCAST_SECRETS_VIA_FILES=1` (repo Variable) → run deploy-prod → verify LLM +
error paths → confirm `.env` carries no plaintext secrets. Rollback = unset the Variable.

## Not in scope (tracked)
- C2 — app reads `*_FILE` at point of use, removing runtime-env exposure: #1252.
- Full private-infra extraction: #1251.

Part of the Goal-1 go-live (#1160). Closes #1250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)