### PR TITLE
chore(ci): migrate tailscale/github-action from authkey to OAuth client

### DIFF
--- a/.github/workflows/backup-corpus-prod.yml
+++ b/.github/workflows/backup-corpus-prod.yml
@@ -12,7 +12,7 @@ name: Backup corpus snapshot (prod VPS)
 # Closes #722 (Phase A side). #744: resolve prod MagicDNS host after join.
 #
 # Operator prerequisites (#714):
-#   secrets: TS_AUTHKEY (see PROD_RUNBOOK.md "Tailscale credentials");
+#   secrets: TS_OAUTH_CLIENT_ID + TS_OAUTH_SECRET (see PROD_RUNBOOK.md "Tailscale credentials");
 #            PROD_SSH_PRIVATE_KEY (Ed25519 PEM for deploy@ — see "GitHub Actions SSH to prod");
 #            BACKUP_REPO_TOKEN (required when dry_run is false)
 #   vars:    PROD_TAILNET_FQDN, PODCAST_BACKUP_REPO (defaults to chipi/podcast_scraper-backup)
@@ -42,14 +42,16 @@ jobs:
       - name: Pre-flight — required secrets/variables present?
         id: preflight
         env:
-          TS_AUTHKEY:            ${{ secrets.TS_AUTHKEY }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
           PROD_SSH_PRIVATE_KEY:  ${{ secrets.PROD_SSH_PRIVATE_KEY }}
           BACKUP_REPO_TOKEN:     ${{ secrets.BACKUP_REPO_TOKEN }}
           PROD_TAILNET_FQDN:     ${{ vars.PROD_TAILNET_FQDN }}
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ]            && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_SECRET:-}" ]    && MISSING="$MISSING TS_OAUTH_SECRET"
           [ -z "${PROD_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING PROD_SSH_PRIVATE_KEY"
           [ -z "${PROD_TAILNET_FQDN:-}" ]    && MISSING="$MISSING PROD_TAILNET_FQDN"
           if [ "${{ inputs.dry_run }}" = "false" ] && [ -z "${BACKUP_REPO_TOKEN:-}" ]; then
@@ -73,7 +75,8 @@ jobs:
         if: steps.preflight.outputs.skip != 'true'
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags:    tag:gha-deployer
           # Pinned — `version: latest` broke sha256 verification in GHA (May 2026).
           version: 1.96.4

--- a/.github/workflows/backup-player-appdata-prod.yml
+++ b/.github/workflows/backup-player-appdata-prod.yml
@@ -35,14 +35,16 @@ jobs:
       - name: Pre-flight — required secrets/variables present?
         id: preflight
         env:
-          TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
           PROD_SSH_PRIVATE_KEY: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
           PROD_TAILNET_FQDN: ${{ vars.PROD_TAILNET_FQDN }}
           BACKUP_REPO_TOKEN: ${{ secrets.BACKUP_REPO_TOKEN }}
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ] && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_SECRET:-}" ]    && MISSING="$MISSING TS_OAUTH_SECRET"
           [ -z "${PROD_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING PROD_SSH_PRIVATE_KEY"
           [ -z "${PROD_TAILNET_FQDN:-}" ] && MISSING="$MISSING PROD_TAILNET_FQDN"
           [ -z "${BACKUP_REPO_TOKEN:-}" ] && MISSING="$MISSING BACKUP_REPO_TOKEN"
@@ -63,7 +65,8 @@ jobs:
         if: steps.preflight.outputs.skip != 'true'
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:gha-deployer
           version: 1.96.4
 

--- a/.github/workflows/deploy-player.yml
+++ b/.github/workflows/deploy-player.yml
@@ -6,7 +6,7 @@
 # surface is untouched. Manual (workflow_dispatch); typed confirm; tailnet-only SSH.
 #
 # Prereqs (stage once, like deploy-prod #714):
-#   secrets: TS_AUTHKEY, PROD_SSH_PRIVATE_KEY, PLAYER_APP_SESSION_SECRET,
+#   secrets: TS_OAUTH_CLIENT_ID + TS_OAUTH_SECRET, PROD_SSH_PRIVATE_KEY, PLAYER_APP_SESSION_SECRET,
 #            PLAYER_GOOGLE_CLIENT_SECRET
 #   vars:    PROD_TAILNET_FQDN, PLAYER_DOMAIN, PODCAST_CORPUS_VOLUME, PLAYER_GOOGLE_CLIENT_ID
 # The Caddy edge + firewall 80/443 must already be live on the box, and DNS for
@@ -48,7 +48,8 @@ jobs:
       - name: Pre-flight — required secrets/variables present?
         id: preflight
         env:
-          TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
           PROD_SSH_PRIVATE_KEY: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
           PROD_TAILNET_FQDN: ${{ vars.PROD_TAILNET_FQDN }}
           PLAYER_DOMAIN: ${{ vars.PLAYER_DOMAIN }}
@@ -59,7 +60,8 @@ jobs:
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ] && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_SECRET:-}" ]    && MISSING="$MISSING TS_OAUTH_SECRET"
           [ -z "${PROD_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING PROD_SSH_PRIVATE_KEY"
           [ -z "${PROD_TAILNET_FQDN:-}" ] && MISSING="$MISSING PROD_TAILNET_FQDN"
           [ -z "${PLAYER_DOMAIN:-}" ] && MISSING="$MISSING PLAYER_DOMAIN"
@@ -82,7 +84,8 @@ jobs:
         if: steps.preflight.outputs.skip != 'true'
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:gha-deployer
           version: 1.96.4
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -13,7 +13,7 @@ name: Deploy to prod VPS
 # #796 (typed confirm, SHA validation, deploy.sh/git/image alignment).
 #
 # Operator prerequisites (#714):
-#   - secrets: TS_AUTHKEY (see PROD_RUNBOOK.md "Tailscale credentials");
+#   - secrets: TS_OAUTH_CLIENT_ID + TS_OAUTH_SECRET (see PROD_RUNBOOK.md "Tailscale credentials");
 #              PROD_SSH_PRIVATE_KEY (Ed25519 PEM for deploy@ — see PROD_RUNBOOK
 #              "GitHub Actions SSH to prod")
 #   - vars:    PROD_TAILNET_FQDN (e.g. "prod-podcast.example.ts.net")
@@ -65,13 +65,15 @@ jobs:
       - name: Pre-flight — required secrets/variables present?
         id: preflight
         env:
-          TS_AUTHKEY:              ${{ secrets.TS_AUTHKEY }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
           PROD_SSH_PRIVATE_KEY:     ${{ secrets.PROD_SSH_PRIVATE_KEY }}
           PROD_TAILNET_FQDN: ${{ vars.PROD_TAILNET_FQDN }}
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ]            && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_SECRET:-}" ]    && MISSING="$MISSING TS_OAUTH_SECRET"
           [ -z "${PROD_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING PROD_SSH_PRIVATE_KEY"
           [ -z "${PROD_TAILNET_FQDN:-}" ]    && MISSING="$MISSING PROD_TAILNET_FQDN"
           if [ -n "$MISSING" ]; then
@@ -153,7 +155,8 @@ jobs:
         if: steps.preflight.outputs.skip != 'true'
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags:    tag:gha-deployer
           # Pinned — `version: latest` broke sha256 verification in GHA (May 2026).
           version: 1.96.4

--- a/.github/workflows/drill-deploy.yml
+++ b/.github/workflows/drill-deploy.yml
@@ -6,7 +6,7 @@ name: DR drill — deploy VPS
 # hard-coded prod values.
 #
 # Prerequisites:
-#   - secrets: TS_AUTHKEY, DRILL_DEPLOY_SSH_PRIVATE_KEY (Ed25519 PEM for
+#   - secrets: TS_OAUTH_CLIENT_ID + TS_OAUTH_SECRET, DRILL_DEPLOY_SSH_PRIVATE_KEY (Ed25519 PEM for
 #              deploy@ on the drill host — same pattern as PROD_SSH_PRIVATE_KEY;
 #              public half must be in deploy@ ~/.ssh/authorized_keys; can be
 #              the same keypair as prod if you appended the same .pub to drill)
@@ -28,7 +28,9 @@ on:
         default: ""
   workflow_call:
     secrets:
-      TS_AUTHKEY:
+      TS_OAUTH_CLIENT_ID:
+        required: true
+      TS_OAUTH_SECRET:
         required: true
       DRILL_DEPLOY_SSH_PRIVATE_KEY:
         required: true
@@ -57,13 +59,15 @@ jobs:
       - name: "DR drill — pre-flight: secrets and variables"
         id: preflight
         env:
-          TS_AUTHKEY:                  ${{ secrets.TS_AUTHKEY }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
           DRILL_DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DRILL_DEPLOY_SSH_PRIVATE_KEY }}
           DRILL_TAILNET_FQDN:          ${{ vars.DRILL_TAILNET_FQDN }}
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ]                    && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_SECRET:-}" ]    && MISSING="$MISSING TS_OAUTH_SECRET"
           [ -z "${DRILL_DEPLOY_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING DRILL_DEPLOY_SSH_PRIVATE_KEY"
           [ -z "${DRILL_TAILNET_FQDN:-}" ]          && MISSING="$MISSING DRILL_TAILNET_FQDN"
           if [ -n "$MISSING" ]; then
@@ -135,7 +139,8 @@ jobs:
         if: steps.preflight.outputs.skip != 'true'
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags:    tag:gha-deployer
           version: 1.96.4
 

--- a/.github/workflows/drill-e2e.yml
+++ b/.github/workflows/drill-e2e.yml
@@ -6,7 +6,7 @@ name: DR drill — smoke (post_deploy_smoke)
 # prod make smoke-prod).
 #
 # Prerequisites:
-#   secrets: TS_AUTHKEY, DRILL_DEPLOY_SSH_PRIVATE_KEY (deploy@ PEM, same as drill-deploy)
+#   secrets: TS_OAUTH_CLIENT_ID + TS_OAUTH_SECRET, DRILL_DEPLOY_SSH_PRIVATE_KEY (deploy@ PEM, same as drill-deploy)
 #   vars:    DRILL_TAILNET_FQDN (e.g. dr-podcast.tail-xxxx.ts.net)
 #
 # Tailscale ACL must allow tag:gha-deployer → tag:dr-drill:443 for HTTPS in
@@ -22,7 +22,9 @@ on:
         default: ''
   workflow_call:
     secrets:
-      TS_AUTHKEY:
+      TS_OAUTH_CLIENT_ID:
+        required: true
+      TS_OAUTH_SECRET:
         required: true
       DRILL_DEPLOY_SSH_PRIVATE_KEY:
         required: true
@@ -54,13 +56,15 @@ jobs:
 
       - name: "DR drill — pre-flight: secrets and variables"
         env:
-          TS_AUTHKEY:                  ${{ secrets.TS_AUTHKEY }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
           DRILL_DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DRILL_DEPLOY_SSH_PRIVATE_KEY }}
           DRILL_TAILNET_FQDN:          ${{ vars.DRILL_TAILNET_FQDN }}
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ]                    && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_SECRET:-}" ]    && MISSING="$MISSING TS_OAUTH_SECRET"
           [ -z "${DRILL_DEPLOY_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING DRILL_DEPLOY_SSH_PRIVATE_KEY"
           [ -z "${DRILL_TAILNET_FQDN:-}" ]          && MISSING="$MISSING DRILL_TAILNET_FQDN"
           if [ -n "$MISSING" ]; then
@@ -82,7 +86,8 @@ jobs:
       - name: "DR drill — join: tailnet (tag:gha-deployer)"
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags:    tag:gha-deployer
           # Pinned — `version: latest` broke sha256 verification in GHA (May 2026).
           version: 1.96.4

--- a/.github/workflows/drill-restore-corpus.yml
+++ b/.github/workflows/drill-restore-corpus.yml
@@ -7,7 +7,7 @@ name: DR drill — restore corpus (backup → host)
 # (ADR-092); optional pin ``backup_tag``. RFC-082 / #752.
 #
 # Prerequisites (same tailnet + SSH contract as drill-deploy / drill-e2e):
-#   secrets: TS_AUTHKEY, DRILL_DEPLOY_SSH_PRIVATE_KEY
+#   secrets: TS_OAUTH_CLIENT_ID + TS_OAUTH_SECRET, DRILL_DEPLOY_SSH_PRIVATE_KEY
 #            BACKUP_REPO_TOKEN (optional — use when backup repo is private;
 #            else ``github.token`` is tried)
 #   vars:    DRILL_TAILNET_FQDN
@@ -37,7 +37,9 @@ on:
         default: false
   workflow_call:
     secrets:
-      TS_AUTHKEY:
+      TS_OAUTH_CLIENT_ID:
+        required: true
+      TS_OAUTH_SECRET:
         required: true
       DRILL_DEPLOY_SSH_PRIVATE_KEY:
         required: true
@@ -81,13 +83,15 @@ jobs:
 
       - name: "DR drill — pre-flight: secrets and variables"
         env:
-          TS_AUTHKEY:                  ${{ secrets.TS_AUTHKEY }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
           DRILL_DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DRILL_DEPLOY_SSH_PRIVATE_KEY }}
           DRILL_TAILNET_FQDN:          ${{ vars.DRILL_TAILNET_FQDN }}
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ]                    && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_SECRET:-}" ]    && MISSING="$MISSING TS_OAUTH_SECRET"
           [ -z "${DRILL_DEPLOY_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING DRILL_DEPLOY_SSH_PRIVATE_KEY"
           [ -z "${DRILL_TAILNET_FQDN:-}" ]          && MISSING="$MISSING DRILL_TAILNET_FQDN"
           if [ -n "$MISSING" ]; then
@@ -109,7 +113,8 @@ jobs:
       - name: "DR drill — join: tailnet (tag:gha-deployer)"
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags:    tag:gha-deployer
           version: 1.96.4
 

--- a/.github/workflows/drill-stack-playwright.yml
+++ b/.github/workflows/drill-stack-playwright.yml
@@ -5,7 +5,7 @@ name: DR drill — stack Playwright (stack-test)
 # with ``STACK_TEST_BASE_URL`` pointing at MagicDNS HTTPS). Validates SPA + nginx
 # proxy + API + restored corpus (``/app/output``) after deploy + restore + smoke.
 #
-# Prerequisites: ``TS_AUTHKEY``, ``DRILL_DEPLOY_SSH_PRIVATE_KEY`` (drill env gate),
+# Prerequisites: ``TS_OAUTH_CLIENT_ID + TS_OAUTH_SECRET``, ``DRILL_DEPLOY_SSH_PRIVATE_KEY`` (drill env gate),
 # ``vars.DRILL_TAILNET_FQDN``, ACL **tag:gha-deployer** → **tag:dr-drill** for **HTTPS :443**
 # (MagicDNS / ``tailscale serve``) in addition to SSH **:22** used by other drill jobs.
 
@@ -23,7 +23,9 @@ on:
         default: false
   workflow_call:
     secrets:
-      TS_AUTHKEY:
+      TS_OAUTH_CLIENT_ID:
+        required: true
+      TS_OAUTH_SECRET:
         required: true
       DRILL_DEPLOY_SSH_PRIVATE_KEY:
         required: true
@@ -56,13 +58,15 @@ jobs:
 
       - name: "DR drill — pre-flight: secrets and variables"
         env:
-          TS_AUTHKEY:                  ${{ secrets.TS_AUTHKEY }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
           DRILL_DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DRILL_DEPLOY_SSH_PRIVATE_KEY }}
           DRILL_TAILNET_FQDN:          ${{ vars.DRILL_TAILNET_FQDN }}
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ]                    && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_SECRET:-}" ]    && MISSING="$MISSING TS_OAUTH_SECRET"
           [ -z "${DRILL_DEPLOY_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING DRILL_DEPLOY_SSH_PRIVATE_KEY"
           [ -z "${DRILL_TAILNET_FQDN:-}" ]          && MISSING="$MISSING DRILL_TAILNET_FQDN"
           if [ -n "$MISSING" ]; then
@@ -84,7 +88,8 @@ jobs:
       - name: "DR drill — join: tailnet (tag:gha-deployer)"
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags:    tag:gha-deployer
           version: 1.96.4
 

--- a/.github/workflows/prod-failover-stand-up.yml
+++ b/.github/workflows/prod-failover-stand-up.yml
@@ -121,7 +121,8 @@ jobs:
       - name: "Prod failover — join: tailnet (tag:gha-deployer)"
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags:    tag:gha-deployer
           version: 1.96.4
 

--- a/.github/workflows/prod-restore-corpus.yml
+++ b/.github/workflows/prod-restore-corpus.yml
@@ -9,7 +9,7 @@ name: Prod restore corpus (backup → prod VPS)
 # High blast radius — manual only, GitHub Environment **prod**, typed confirm.
 #
 # Prerequisites:
-#   secrets: TS_AUTHKEY, PROD_SSH_PRIVATE_KEY
+#   secrets: TS_OAUTH_CLIENT_ID + TS_OAUTH_SECRET, PROD_SSH_PRIVATE_KEY
 #            BACKUP_REPO_TOKEN (optional when backup repo is private)
 #   vars:    PROD_TAILNET_FQDN
 #
@@ -59,13 +59,15 @@ jobs:
 
       - name: Pre-flight — required secrets/variables present?
         env:
-          TS_AUTHKEY:           ${{ secrets.TS_AUTHKEY }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
           PROD_SSH_PRIVATE_KEY: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
           PROD_TAILNET_FQDN:    ${{ vars.PROD_TAILNET_FQDN }}
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ]            && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_SECRET:-}" ]    && MISSING="$MISSING TS_OAUTH_SECRET"
           [ -z "${PROD_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING PROD_SSH_PRIVATE_KEY"
           [ -z "${PROD_TAILNET_FQDN:-}" ]    && MISSING="$MISSING PROD_TAILNET_FQDN"
           if [ -n "$MISSING" ]; then
@@ -86,7 +88,8 @@ jobs:
       - name: Join the tailnet
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags:    tag:gha-deployer
           version: 1.96.4
 

--- a/.github/workflows/reprocess-prod.yml
+++ b/.github/workflows/reprocess-prod.yml
@@ -50,13 +50,15 @@ jobs:
 
       - name: Pre-flight — required secrets/variables present?
         env:
-          TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
           PROD_SSH_PRIVATE_KEY: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
           PROD_TAILNET_FQDN: ${{ vars.PROD_TAILNET_FQDN }}
         run: |
           set -euo pipefail
           MISSING=""
-          [ -z "${TS_AUTHKEY:-}" ]           && MISSING="$MISSING TS_AUTHKEY"
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_SECRET:-}" ]    && MISSING="$MISSING TS_OAUTH_SECRET"
           [ -z "${PROD_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING PROD_SSH_PRIVATE_KEY"
           [ -z "${PROD_TAILNET_FQDN:-}" ]    && MISSING="$MISSING PROD_TAILNET_FQDN"
           if [ -n "$MISSING" ]; then
@@ -70,7 +72,8 @@ jobs:
       - name: Join the tailnet
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:gha-deployer
           # Pinned — `version: latest` broke sha256 verification in GHA (May 2026).
           version: 1.96.4


### PR DESCRIPTION
## Summary

Replaces the deprecated `authkey:` input on `tailscale/github-action@v4` with `oauth-client-id:` / `oauth-secret:` across **all 11 workflows** that join the tailnet. Silences the deprecation warning Tailscale emits on every deploy.

Prereqs are now in place: an OAuth client (scope `auth_keys` write, owns `tag:gha-deployer`) exists, and `TS_OAUTH_CLIENT_ID` + `TS_OAUTH_SECRET` are staged as repo secrets.

## What changed (per workflow)
- **Action input:** `authkey: ${{ secrets.TS_AUTHKEY }}` → `oauth-client-id:` / `oauth-secret:`.
- **Pre-flight secret-presence** env + check: `TS_AUTHKEY` → `TS_OAUTH_CLIENT_ID` + `TS_OAUTH_SECRET` (fail-loud parity preserved).
- **4 reusable (`workflow_call`) drill workflows** (`drill-deploy`, `drill-e2e`, `drill-restore-corpus`, `drill-stack-playwright`): the declared `secrets:` inputs swapped too. Callers use `secrets: inherit`, so no caller change.
- `tags: tag:gha-deployer` unchanged — the OAuth client owns that tag.

### Files (11)
deploy-prod, deploy-player, prod-failover-stand-up, prod-restore-corpus, backup-corpus-prod, backup-player-appdata-prod, reprocess-prod, drill-deploy, drill-e2e, drill-restore-corpus, drill-stack-playwright.

## Kept intentionally
`TS_AUTHKEY` (the GH secret) is **not** deleted — terraform/cloud-init tooling still reference the device-join key path (`variables.tf`, `prod.user-data`). Only the github-action stops using it.

## Validation
- `actionlint` ✓ (all 11 + `drill-exercise.yml` caller), YAML ✓, secret-scan ✓ (pre-commit).
- No functional `TS_AUTHKEY` reference remains in the migrated workflows (verified).

## Runtime verification (after merge)
The real proof is a live tailnet join over OAuth. Lowest-risk check: dispatch a read-only drill smoke (`drill-e2e`) or a backup workflow first, confirm the `Join the tailnet` step authenticates via OAuth, before relying on it for a prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)