### PR TITLE
test+docs(resolidify): cover session refactors + fix authkey/DSN doc drift

### DIFF
--- a/docs/architecture/HOSTING_AND_INFRASTRUCTURE.md
+++ b/docs/architecture/HOSTING_AND_INFRASTRUCTURE.md
@@ -109,7 +109,7 @@ scanner noise, and a wider blast radius. Here, **the application is intended to 
 tailnet**: MagicDNS gives stable names; **`tailscale serve`** (or equivalent) terminates TLS for
 the viewer; ACLs express **who may SSH** and **which tags may reach which ports**.
 
-**CI deployers** are first-class tailnet members with **`TS_AUTHKEY`** scoped to **`tag:gha-deployer`**.
+**CI deployers** join via a **Tailscale OAuth client** (`TS_OAUTH_CLIENT_ID`/`TS_OAUTH_SECRET`), minting an ephemeral node tagged **`tag:gha-deployer`** (migrated off `authkey`, #1289).
 ACL rules allow **SSH from that tag to `tag:prod:22` or `tag:dr-drill:22`**, not arbitrary WAN SSH.
 
 ```mermaid
@@ -128,7 +128,7 @@ flowchart LR
     DRILL["tag:dr-drill VPS"]
   end
 
-  JOB -->|"authkey join"| GHA
+  JOB -->|"OAuth join"| GHA
   ACL --> hosts
   GHA -->|"SSH 22 if ACL allows"| PROD
   GHA -->|"SSH 22 if ACL allows"| DRILL
@@ -360,7 +360,7 @@ Backups are **git-visible workflows**, not a hidden cron on the VPS only, so cha
 | --- | --- |
 | **Network exposure** | Tailscale ACLs; Hetzner firewall default deny inbound for app ports |
 | **CI to host** | Ed25519 deploy key in GitHub **Secrets**; only **`deploy@`** runs **`deploy.sh`** |
-| **Infra secrets** | `HCLOUD_TOKEN`, `TS_API_KEY`, `TFSTATE_AGE_KEY`, device **`TS_AUTHKEY`**, per-env SSH keys |
+| **Infra secrets** | `HCLOUD_TOKEN`, `TS_API_KEY`, `TFSTATE_AGE_KEY`, deployer **`TS_OAUTH_CLIENT_ID`/`TS_OAUTH_SECRET`** (tailnet join), device **`TS_AUTHKEY`** (cloud-init/VPS `tailscale up`), per-env SSH keys |
 | **State at rest** | sops + age encrypted files; age private key not in repo |
 | **Drill isolation** | Separate Hetzner token and OpenTofu state; destroy path returns workspace to empty |
 

--- a/docs/guides/OBSERVABILITY_RUNBOOK.md
+++ b/docs/guides/OBSERVABILITY_RUNBOOK.md
@@ -141,7 +141,9 @@ curl -sG http://homelab:9428/select/logsql/query \
    Podcast" folder) predates the **file-provisioned** homelab Grafana with **Podcast
    Operator** / **Podcast Player** folders.
 9. Same guide says player backend errors "land under `api`" — **stale**: the player has its
-   **own GlitchTip project (5)** + backend DSN (`PROD_SENTRY_DSN_PLAYER`).
+   **own GlitchTip project (5)** + per-surface DSNs split into `PROD_SENTRY_DSN_PLAYER_API`
+   (backend) and `PROD_SENTRY_DSN_PLAYER_WEB` (browser); the bare `PROD_SENTRY_DSN_PLAYER`
+   secret was retired.
 
 ## Where things live (file map)
 

--- a/tests/unit/scripts/test_emit_ops_event.py
+++ b/tests/unit/scripts/test_emit_ops_event.py
@@ -1,0 +1,111 @@
+"""Guard for ``scripts/ops/emit_ops_event.sh`` — the Tier-1 CI/ops event emitter (#1297).
+
+Runs the real script against a **fake ``curl``** on PATH that captures the POST body, and
+asserts the canonical ``ops_event/v1`` envelope (ADR-119): stream fields ``{app, env,
+event_type}``, ``_time``/``_msg``, and typed field coercion (ints/bools, not strings).
+No network — the sink is stubbed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "ops" / "emit_ops_event.sh"
+
+_FAKE_CURL = """#!/usr/bin/env bash
+# Capture the --data-binary payload to $CAPTURE_FILE, ignore the rest, succeed.
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--data-binary" ]; then printf '%s' "$2" > "$CAPTURE_FILE"; fi
+  shift
+done
+exit 0
+"""
+
+
+def _run(tmp_path: Path, *args: str) -> dict:
+    capture = tmp_path / "payload.json"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    curl = fake_bin / "curl"
+    curl.write_text(_FAKE_CURL, encoding="utf-8")
+    curl.chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["CAPTURE_FILE"] = str(capture)
+    env["VICTORIALOGS_URL"] = "http://homelab:9428"
+
+    res = subprocess.run(
+        ["bash", str(SCRIPT), *args], env=env, capture_output=True, text=True, timeout=30
+    )
+    assert res.returncode == 0, f"emit failed: {res.stderr}"
+    data: dict = json.loads(capture.read_text(encoding="utf-8"))
+    return data
+
+
+@pytest.mark.unit
+def test_emit_builds_canonical_envelope_with_typed_fields(tmp_path: Path) -> None:
+    obj = _run(
+        tmp_path,
+        "--event-type",
+        "deploy",
+        "--env",
+        "test",
+        "--msg",
+        "prod deploy success",
+        "--field",
+        "status=success",
+        "--field",
+        "duration_ms=42000",
+        "--field",
+        "dry_run=false",
+        "--field",
+        "sha=abc1234",
+    )
+    # Stream fields + envelope.
+    assert obj["schema"] == "ops_event/v1"
+    assert obj["event_type"] == "deploy"
+    assert obj["app"] == "podcast_scraper"
+    assert obj["env"] == "test"
+    assert obj["_msg"] == "prod deploy success"
+    assert obj["_time"].endswith("Z")
+    # Typed coercion: number stays a number, bool stays a bool, string stays a string.
+    assert obj["duration_ms"] == 42000 and isinstance(obj["duration_ms"], int)
+    assert obj["dry_run"] is False
+    assert obj["sha"] == "abc1234"
+    assert obj["status"] == "success"
+
+
+@pytest.mark.unit
+def test_emit_defaults_app_and_env_and_synthesizes_msg(tmp_path: Path) -> None:
+    obj = _run(tmp_path, "--event-type", "backup", "--field", "status=failure")
+    assert obj["app"] == "podcast_scraper"
+    assert obj["env"] == "prod"  # default
+    # No --msg → synthesized from event_type + status.
+    assert obj["_msg"] == "backup failure"
+
+
+@pytest.mark.unit
+def test_emit_requires_event_type_and_url(tmp_path: Path) -> None:
+    # Missing --event-type → non-zero exit.
+    env = dict(os.environ, VICTORIALOGS_URL="http://homelab:9428")
+    res = subprocess.run(
+        ["bash", str(SCRIPT), "--env", "test"], env=env, capture_output=True, text=True, timeout=30
+    )
+    assert res.returncode != 0
+    # Missing VICTORIALOGS_URL → non-zero exit.
+    env2 = {k: v for k, v in os.environ.items() if k != "VICTORIALOGS_URL"}
+    res2 = subprocess.run(
+        ["bash", str(SCRIPT), "--event-type", "deploy"],
+        env=env2,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert res2.returncode != 0

--- a/tests/unit/scripts/test_tailscale_oauth_migration.py
+++ b/tests/unit/scripts/test_tailscale_oauth_migration.py
@@ -1,0 +1,43 @@
+"""Guard for the tailscale/github-action authkey→OAuth migration (#1289).
+
+Every workflow that joins the tailnet must authenticate via the **OAuth client**
+(``oauth-client-id`` / ``oauth-secret``), never the deprecated ``authkey`` input. Locks
+the migration so a copy-paste can't reintroduce ``authkey:`` on a prod deploy/backup/drill.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def _tailnet_joining_workflows() -> list[Path]:
+    return sorted(
+        p
+        for p in WORKFLOWS.glob("*.yml")
+        if "tailscale/github-action" in p.read_text(encoding="utf-8")
+    )
+
+
+@pytest.mark.unit
+def test_there_are_tailnet_joining_workflows() -> None:
+    # Sanity: the guard is actually scanning something (it was 11 at migration time).
+    assert len(_tailnet_joining_workflows()) >= 8
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("wf", _tailnet_joining_workflows(), ids=lambda p: p.name)
+def test_tailscale_action_uses_oauth_not_authkey(wf: Path) -> None:
+    text = wf.read_text(encoding="utf-8")
+    # Must use the OAuth client inputs.
+    assert "oauth-client-id:" in text, f"{wf.name}: tailscale action must use oauth-client-id"
+    assert "oauth-secret:" in text, f"{wf.name}: tailscale action must use oauth-secret"
+    # Must NOT use the deprecated authkey action input (secrets.TS_AUTHKEY as the join key).
+    assert not re.search(
+        r"^\s*authkey:\s*\$\{\{\s*secrets\.TS_AUTHKEY", text, re.MULTILINE
+    ), f"{wf.name}: deprecated authkey input reintroduced — use OAuth"


### PR DESCRIPTION
Resolidify interlude before the operator-public epic's final push. Closes test-coverage + docs-drift gaps from this session's observability / OAuth-migration / DSN-split work.

**Tests:** `emit_ops_event.sh` envelope guard (was untested); parametrized guard that every tailnet-joining workflow uses OAuth not `authkey`.
**Docs:** `HOSTING_AND_INFRASTRUCTURE.md` (deployer join = OAuth), `OBSERVABILITY_RUNBOOK.md` (player `_API`/`_WEB` DSN split).

15 new assertions pass; strict docs build green; pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)