### PR TITLE
fix(infra-drift): stop false-flagging the firewall + document prod plan/apply flow

### DIFF
--- a/.github/workflows/infra-drift.yml
+++ b/.github/workflows/infra-drift.yml
@@ -91,6 +91,11 @@ jobs:
           TF_VAR_tailscale_api_key: ${{ secrets.TS_API_KEY }}
           TF_VAR_ssh_public_key:    ${{ secrets.OPERATOR_SSH_PUBLIC_KEY }}
           TF_VAR_tailscale_tailnet: ${{ vars.TAILNET_NAME }}
+          # MUST mirror infra-apply.yml. Without it, cloudflare_origin_lock defaults to
+          # false, so drift plans :443 as 0.0.0.0/0 and perpetually reports a spurious
+          # "firewall opening" against a live firewall that is CF-CIDR-locked (T-05/ADR-118).
+          # That false positive would also mask a *real* firewall drift someday.
+          TF_VAR_cloudflare_origin_lock: ${{ vars.CLOUDFLARE_ORIGIN_LOCK || 'false' }}
         run: |
           set +e
           tofu init -input=false

--- a/infra/README.md
+++ b/infra/README.md
@@ -39,21 +39,62 @@ One-time setup (per operator):
 1. `brew install opentofu sops age`
 2. `age-keygen -o ~/.config/sops/age/keys.txt`
 3. Copy the public key (the `# public key:` comment) into [`.sops.yaml`](.sops.yaml), replacing the `age1PLACEHOLDER…` value.
