### PR TITLE
feat: operator-public surface — serve mode + gate + compose + Caddy (epic #1320)

### DIFF
--- a/compose/docker-compose.operator-public.yml
+++ b/compose/docker-compose.operator-public.yml
@@ -1,0 +1,114 @@
+# Public operator surface (RFC-108 / epic #1320 — operator.closelistening.app).
+#
+# A STANDALONE composition (do NOT merge with the privileged operator stack): the
+# gi-kg-viewer SPA + a LOW-PRIVILEGE operator-read backend. The backend runs with
+# PODCAST_SERVE_OPERATOR_PUBLIC=1 so it mounts ONLY health + /api/app/* + a CURATED
+# read-only subset of the operator routes, each ≥creator-gated — and therefore carries
+# **no docker.sock and no provider keys**. That is what makes it safe to expose on the
+# public edge (ADR-114) behind the operator domain, threading THREAT_MODEL T-01.
+#
+#   docker compose -f compose/docker-compose.operator-public.yml up -d --build
+#
+# The PRIVILEGED operator api (docker.sock + LLM keys, index_rebuild/ops/pipeline
+# triggers) stays on the tailnet-only operator stack, untouched. Corpus is shared
+# read-only from the operator stack's volume.
+
+services:
+  # Low-privilege operator-read API backend. Named `api` so the viewer image's baked nginx
+  # upstream (http://api:8000) resolves to it — NOT the privileged operator api (absent here).
+  api:
+    image: ghcr.io/chipi/podcast-scraper-stack-api:${PODCAST_IMAGE_TAG:-main}
+    restart: unless-stopped
+    environment:
+      # Curated operator-read surface, each route ≥creator-gated (require_viewer_access).
+      # Excludes index_rebuild/ops/resilience + the flag-gated privileged routers.
+      PODCAST_SERVE_OPERATOR_PUBLIC: "1"
+      # Real Google OIDC (reuse the player's OAuth client). Redirect URI to register:
+      #   https://<operator-domain>/api/app/auth/callback  (same Google client as the player).
+      APP_OAUTH_PROVIDER: google
+      APP_OAUTH_GOOGLE_CLIENT_ID: ${APP_OAUTH_GOOGLE_CLIENT_ID:-}
+      APP_OAUTH_GOOGLE_CLIENT_SECRET: ${APP_OAUTH_GOOGLE_CLIENT_SECRET:-}
+      APP_SESSION_SECRET: ${APP_SESSION_SECRET:-}
+      APP_SESSION_COOKIE_SECURE: "true"
+      # Reachable only via its own nginx proxy on the compose network → trust X-Forwarded-*
+      # so uvicorn derives the OAuth callback as https://<operator-domain>/...
+      FORWARDED_ALLOW_IPS: "*"
+      APP_DATA_DIR: /app/appdata
+      # THE operator differentiator: these emails become admin (creator via grant). A signed-in
+      # listener is 403'd from the operator routes (require_viewer_access = ≥creator).
+      APP_ADMIN_EMAILS: ${APP_ADMIN_EMAILS:-}
+      # Default-deny sign-in policy (server/app_access.py): allowlist + empty list = deny-all.
+      APP_SIGNUP_MODE: ${APP_SIGNUP_MODE:-allowlist}
+      APP_ALLOWED_EMAILS: ${APP_ALLOWED_EMAILS:-}
+      APP_ALLOWED_DOMAINS: ${APP_ALLOWED_DOMAINS:-}
+      PODCAST_SENTRY_DSN_API: ${PODCAST_SENTRY_DSN_API:-}
+      PODCAST_ENV: ${PODCAST_ENV:-dev}
+      # OTEL tracing (ADR-119) — mirror the operator/player api. Exporter + endpoint + homelab
+      # tailnet IP staged host-side by the deploy script; default `none` = off (non-fatal).
+      OTEL_SERVICE_NAME: operator-public-api
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-none}
+      OTEL_METRICS_EXPORTER: none
+      OTEL_LOGS_EXPORTER: none
+      OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-}
+      OTEL_PYTHON_LOG_CORRELATION: "true"
+      OTEL_PYTHON_FASTAPI_EXCLUDED_URLS: "health"
+    extra_hosts:
+      # homelab (VictoriaTraces/GlitchTip) MagicDNS — IP resolved fresh at deploy, never
+      # hardcoded; loopback default so compose interpolation never fails when tracing is off.
+      - "homelab:${HOMELAB_TAILNET_IP:-127.0.0.1}"
+    volumes:
+      # Corpus READ-ONLY (the operator-read plane reads it); per-user data is separate.
+      - corpus_data:/app/output:ro
+      # Per-user operator data (prefs/library) — a HOST bind mount, backupable + durable,
+      # separate from the player's appdata.
+      - ${OPERATOR_APPDATA_HOST_PATH:-/srv/podcast-scraper/operator-appdata}:/app/appdata
+    # Hardening (T-01/T-04): NO docker.sock, NO provider keys, drop caps. NOT read_only
+    # (entrypoint chown + app-data writes). Mirrors the player-public api boot profile.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETUID
+      - SETGID
+
+  # Operator viewer SPA (gi-kg-viewer) — nginx serving the SPA + proxying /api/ to `api`.
+  # The backend only mounts the curated+app+health surface, so privileged /api/* 404 at the
+  # backend even though nginx proxies all of /api/ (defense in depth).
+  viewer:
+    image: ghcr.io/chipi/podcast-scraper-stack-viewer:${PODCAST_IMAGE_TAG:-main}
+    restart: unless-stopped
+    ports:
+      # Loopback only — the Caddy edge (operator.caddy) is the public front (ADR-114).
+      - "127.0.0.1:${OPERATOR_PORT:-8093}:80"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+      - CHOWN
+      - SETUID
+      - SETGID
+      - DAC_OVERRIDE
+    read_only: true
+    tmpfs:
+      # nginx runtime scratch + the image's envsubst-rendered server block.
+      - /var/cache/nginx
+      - /var/run
+      - /tmp
+      - /etc/nginx/conf.d
+    depends_on:
+      api:
+        condition: service_healthy
+
+volumes:
+  # Shared read-only with the operator stack. Set PODCAST_CORPUS_VOLUME to that stack's
+  # external volume name on the VPS (e.g. compose_corpus_data).
+  corpus_data:
+    external: true
+    name: ${PODCAST_CORPUS_VOLUME:-compose_corpus_data}