-4. Save the **private** key to 1Password as `sops/podcast-scraper/tofu-state-age-key`.
+4. Back up the **private** key somewhere durable — it's the only thing that decrypts prod
+   tofu state (`~/.config/sops/age/keys.txt` locally; the same value is the `TFSTATE_AGE_KEY`
+   repo Actions secret for CI).
 5. Stage `HCLOUD_TOKEN`, `TS_AUTHKEY` (device-join), `TS_API_KEY` (terraform's tailscale provider; Free-plan substitute for OAuth — see [PROD_RUNBOOK.md "Tailscale credentials"](../docs/guides/PROD_RUNBOOK.md)), `TFSTATE_AGE_KEY` in repo Actions secrets (see [#714](https://github.com/chipi/podcast_scraper/issues/714)).
 
-Per-operation:
+## Prod plan & apply — the whole flow (read this before touching prod)
+
+Prod tofu manages the **entire estate in one state**: `hcloud_server.prod` (the VPS),
+volumes, storage box, network, firewall, **and** `tailscale_acl.main`. **Any apply
+reconciles all of it** — so a one-line ACL change is *not* an isolated apply. Plan first,
+every time, and read the diff.
+
+**Recommended path — GitHub Actions (no local creds needed; guarded):**
+
+| Step | Workflow | What it does |
+| --- | --- | --- |
+| **Plan / review** | **`infra-drift.yml`** (`workflow_dispatch`) | Read-only `tofu plan` vs live; opens/updates a drift issue with the diff. Run this first: `gh workflow run infra-drift.yml` (add `--ref <branch>` to test a workflow change). |
+| **Apply** | **`infra-apply.yml`** (`workflow_dispatch`, `mode=apply`, type `APPLY`) | Re-plans, then applies. `environment: prod` (approval gate) **and** `override_destructive` **blocks any plan containing "forces replacement / must be replaced / will be destroyed"** unless you explicitly override. So it cannot recreate the VPS by accident. |
+
+> **Guard gap to know:** `override_destructive` only blocks *destroy/replace*. An **in-place**
+> change that *opens the firewall* (`0 to destroy`) is **not** blocked — so you must still read
+> the plan's firewall diff yourself.
+
+**Gotcha — `cloudflare_origin_lock` (T-05 / ADR-118):** the firewall's `:443`/`:80` `source_ips`
+switch on this bool — `true` → Cloudflare CIDRs (origin-lock), `false` (the variable default) →
+`0.0.0.0/0`. The live prod firewall is **locked** (repo var `CLOUDFLARE_ORIGIN_LOCK=true`).
+Every workflow that plans/applies prod **must** pass `TF_VAR_cloudflare_origin_lock:
+${{ vars.CLOUDFLARE_ORIGIN_LOCK || 'false' }}` — otherwise it plans with the `false` default and
+reports a **spurious "opening :443 to 0.0.0.0/0"** drift against a firewall that is actually
+locked. If a plan shows `443/80 → 0.0.0.0/0`, check that the workflow passes this var before
+believing the diff.
+
+**Scoped apply (change *only* the ACL, leave the rest alone):**
+
+```bash
+cd infra && ./tofu apply -target='tailscale_acl.main[0]'
+```
+
+`infra-apply.yml` does a *full* apply (no `-target`), so use the CLI for a surgical ACL-only
+change when you don't want to touch anything else in the same run.
+
+**Local path (if you hold the tokens — no 1Password):** export the two provider tokens from
+your own secret store, then use the sops-aware wrapper:
 
 ```bash
 cd infra
-export HCLOUD_TOKEN=$(op read 'op://Personal/Hetzner Cloud/podcast-scraper-prod/api-token')
-export TF_VAR_tailscale_api_key=$(op read 'op://Personal/Tailscale/podcast-scraper/api-key')
-./tofu init
-./tofu plan
-./tofu apply
+export TF_VAR_hcloud_token=…            # Hetzner Cloud API token (prod project)
+export TF_VAR_tailscale_api_key=…       # Tailscale API key (provider; Free-plan OAuth substitute)
+export TF_VAR_ssh_public_key="$(cat ~/.ssh/id_ed25519.pub)"
+export TF_VAR_cloudflare_origin_lock=true   # match live — else you'll plan the firewall open
+./tofu init && ./tofu plan               # or: make infra-plan (sources infra/.env.local)
+./tofu apply                             # prompts y/n; ./tofu apply -target=… to scope
 ```
 
-The `tofu` wrapper auto-decrypts state before invocation and re-encrypts after.
+The `tofu` wrapper auto-decrypts state before invocation and re-encrypts after (see § State
+encryption model).
 
 ## DR drill workspace (OpenTofu, GitHub #752)
 


### PR DESCRIPTION
## Summary

Two things, both surfaced while planning the operator-viewer Umami `:443` ACL grant (ADR-126):

1. **Bug fix** — `infra-drift.yml` planned prod **without** `TF_VAR_cloudflare_origin_lock`, so the variable fell back to its `false` default and **every** scheduled drift plan reported a spurious *"firewall opening `:443`/`:80` to `0.0.0.0/0`"* against a firewall that is actually CF-CIDR-locked (T-05 / ADR-118; repo var `CLOUDFLARE_ORIGIN_LOCK=true`). `infra-apply.yml` already passes the var, so **real applies were always correct** — but the drift report was a permanent false positive that would also **mask a genuine firewall drift** someday. Fix: mirror `infra-apply.yml`'s env in the plan step.

2. **Docs** — `infra/README.md` gains a **"Prod plan & apply — the whole flow"** section so we don't roam around next time: the GHA path (`infra-drift` = read-only plan, `infra-apply` = apply + `environment: prod` gate + `override_destructive` guard), the **whole-estate-in-one-state** caveat (a one-line ACL change is not an isolated apply), the guard's **blind spot** (it blocks destroy/replace, *not* an in-place firewall open), a **scoped** `-target=tailscale_acl.main[0]` apply recipe, and the `cloudflare_origin_lock` gotcha. Also drops the stale 1Password references.

## Why now

Planning the `:443` tailnet ACL grant showed a 2-change drift plan (the ACL + a "firewall open"). The firewall line was **this false positive** — the real apply touches only `tailscale_acl.main`. This PR makes a re-plan show the honest single-resource diff as independent confirmation before any apply.

## Validation

- Pre-commit: markdown-lint ✓, actionlint ✓, YAML ✓, secret-scan ✓.
- A dispatch of `infra-drift.yml --ref fix/infra-drift-cloudflare-origin-lock` should now show **only** `tailscale_acl.main` as the pending change (the firewall line gone). Surfacing that plan for review before any `infra-apply`.

## NOT in this PR
- No `tofu apply`. No deploy. This is workflow + docs only — the ACL apply stays behind the manual `infra-apply.yml` dispatch + prod environment gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)