--- a/infra/caddy/operator.caddy
+++ b/infra/caddy/operator.caddy
@@ -1,0 +1,93 @@
+# operator.closelistening.app — the PUBLIC operator surface (RFC-108 / epic #1320).
+#
+# Same coming-soon SECRET-COOKIE gate as player.caddy, one rung wider: past the gate the
+# gi-kg-viewer SPA loads and Google sign-in gates the app; the backend (operator-public
+# compose, 127.0.0.1:8093) enforces the ≥creator role on the operator-read routes. A
+# DISTINCT preview cookie (cl_op_preview) keeps the operator gate separate from the player.
+#
+# Deploy substitutes __OPERATOR_PREVIEW_COOKIE__ -> the OPERATOR_PREVIEW_COOKIE secret
+# (host-side .env, never committed), exactly like player.caddy's __PREVIEW_COOKIE__.
+
+operator.closelistening.app {
+	import hardened
+	# Per-site ACME email (same domain family; LE cert under info@closelistening.app).
+	tls info@closelistening.app
+
+	# /preview — the one-time doorman. Basic-auth challenge; on success set the secret
+	# preview cookie + 302 to /. `route` forces basic_auth FIRST, then Set-Cookie + redir
+	# (a bare `handle` fires redir before basic_auth → 302s everyone unchallenged).
+	@preview path /preview
+	handle @preview {
+		route {
+			basic_auth {
+				marko $2a$14$GV8EL65DWyPcI3qYoZsDXunPwdPCevcAT4/Wfg55gJpTtyyWn3..O
+				guest $2a$14$uhMHys8DHkU9P/F2IBgAWutTwz0eznL1yCwzHaEDsEKGhb8dJ9ZO2
+			}
+			header +Set-Cookie "cl_op_preview=__OPERATOR_PREVIEW_COOKIE__; Path=/; Max-Age=2592000; Secure; HttpOnly; SameSite=Lax"
+			redir https://operator.closelistening.app/ 302
+		}
+	}
+
+	# Static app-shell files (JS/CSS/fonts/icons/SW) — served to everyone, gate or not.
+	# They carry no data (the API stays gated + role-gated) and the coming-soon HTML must
+	# NEVER return under an asset URL (crossorigin ES-module imports don't carry the gate).
+	@static path_regexp \.(js|mjs|css|map|woff2?|ttf|otf|eot|png|jpe?g|gif|svg|ico|webmanifest|webp|avif)$
+	handle @static {
+		reverse_proxy 127.0.0.1:8093
+	}
+
+	# Preview cookie present -> the real operator app (PRIMARY gate: sent on navigations,
+	# XHR, module imports, and the OAuth callback alike).
+	@preview_ok header Cookie *cl_op_preview=__OPERATOR_PREVIEW_COOKIE__*
+	handle @preview_ok {
+		reverse_proxy 127.0.0.1:8093
+	}
+
+	# Fallback: a valid Basic-auth Authorization header also reaches the app (keeps
+	# `curl -u` verification working; browsers use the cookie above).
+	@authed header Authorization *
+	handle @authed {
+		basic_auth {
+			marko $2a$14$GV8EL65DWyPcI3qYoZsDXunPwdPCevcAT4/Wfg55gJpTtyyWn3..O
+			guest $2a$14$uhMHys8DHkU9P/F2IBgAWutTwz0eznL1yCwzHaEDsEKGhb8dJ9ZO2
+		}
+		reverse_proxy 127.0.0.1:8093
+	}
+
+	# Everyone else -> coming soon (no-store so a first no-cookie visit isn't cached).
+	handle {
+		header Content-Type "text/html; charset=utf-8"
+		header Cache-Control "no-store"
+		respond <<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Close Listening</title>
+  <style>
+    :root { color-scheme: dark; }
+    html,body { height:100%; margin:0; }
+    body { display:grid; place-items:center; min-height:100vh;
+      font: 400 17px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+      background: radial-gradient(1200px 600px at 50% -10%, #1a2233, #0b0e14 60%); color:#e7ecf3; }
+    .wrap { text-align:center; padding:2rem; max-width:34rem; }
+    .mark { letter-spacing:.14em; font-size:.8rem; text-transform:uppercase; color:#8aa0bd; }
+    h1 { font-size:clamp(2rem,6vw,3.2rem); margin:.4rem 0 .6rem; font-weight:600; }
+    p { color:#aab6c7; margin:0 auto; max-width:26rem; }
+    .soon { display:inline-block; margin-top:1.6rem; padding:.5rem 1rem; border:1px solid #2b3a52;
+      border-radius:999px; font-size:.85rem; color:#9fb2cc; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="mark">Close Listening</div>
+    <h1>Something worth hearing.</h1>
+    <p>A calmer way to listen to podcasts — with the good parts surfaced. We're putting on the finishing touches.</p>
+    <div class="soon">Coming soon</div>
+  </div>
+</body>
+</html>
+HTML 200
+	}
+}

--- a/src/podcast_scraper/server/app.py
+++ b/src/podcast_scraper/server/app.py
@@ -10,7 +10,7 @@ import time
 from pathlib import Path
 from typing import AsyncIterator, cast
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -157,6 +157,38 @@ _OPERATOR_READ_ROUTES = (
     cil,
     ops,
 )
+# RFC-108: the CURATED subset of operator-read routers safe for the PUBLIC operator
+# surface (operator.closelistening.app). This is ``_OPERATOR_READ_ROUTES`` MINUS the ones
+# that mutate / control:
+#   - ``index_rebuild`` (rebuilds the index — compute/write)
+#   - ``ops`` (operational controls)
+#   - ``resilience_routes`` (carries POST ``/api/ops/resilience/reset`` — a reset)
+# Those stay on the tailnet-only operator serve. Everything kept here is read-only (the
+# remaining POST routes are POST-for-query: search/compare, corpus resolve, topics/timeline
+# — they compute + return, they do not mutate). Mounted with a router-level ≥creator gate.
+# A new operator-read router MUST be consciously classified here (audit its non-GET routes).
+_OPERATOR_PUBLIC_READ_ROUTES = (
+    usage_routes,
+    artifacts,
+    index_stats,
+    search,
+    relational,
+    query_activity,
+    explore,
+    corpus_library,
+    corpus_binary,
+    corpus_media,
+    corpus_text_file,
+    corpus_metrics,
+    corpus_coverage,
+    corpus_persons,
+    corpus_digest,
+    corpus_enrichments,
+    corpus_topic_clusters,
+    corpus_theme_clusters,
+    corpus_trending,
+    cil,
+)
 # Consumer Learning Platform API (RFC-098): slug-addressed routes under their own
 # ``/api/app`` namespace, auth-gated (#1063/#1066). Always mounted.
 _APP_ROUTES = (
@@ -176,12 +208,24 @@ _APP_ROUTES = (
 )
 
 
-def _mount_api_routers(app: FastAPI, *, app_only: bool) -> None:
-    """Mount HTTP routers. ``health`` + the consumer ``/api/app/*`` plane always mount;
-    the operator/read ``/api/*`` routes mount only when NOT app-only — the low-privilege
-    public player backend (#1163 / ADR-116)."""
+def _mount_api_routers(app: FastAPI, *, app_only: bool, operator_public: bool = False) -> None:
+    """Mount HTTP routers. ``health`` + the consumer ``/api/app/*`` plane always mount.
+
+    Three serve postures for the operator/read ``/api/*`` plane:
+
+    - **full** (tailnet operator, default): all ``_OPERATOR_READ_ROUTES``, **ungated** —
+      tailnet privacy is the gate.
+    - **app_only** (public player, #1163 / ADR-116): none of them — low-privilege backend.
+    - **operator_public** (RFC-108, public operator surface): only the CURATED
+      ``_OPERATOR_PUBLIC_READ_ROUTES`` subset, each mounted with a **router-level ≥creator
+      gate** (``require_viewer_access``). ``index_rebuild`` / ``ops`` are NOT mounted here.
+    """
     app.include_router(health.router, prefix="/api")
-    if not app_only:
+    if operator_public:
+        gate = [Depends(app_auth.require_viewer_access)]
+        for module in _OPERATOR_PUBLIC_READ_ROUTES:
+            app.include_router(module.router, prefix="/api", dependencies=gate)
+    elif not app_only:
         for module in _OPERATOR_READ_ROUTES:
             app.include_router(module.router, prefix="/api")
     for module in _APP_ROUTES:
@@ -369,12 +413,17 @@ def create_app(
     # here too, belt-and-suspenders, so the privileged surface can never mount on a
     # public deployment even if a flag env leaks in.
     app_only = _env_truthy("PODCAST_SERVE_APP_ONLY")
-    if app_only:
+    # RFC-108: public operator surface — curated operator-read subset, each ≥creator-gated.
+    # A separate least-privilege deployment (no docker.sock, no keys) like the player.
+    operator_public = _env_truthy("PODCAST_SERVE_OPERATOR_PUBLIC")
+    if app_only or operator_public:
+        # Public deployments never mount the privileged flag-gated routers
+        # (jobs/operator-config/feeds) — belt-and-suspenders even if a flag env leaks in.
         enable_feeds_api = False
         enable_operator_config_api = False
         enable_jobs_api = False
 
-    _mount_api_routers(app, app_only=app_only)
+    _mount_api_routers(app, app_only=app_only, operator_public=operator_public)
 
     resolved_output = Path(output_dir).expanduser().resolve() if output_dir is not None else None
     app.state.output_dir = resolved_output

--- a/src/podcast_scraper/server/routes/app_auth.py
+++ b/src/podcast_scraper/server/routes/app_auth.py
@@ -78,6 +78,20 @@ def get_admin_user(request: Request) -> User:
     return user
 
 
+def require_viewer_access(request: Request) -> User:
+    """Require a signed-in user with **at least ``creator``** (RFC-108 operator surfaces).
+
+    Mounted as a router-level dependency on the operator-read routers **only** in the
+    public operator serve mode (``PODCAST_SERVE_OPERATOR_PUBLIC``); the tailnet-only
+    operator serve leaves them ungated (tailnet privacy is the gate). A signed-in
+    ``listener`` gets 403 — the operator surface is creator/admin only.
+    """
+    user = get_current_user(request)
+    if not app_roles.can_use_viewer(user.role):
+        raise HTTPException(status_code=403, detail="Creator or admin role required.")
+    return user
+
+
 @router.get("/auth/login")
 async def app_auth_login(
     request: Request,

--- a/tests/integration/server/test_operator_public_compose_contract.py
+++ b/tests/integration/server/test_operator_public_compose_contract.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Compose-config contract tests for the PUBLIC operator surface (RFC-108 / epic #1320).
+
+Encodes the T-01 safety claim as a gate: the public operator backend must be
+low-privilege — ``PODCAST_SERVE_OPERATOR_PUBLIC=1`` (curated read-only + ≥creator gate),
+**no ``docker.sock``**, **no provider keys** — so exposing it on the edge cannot reach
+host-root or the privileged operator plane. Also asserts the operator differentiator
+(``APP_ADMIN_EMAILS``), the hardening, and loopback-only ports (Caddy edge is the front).
+
+Reverting any of these on ``docker-compose.operator-public.yml`` must fail here before it
+ever reaches real infra.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.integration, pytest.mark.critical_path]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OPERATOR_YML = REPO_ROOT / "compose" / "docker-compose.operator-public.yml"
+
+pytestmark.append(
+    pytest.mark.skipif(
+        shutil.which("docker") is None,
+        reason="docker CLI not on PATH; compose-config contract test requires docker",
+    )
+)
+
+_FORBIDDEN_KEYS = {
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "MISTRAL_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GROK_API_KEY",
+}
+
+
+def _render() -> Dict[str, Any]:
+    env = {**os.environ, "PODCAST_CORPUS_VOLUME": "compose_corpus_data"}
+    cmd = ["docker", "compose", "-f", str(OPERATOR_YML), "config", "--format", "yaml"]
+    proc = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise AssertionError(f"`docker compose config` exited {proc.returncode}\n{proc.stderr}")
+    parsed: Dict[str, Any] = yaml.safe_load(proc.stdout)
+    return parsed
+
+
+@pytest.fixture(scope="module")
+def resolved() -> Dict[str, Any]:
+    return _render()
+
+
+def _svc(resolved: Dict[str, Any], name: str) -> Dict[str, Any]:
+    svc = (resolved.get("services") or {}).get(name)
+    assert svc is not None, f"operator-public compose has no ``{name}`` service"
+    out: Dict[str, Any] = svc
+    return out
+
+
+def _volumes(svc: Dict[str, Any]) -> str:
+    return " ".join(str(v) for v in (svc.get("volumes") or []))
+
+
+def test_backend_is_operator_public_not_app_only(resolved: Dict[str, Any]) -> None:
+    env = _svc(resolved, "api").get("environment") or {}
+    assert str(env.get("PODCAST_SERVE_OPERATOR_PUBLIC")) == "1", "backend must be operator-public"
+    # Must NOT also be app-only (that would drop the operator-read plane entirely).
+    assert str(env.get("PODCAST_SERVE_APP_ONLY", "")) not in ("1", "true")
+
+
+def test_backend_has_no_docker_socket(resolved: Dict[str, Any]) -> None:
+    # T-01: a public-reachable backend must not hold host-root via docker.sock.
+    assert "docker.sock" not in _volumes(_svc(resolved, "api"))
+
+
+def test_backend_has_no_provider_keys(resolved: Dict[str, Any]) -> None:
+    env = _svc(resolved, "api").get("environment") or {}
+    present = _FORBIDDEN_KEYS & set(env.keys())
+    assert not present, f"public operator backend must carry no provider keys; found {present}"
+
+
+def test_backend_corpus_is_read_only(resolved: Dict[str, Any]) -> None:
+    corpus_mounts = [
+        v
+        for v in (_svc(resolved, "api").get("volumes") or [])
+        if isinstance(v, dict) and v.get("target") == "/app/output"
+    ]
+    assert corpus_mounts, "operator backend must mount the corpus at /app/output"
+    assert all(m.get("read_only") is True for m in corpus_mounts), "corpus must be read-only"
+
+
+def test_backend_is_operator_role_gated(resolved: Dict[str, Any]) -> None:
+    # The operator differentiator: APP_ADMIN_EMAILS is present (→ admin/creator roles). The
+    # ≥creator router gate (require_viewer_access) is enforced by the OPERATOR_PUBLIC mode.
+    env = _svc(resolved, "api").get("environment") or {}
+    assert "APP_ADMIN_EMAILS" in env, "operator backend must wire APP_ADMIN_EMAILS (role bootstrap)"
+    assert str(env.get("APP_OAUTH_PROVIDER")) == "google"
+    assert env.get("FORWARDED_ALLOW_IPS") == "*"
+
+
+def test_backend_is_hardened(resolved: Dict[str, Any]) -> None:
+    api = _svc(resolved, "api")
+    assert "no-new-privileges:true" in " ".join(api.get("security_opt") or [])
+    assert (api.get("cap_drop") or []) == ["ALL"]
+
+
+def test_viewer_loopback_only_and_hardened(resolved: Dict[str, Any]) -> None:
+    fe = _svc(resolved, "viewer")
+    ports = " ".join(str(p) for p in (fe.get("ports") or []))
+    assert "127.0.0.1" in ports, "operator viewer must bind loopback only (edge is the front)"
+    assert fe.get("read_only") is True
+    assert "no-new-privileges:true" in " ".join(fe.get("security_opt") or [])

--- a/tests/integration/server/test_operator_public_mode.py
+++ b/tests/integration/server/test_operator_public_mode.py
@@ -1,0 +1,105 @@
+"""``PODCAST_SERVE_OPERATOR_PUBLIC`` — the public operator surface (RFC-108).
+
+`operator.closelistening.app` exposes a **curated read-only subset** of the operator
+routes, each mounted with a **router-level ≥creator gate**. `index_rebuild`, `ops`, and
+the privileged flag-gated plane (jobs/operator-config/feeds) stay tailnet-only. This locks
+the exposed-vs-private split AND that the gate is enforced (unauthed → 401, never open).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from podcast_scraper.server import app as app_mod
+from podcast_scraper.server.app import create_app
+
+pytestmark = [pytest.mark.integration]
+
+
+def _api_paths(output_dir: Path) -> set[str]:
+    app = create_app(output_dir=output_dir)
+    return {getattr(r, "path", "") for r in app.routes if getattr(r, "path", "").startswith("/api")}
+
+
+def test_operator_public_mounts_curated_read_subset(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("PODCAST_SERVE_APP_ONLY", raising=False)
+    monkeypatch.setenv("PODCAST_SERVE_OPERATOR_PUBLIC", "1")
+    paths = _api_paths(Path(str(tmp_path)))
+
+    # Curated read routes + consumer plane + health ARE present.
+    assert any(p.startswith("/api/search") for p in paths), "search must mount"
+    assert any("/api/corpus/media" in p for p in paths), "corpus media must mount"
+    assert any(p.startswith("/api/app") for p in paths), "consumer plane must mount"
+    assert any(p.startswith("/api/health") for p in paths), "health must mount"
+
+    # The privileged / compute routes must NOT mount on the public operator surface.
+    assert not any("rebuild" in p for p in paths), "index_rebuild must NOT mount"
+    assert not any(p.startswith("/api/ops") for p in paths), "ops must NOT mount"
+    assert not any(p.startswith("/api/jobs") for p in paths), "jobs must NOT mount"
+
+
+def test_operator_public_gates_read_routes_unauthed_401(tmp_path, monkeypatch) -> None:
+    """The gate fires: curated operator routes are mounted (not 404) but require a
+    signed-in ≥creator — an unauthenticated request gets **401**, never an open 200."""
+    from fastapi.testclient import TestClient
+
+    monkeypatch.delenv("PODCAST_SERVE_APP_ONLY", raising=False)
+    monkeypatch.setenv("PODCAST_SERVE_OPERATOR_PUBLIC", "1")
+    client = TestClient(create_app(output_dir=Path(str(tmp_path))))
+
+    for path in ("/api/search", "/api/artifacts"):
+        code = client.get(path).status_code
+        assert (
+            code == 401
+        ), f"{path} must be ≥creator-gated (401 unauthed) in operator-public, got {code}"
+
+    # Privileged routes stay absent (404, not merely gated); health is open.
+    assert client.get("/api/ops/summary").status_code == 404
+    assert client.get("/api/health").status_code == 200
+
+
+def test_operator_public_subset_excludes_the_mutating_operator_routes() -> None:
+    public = set(app_mod._OPERATOR_PUBLIC_READ_ROUTES)
+    full = set(app_mod._OPERATOR_READ_ROUTES)
+    assert public < full, "public subset must be strictly smaller than the full read set"
+    assert full - public == {
+        app_mod.index_rebuild,
+        app_mod.ops,
+        app_mod.resilience_routes,
+    }, "operator-public must exclude the mutating/control routes (index_rebuild, ops, resilience)"
+
+
+def test_operator_public_curated_subset_has_no_mutating_operator_writes() -> None:
+    """Guard the read-only invariant: no curated public module may expose a genuinely
+    *mutating* operator route. POST-for-query (search/compare, corpus resolve,
+    topics/timeline) is allowed; a reset/write is not."""
+    allowed_post_for_query = {
+        "/api/search/compare",
+        "/api/corpus/resolve-episode-artifacts",
+        "/api/corpus/node-episodes",
+        "/api/topics/timeline",
+    }
+    offenders = []
+    for mod in app_mod._OPERATOR_PUBLIC_READ_ROUTES:
+        for r in mod.router.routes:
+            writes: set[str] = (getattr(r, "methods", set()) or set()) - {"GET", "HEAD", "OPTIONS"}
+            path = "/api" + mod.router.prefix + getattr(r, "path", "")
+            if writes and path not in allowed_post_for_query:
+                offenders.append((sorted(writes), path))
+    assert not offenders, f"curated public subset must not expose mutating routes: {offenders}"
+
+
+def test_full_tailnet_mode_leaves_operator_routes_ungated(tmp_path, monkeypatch) -> None:
+    """Contrast: the default (tailnet) operator serve mounts /api/search WITHOUT the
+    ≥creator gate — tailnet privacy is the gate, so it is not 401/404."""
+    from fastapi.testclient import TestClient
+
+    monkeypatch.delenv("PODCAST_SERVE_APP_ONLY", raising=False)
+    monkeypatch.delenv("PODCAST_SERVE_OPERATOR_PUBLIC", raising=False)
+    client = TestClient(create_app(output_dir=Path(str(tmp_path))))
+    code = client.get("/api/search").status_code
+    assert code not in (401, 404), f"tailnet operator /api/search must be ungated, got {code}"


### PR DESCRIPTION
Implements the in-repo core of **epic #1320** (operator viewer → public gated surface), following the approved **RFC-108** (#1322). Stacks: serve-mode → compose → Caddy.

## What's here
- **Serve mode + role gate** (`app.py`, `app_auth.py`): `PODCAST_SERVE_OPERATOR_PUBLIC` mounts a **curated read-only subset** of the operator routes, each **≥creator-gated** (`require_viewer_access`). `index_rebuild`/`ops`/`resilience-reset` + the flag-gated privileged plane are excluded. Unauthed → 401.
- **Least-privilege compose** (`docker-compose.operator-public.yml`): viewer SPA + `OPERATOR_PUBLIC` backend, **no docker.sock, no keys**, hardened; `APP_ADMIN_EMAILS` = the operator differentiator. Threads THREAT_MODEL **T-01** (privileged api stays tailnet-only).
- **Caddy vhost** (`operator.caddy`): coming-soon `/preview` cookie gate mirroring the player, own cookie (`cl_op_preview`) + port 8093.

## Tests (all green locally)
- serve-mode: curated subset mounts; unauthed operator routes **401**; privileged absent (404); read-only-invariant guard.
- compose-contract: no socket, no keys, corpus RO, `APP_ADMIN_EMAILS` wired, hardened, loopback-only.

## NOT in this PR (remaining epic)
- #49 telemetry repoint (viewer DSN → `telemetry.closelistening.app/1`; needs a viewer rebuild) · #50 deploy machinery (`deploy-operator.yml`/`.sh`) + gated deploy · **your side:** #45 CF DNS `operator.closelistening.app`, and the Google redirect URI `https://operator.closelistening.app/api/app/auth/callback` on the existing client.

Design + THREAT_MODEL row: #1322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)