### PR TITLE
feat(deploy): operator-public deploy machinery (epic #1320 #50)

### DIFF
--- a/.github/workflows/deploy-operator.yml
+++ b/.github/workflows/deploy-operator.yml
@@ -1,0 +1,321 @@
+# Deploy the PUBLIC operator surface (RFC-108 / epic #1320) to the always-on VPS.
+#
+# Standalone from deploy-prod.yml: brings up compose/docker-compose.operator-public.yml
+# (a low-privilege operator-read backend — no docker.sock, no provider keys —
+# PODCAST_SERVE_OPERATOR_PUBLIC + the gi-kg-viewer SPA) and drops the operator.caddy vhost
+# into the shared Caddy edge (ADR-114). The privileged operator/kg-gi surface is untouched.
+# Manual (workflow_dispatch); typed confirm; tailnet-only SSH.
+#
+# Prereqs (stage once, like deploy-prod #714):
+#   secrets: TS_OAUTH_CLIENT_ID + TS_OAUTH_SECRET, PROD_SSH_PRIVATE_KEY, APP_SESSION_SECRET,
+#            APP_OAUTH_GOOGLE_CLIENT_SECRET, OPERATOR_PREVIEW_COOKIE
+#   vars:    PROD_TAILNET_FQDN, OPERATOR_DOMAIN, PODCAST_CORPUS_VOLUME,
+#            APP_OAUTH_GOOGLE_CLIENT_ID
+# The Caddy edge + firewall 80/443 must already be live on the box, and DNS for
+# OPERATOR_DOMAIN must point at the VPS (see docs/guides/PLAYER_PUBLIC_LAUNCH.md).
+
+name: Deploy operator (public)
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type OPERATOR_DEPLOY to confirm'
+        required: true
+      override_image_sha:
+        description: 'Optional api image sha-<7> to deploy (blank = newest published from main)'
+        required: false
+
+concurrency:
+  group: deploy-operator
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: prod
+    steps:
+      - name: Confirm OPERATOR_DEPLOY
+        run: |
+          if [ "${{ inputs.confirm }}" != "OPERATOR_DEPLOY" ]; then
+            echo "::error::Must type OPERATOR_DEPLOY to confirm. Got: '${{ inputs.confirm }}'"
+            exit 1
+          fi
+
+      - name: Pre-flight — required secrets/variables present?
+        id: preflight
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          PROD_SSH_PRIVATE_KEY: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          PROD_TAILNET_FQDN: ${{ vars.PROD_TAILNET_FQDN }}
+          OPERATOR_DOMAIN: ${{ vars.OPERATOR_DOMAIN }}
+          PODCAST_CORPUS_VOLUME: ${{ vars.PODCAST_CORPUS_VOLUME }}
+          # Coming-soon gate cookie secret (host-side; substituted into operator.caddy at
+          # deploy). Required — an empty value would ship a guessable gate.
+          OPERATOR_PREVIEW_COOKIE: ${{ secrets.OPERATOR_PREVIEW_COOKIE }}
+        run: |
+          set -euo pipefail
+          MISSING=""
+          [ -z "${TS_OAUTH_CLIENT_ID:-}" ] && MISSING="$MISSING TS_OAUTH_CLIENT_ID"
+          [ -z "${TS_OAUTH_SECRET:-}" ]    && MISSING="$MISSING TS_OAUTH_SECRET"
+          [ -z "${PROD_SSH_PRIVATE_KEY:-}" ] && MISSING="$MISSING PROD_SSH_PRIVATE_KEY"
+          [ -z "${PROD_TAILNET_FQDN:-}" ] && MISSING="$MISSING PROD_TAILNET_FQDN"
+          [ -z "${OPERATOR_DOMAIN:-}" ] && MISSING="$MISSING OPERATOR_DOMAIN"
+          [ -z "${PODCAST_CORPUS_VOLUME:-}" ] && MISSING="$MISSING PODCAST_CORPUS_VOLUME"
+          [ -z "${OPERATOR_PREVIEW_COOKIE:-}" ] && MISSING="$MISSING OPERATOR_PREVIEW_COOKIE"
+          if [ -n "$MISSING" ]; then
+            echo "::warning::Missing prereqs:$MISSING — stage them then re-run."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout (resolver scripts)
+        if: steps.preflight.outputs.skip != 'true'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Join the tailnet
+        if: steps.preflight.outputs.skip != 'true'
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:gha-deployer
+          version: 1.96.4
+
+      - name: Install SSH identity for deploy@ (PROD_SSH_PRIVATE_KEY)
+        if: steps.preflight.outputs.skip != 'true'
+        uses: ./.github/actions/prod-ssh-key
+        with:
+          ssh_private_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+
+      - name: Resolve prod MagicDNS host
+        id: ts_host
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          PROD_TAILNET_FQDN: ${{ vars.PROD_TAILNET_FQDN }}
+        run: |
+          set -euo pipefail
+          R=$(bash scripts/ops/resolve_prod_tailnet_host.sh)
+          echo "resolved_fqdn=$R" >> "$GITHUB_OUTPUT"
+
+      - name: Refresh repo on the box to this ref
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          SSH_TARGET: deploy@${{ steps.ts_host.outputs.resolved_fqdn }}
+          # Deploy the ref the workflow was dispatched on — NOT a hardcoded branch. The edge
+          # / operator work lives on `production`; hardcoding origin/main silently deployed the
+          # wrong commit (chmod + conf.d fixes on production never reached the box; 2026-07-23).
+          # Via env (not inline ${{ }}) to keep the ref out of the shell-injection surface.
+          DEPLOY_REF: ${{ github.ref_name }}
+        run: |
+          ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+            "set -euo pipefail; cd /srv/podcast-scraper; \
+             git fetch --depth=50 origin '+refs/heads/*:refs/remotes/origin/*'; \
+             git reset --hard 'origin/$DEPLOY_REF'"
+
+      - name: Resolve api image tag
+        id: imgsha
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          OVERRIDE: ${{ inputs.override_image_sha }}
+        run: |
+          set -euo pipefail
+          # "One engine, two surfaces" (ADR-116): by DEFAULT the operator-public runs the EXACT
+          # same api image the privileged operator stack is currently running — resolved on the
+          # box by deploy-operator.sh from the live operator api container. So the default here
+          # is to emit an EMPTY tag and let the script pin it. An explicit override_image_sha
+          # still wins (validated below + staged). Never the literal :main tag (CI stopped
+          # updating it 2026-05-28 -> pre-ADR-116, no /api/app/* surface -> 404s).
+          SHA_SHORT="${OVERRIDE:-}"; SHA_SHORT="${SHA_SHORT#sha-}"
+          if [ -n "$SHA_SHORT" ]; then
+            if ! [[ "$SHA_SHORT" =~ ^[a-f0-9]{7,40}$ ]]; then
+              echo "::error::override_image_sha must match ^[a-f0-9]{7,40}$ (got: ${SHA_SHORT})"; exit 1
+            fi
+            echo "tag=sha-$SHA_SHORT" >> "$GITHUB_OUTPUT"
+            echo "::notice::Operator api image pinned to override sha-$SHA_SHORT"
+          else
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "::notice::No override — deploy-operator.sh will pin the operator surface to the privileged stack's running engine sha"
+          fi
+
+      - name: Validate GHCR api image manifest exists (override only, pre-SSH)
+        if: steps.preflight.outputs.skip != 'true' && steps.imgsha.outputs.tag != ''
+        env:
+          TAG: ${{ steps.imgsha.outputs.tag }}
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker manifest inspect "ghcr.io/chipi/podcast-scraper-stack-api:${TAG}" >/dev/null
+
+      - name: Stage .env.operator (secrets via /dev/shm scp, never inline over ssh)
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          SSH_TARGET: deploy@${{ steps.ts_host.outputs.resolved_fqdn }}
+          OPERATOR_DOMAIN: ${{ vars.OPERATOR_DOMAIN }}
+          PODCAST_CORPUS_VOLUME: ${{ vars.PODCAST_CORPUS_VOLUME }}
+          # Empty by default -> deploy-operator.sh pins to the privileged stack's running engine sha.
+          PODCAST_IMAGE_TAG: ${{ steps.imgsha.outputs.tag }}
+          GOOGLE_CLIENT_ID: ${{ vars.APP_OAUTH_GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.APP_OAUTH_GOOGLE_CLIENT_SECRET }}
+          APP_SESSION_SECRET: ${{ secrets.APP_SESSION_SECRET }}
+          # Operator error DSN → self-hosted GlitchTip. Empty → no-op.
+          PODCAST_SENTRY_DSN_API: ${{ secrets.PODCAST_SENTRY_DSN_API }}
+          # ADR-115 Option A: when '1', the RUNTIME secrets (client secret, session secret,
+          # backend DSN) are delivered as tmpfs files + exported by the shim, so they are
+          # DROPPED from .env.operator. Default empty = today's env behaviour. Cutover = set
+          # the GH var. Mirrors the player's PLAYER_SECRETS_VIA_FILES.
+          OPERATOR_SECRETS_VIA_FILES: ${{ vars.OPERATOR_SECRETS_VIA_FILES }}
+          # Coming-soon gate cookie secret. Consumed HOST-SIDE by deploy-operator.sh (sed'd
+          # into operator.caddy) — it never enters the container, so it lives in .env.operator
+          # (0600, scp'd, never inline over ssh), not the tmpfs container-secret set.
+          OPERATOR_PREVIEW_COOKIE: ${{ secrets.OPERATOR_PREVIEW_COOKIE }}
+          # THE operator differentiator: these emails become admin (creator via grant).
+          # A signed-in listener is 403'd from the operator routes (require_viewer_access = ≥creator).
+          APP_ADMIN_EMAILS: ${{ vars.APP_ADMIN_EMAILS }}
+          # Backend sign-in access policy (server/app_access.py). Non-secret (emails/domains
+          # + mode) → GH vars. Unset APP_SIGNUP_MODE defaults to `allowlist`; with an empty
+          # email/domain list that is DEFAULT-DENY, so these must be set for anyone to sign in.
+          APP_SIGNUP_MODE: ${{ vars.OPERATOR_SIGNUP_MODE }}
+          APP_ALLOWED_EMAILS: ${{ vars.OPERATOR_ALLOWED_EMAILS }}
+          APP_ALLOWED_DOMAINS: ${{ vars.OPERATOR_ALLOWED_DOMAINS }}
+        run: |
+          set -euo pipefail
+          ENVTMP="$(mktemp -p /dev/shm)"
+          {
+            echo "OPERATOR_DOMAIN=${OPERATOR_DOMAIN}"
+            echo "PODCAST_CORPUS_VOLUME=${PODCAST_CORPUS_VOLUME}"
+            # Host-side gate cookie secret (sed'd into operator.caddy by deploy-operator.sh).
+            echo "OPERATOR_PREVIEW_COOKIE=${OPERATOR_PREVIEW_COOKIE}"
+            # Tags backend Sentry events (+ any env-gated behaviour) as prod — matches the
+            # operator api. Without it the backend defaults to environment=dev (sentry_init).
+            echo "PODCAST_ENV=prod"
+            # THE operator differentiator: admin emails granting creator access.
+            echo "APP_ADMIN_EMAILS=${APP_ADMIN_EMAILS}"
+            # Backend sign-in access policy. Default (unset) is allowlist; with an empty
+            # email/domain list that denies EVERYONE ("This account is not allowed to sign
+            # in"). Set OPERATOR_ALLOWED_EMAILS (or _DOMAINS, or OPERATOR_SIGNUP_MODE=open).
+            echo "APP_SIGNUP_MODE=${APP_SIGNUP_MODE:-allowlist}"
+            echo "APP_ALLOWED_EMAILS=${APP_ALLOWED_EMAILS}"
+            echo "APP_ALLOWED_DOMAINS=${APP_ALLOWED_DOMAINS}"
+            # OTEL distributed tracing (ADR-119) → the SAME homelab VictoriaTraces OTLP
+            # ingest the operator uses (deploy-prod.yml). Turns operator-public API request
+            # spans on so a user-triggered error on the operator surface pivots to its trace.
+            # The homelab tailnet IP for extra_hosts is resolved on the box by deploy-operator.sh.
+            echo "OTEL_TRACES_EXPORTER=otlp"
+            echo "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://homelab:10428/insert/opentelemetry/v1/traces"
+            # Pin the api image to the resolved newest-published sha (never stale :main).
+            echo "PODCAST_IMAGE_TAG=${PODCAST_IMAGE_TAG}"
+            echo "APP_OAUTH_PROVIDER=google"
+            echo "APP_OAUTH_GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}"
+            # Runtime secrets (ADR-115 Option A): under OPERATOR_SECRETS_VIA_FILES=1 these are
+            # delivered as /run/secrets files + exported by the shim, so DROPPED from
+            # .env.operator (no secrets at rest on disk). Flag off = today's env behaviour.
+            if [ "${OPERATOR_SECRETS_VIA_FILES:-}" != "1" ]; then
+              echo "APP_OAUTH_GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}"
+              echo "APP_SESSION_SECRET=${APP_SESSION_SECRET}"
+            fi
+            echo "OPERATOR_PORT=8093"
+            # Operator BACKEND (server-side) errors -> GlitchTip. RUNTIME secret
+            # -> delivered as a file under Option A, so DROPPED from .env.operator when
+            # OPERATOR_SECRETS_VIA_FILES=1.
+            if [ "${OPERATOR_SECRETS_VIA_FILES:-}" != "1" ]; then
+              echo "PODCAST_SENTRY_DSN_API=${PODCAST_SENTRY_DSN_API}"
+            fi
+          } > "$ENVTMP"
+          scp -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+            "$ENVTMP" "${SSH_TARGET}:/srv/podcast-scraper/.env.operator.staged"
+          rm -f "$ENVTMP"
+          ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+            "set -euo pipefail; cd /srv/podcast-scraper; \
+             mv .env.operator.staged .env.operator; chmod 600 .env.operator"
+
+      - name: Stage tmpfs secret files (ADR-115 Option A)
+        # When OPERATOR_SECRETS_VIA_FILES=1, write the operator runtime secrets to HOST tmpfs
+        # /dev/shm/operator-secrets/ (RAM, never disk). deploy-operator.sh joins the secrets
+        # overlay so they mount as /run/secrets/* and the image shim exports them. Atomic:
+        # build the dir on the runner in /dev/shm, scp, then swap into place. Mirrors the
+        # player's "Stage tmpfs secret files" step. Filenames are the LOWERCASE of the env
+        # the shim must export (app_session_secret -> APP_SESSION_SECRET).
+        if: steps.preflight.outputs.skip != 'true' && vars.OPERATOR_SECRETS_VIA_FILES == '1'
+        env:
+          SSH_TARGET: deploy@${{ steps.ts_host.outputs.resolved_fqdn }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.APP_OAUTH_GOOGLE_CLIENT_SECRET }}
+          APP_SESSION_SECRET: ${{ secrets.APP_SESSION_SECRET }}
+          PODCAST_SENTRY_DSN_API: ${{ secrets.PODCAST_SENTRY_DSN_API }}
+        run: |
+          set -euo pipefail
+          STAGE=$(mktemp -d -p /dev/shm opsecstage.XXXXXX)
+          trap 'rm -rf "$STAGE" 2>/dev/null || true' EXIT
+          printf '%s' "$GOOGLE_CLIENT_SECRET"   > "$STAGE/app_oauth_google_client_secret"
+          printf '%s' "$APP_SESSION_SECRET"     > "$STAGE/app_session_secret"
+          printf '%s' "$PODCAST_SENTRY_DSN_API" > "$STAGE/podcast_sentry_dsn_api"
+          chmod 400 "$STAGE"/*
+          ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+            "rm -rf /dev/shm/operator-secrets.staged && mkdir -p /dev/shm/operator-secrets.staged && chmod 700 /dev/shm/operator-secrets.staged"
+          scp -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+            "$STAGE"/* "${SSH_TARGET}:/dev/shm/operator-secrets.staged/"
+          ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+            "set -euo pipefail; chmod 400 /dev/shm/operator-secrets.staged/*; \
+             rm -rf /dev/shm/operator-secrets; \
+             mv /dev/shm/operator-secrets.staged /dev/shm/operator-secrets"
+
+      - name: Deploy (build + up + vhost drop + reload + health)
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          SSH_TARGET: deploy@${{ steps.ts_host.outputs.resolved_fqdn }}
+          # ADR-115 Option A: deploy-operator.sh joins the secrets overlay + runs the exit-5/6
+          # gates only when it SEES this flag. It is not in .env.operator and SSH does not
+          # inherit the runner env, so it MUST be passed inline (same as deploy-prod passes
+          # PODCAST_SECRETS_VIA_FILES to deploy.sh). Without this the script silently skips
+          # the overlay while .env.operator has dropped the secrets -> keyless container -> 503.
+          VIA_FILES: ${{ vars.OPERATOR_SECRETS_VIA_FILES }}
+        run: |
+          ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \
+            "OPERATOR_SECRETS_VIA_FILES='${VIA_FILES}' /srv/podcast-scraper/infra/deploy/deploy-operator.sh"
+
+      - name: External health probe (public operator domain)
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          # Probe the public ROOT (edge + Cloudflare + TLS reachability), NOT an app path.
+          # During the pre-launch coming-soon phase the edge gate returns the coming-soon
+          # page (200) for every path incl. /api/app/*, so an app-path probe validates
+          # nothing extra; and the backend itself is already validated in-container by the
+          # deploy step's /api/health check. A 200 here means DNS+CF+origin-lock+TLS+edge
+          # are all serving.
+          PROBE: https://${{ vars.OPERATOR_DOMAIN || 'operator.closelistening.app' }}/
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 12); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$PROBE" || echo 000)
+            if [ "$code" = "200" ]; then echo "operator public edge OK ($PROBE)"; exit 0; fi
+            sleep 5
+          done
+          echo "::error::public operator edge probe did not return 200 ($PROBE)"; exit 1
+
+      - name: Emit deploy event to VictoriaLogs (Tier-1 o11y, ADR-119)
+        # Self-hosted sink over the tailnet (runner already joined above). Fires on
+        # success AND failure. Non-fatal — never turns a deploy red.
+        if: always() && steps.preflight.outputs.skip != 'true'
+        uses: ./.github/actions/emit-ops-event
+        with:
+          event-type: deploy
+          env: prod
+          victorialogs-url: ${{ vars.HOMELAB_VICTORIALOGS_URL }}
+          msg: "operator deploy ${{ job.status }}"
+          fields: status=${{ job.status }} surface=operator triggered_by=${{ github.actor }}

--- a/infra/deploy/deploy-operator.sh
+++ b/infra/deploy/deploy-operator.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# infra/deploy/deploy-operator.sh — bring up the PUBLIC operator surface (RFC-108 / epic #1320).
+#
+# Runs ON the VPS as the deploy user (invoked by deploy-operator.yml after the runner joins
+# the tailnet). Standalone from the privileged operator stack: a LOW-PRIVILEGE operator-read
+# backend (no docker.sock, no provider keys — PODCAST_SERVE_OPERATOR_PUBLIC) + the gi-kg-viewer
+# SPA, fronted by the shared Caddy edge (ADR-114). The privileged operator / kg-gi surface
+# (tailnet-only) is untouched.
+#
+# Required env (staged by the workflow from GH secrets, or set manually):
+#   OPERATOR_DOMAIN                 public operator domain (vhost + health)
+#   PODCAST_CORPUS_VOLUME           operator stack's external corpus volume name
+#   APP_SESSION_SECRET              (secret) session signing key
+#   APP_OAUTH_GOOGLE_CLIENT_ID      Google OAuth client id
+#   APP_OAUTH_GOOGLE_CLIENT_SECRET  (secret) Google OAuth client secret
+#   APP_ADMIN_EMAILS                operator differentiator — these emails become admin/creator
+#
+# Exit: 0 ok / 1 compose up failed / 2 vhost/reload failed / 3 health failed
+set -euo pipefail
+
+REPO_DIR=/srv/podcast-scraper
+cd "$REPO_DIR"
+
+# Operator env — separate from the privileged operator .env; 0600, secrets never committed.
+# The workflow scp's a pre-staged .env.operator (secrets NOT passed inline over ssh); a manual
+# run builds it here from the environment. Either way it holds the config below.
+OPERATOR_ENV="$REPO_DIR/.env.operator"
+umask 077
+if [ -f "$OPERATOR_ENV" ]; then
+  # Staged by the deploy workflow — source it for OPERATOR_DOMAIN / PODCAST_CORPUS_VOLUME.
+  set -a
+  # shellcheck disable=SC1090
+  . "$OPERATOR_ENV"
+  set +a
+else
+  : "${OPERATOR_DOMAIN:?set OPERATOR_DOMAIN}"
+  : "${PODCAST_CORPUS_VOLUME:?set PODCAST_CORPUS_VOLUME to the operator stack corpus volume}"
+  {
+    echo "OPERATOR_DOMAIN=${OPERATOR_DOMAIN}"
+    echo "PODCAST_CORPUS_VOLUME=${PODCAST_CORPUS_VOLUME}"
+    echo "APP_OAUTH_PROVIDER=google"
+    echo "APP_OAUTH_GOOGLE_CLIENT_ID=${APP_OAUTH_GOOGLE_CLIENT_ID:-}"
+    echo "APP_OAUTH_GOOGLE_CLIENT_SECRET=${APP_OAUTH_GOOGLE_CLIENT_SECRET:-}"
+    echo "APP_SESSION_SECRET=${APP_SESSION_SECRET:-}"
+    echo "APP_ADMIN_EMAILS=${APP_ADMIN_EMAILS:-}"
+    echo "OPERATOR_PREVIEW_COOKIE=${OPERATOR_PREVIEW_COOKIE:-}"
+    echo "APP_SIGNUP_MODE=${APP_SIGNUP_MODE:-allowlist}"
+    echo "APP_ALLOWED_EMAILS=${APP_ALLOWED_EMAILS:-}"
+    echo "APP_ALLOWED_DOMAINS=${APP_ALLOWED_DOMAINS:-}"
+    # OTEL traces (ADR-119). Default OFF for a manual run; set both to enable.
+    echo "OTEL_TRACES_EXPORTER=${OTEL_TRACES_EXPORTER:-none}"
+    echo "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-}"
+    echo "OPERATOR_PORT=8093"
+  } >"$OPERATOR_ENV"
+fi
+chmod 600 "$OPERATOR_ENV"
+
+: "${OPERATOR_DOMAIN:?OPERATOR_DOMAIN missing from .env.operator and env}"
+: "${PODCAST_CORPUS_VOLUME:?PODCAST_CORPUS_VOLUME missing from .env.operator and env}"
+# Coming-soon gate cookie secret — substituted into operator.caddy below. REQUIRED: an empty
+# value would ship `cl_op_preview=` as the gate, which is guessable → the gate opens for
+# anyone. Fail loudly rather than deploy a broken gate.
+: "${OPERATOR_PREVIEW_COOKIE:?OPERATOR_PREVIEW_COOKIE missing from .env.operator and env (coming-soon gate cookie secret)}"
+
+# OTEL traces (ADR-119) reach the homelab VictoriaTraces OTLP ingest via the Tailscale
+# MagicDNS name `homelab`, which Docker's embedded DNS can't resolve — so the operator
+# containers get a static `extra_hosts` entry. Resolve the tailnet IP FRESH here (never
+# hardcoded, mirrors deploy.sh) and write it into .env.operator for compose interpolation.
+# NON-fatal: if it can't resolve, the compose default (loopback) applies and OTEL export
+# just fails silently — the app keeps serving; only traces are lost.
+HL_IP="$(tailscale ip -4 homelab 2>/dev/null | head -1 || true)"
+if [ -n "$HL_IP" ]; then
+  if grep -qE '^HOMELAB_TAILNET_IP=' "$OPERATOR_ENV"; then
+    sed -i "s#^HOMELAB_TAILNET_IP=.*#HOMELAB_TAILNET_IP=$HL_IP#" "$OPERATOR_ENV"
+  else
+    echo "HOMELAB_TAILNET_IP=$HL_IP" >>"$OPERATOR_ENV"
+  fi
+  echo "[$(date -u +%FT%TZ)] resolved homelab tailnet IP for OTEL traces: $HL_IP"
+else
+  echo "WARN: could not resolve 'homelab' tailnet IP; operator OTEL traces will not reach VictoriaTraces" >&2
+fi
+
+# Pin the api image to a CURRENT sha — NEVER the literal :main tag. CI stopped updating
+# :main 2026-05-28, so it is stale: pre-ADR-116, with no /api/app/* consumer surface.
+# The deploy workflow stages PODCAST_IMAGE_TAG (newest published sha from main) into
+# .env.operator. For a manual run where it is still unset, fall back to the SAME engine the
+# privileged operator stack is running ("one engine, two surfaces", ADR-116) by reading its
+# live api container. Refuse to deploy if neither resolves — do not silently ship stale :main.
+if [ -z "${PODCAST_IMAGE_TAG:-}" ]; then
+  op_img=$(docker inspect compose-api-1 --format '{{.Config.Image}}' 2>/dev/null || true)
+  PODCAST_IMAGE_TAG="${op_img##*:}"
+  case "${PODCAST_IMAGE_TAG:-}" in
+    sha-*) echo "[$(date -u +%FT%TZ)] pinned PODCAST_IMAGE_TAG=${PODCAST_IMAGE_TAG} (from running operator api)" ;;
+    *) echo "ERROR: PODCAST_IMAGE_TAG unset and could not resolve the operator api image (got: '${PODCAST_IMAGE_TAG:-}'); set PODCAST_IMAGE_TAG=sha-<7> explicitly — refusing to deploy stale :main" >&2; exit 1 ;;
+  esac
+fi
+export PODCAST_IMAGE_TAG
+
+# CRITICAL: run the operator-public stack under its OWN compose project (`-p operator`),
+# NOT the default (`compose`, derived from the compose/ dir) which is the PRIVILEGED
+# operator stack's project. Without this, `up --remove-orphans` reconciles the operator
+# project — removing privileged containers. `-p operator` isolates it: shared read-only
+# corpus volume, separate containers/network/lifecycle.
+COMPOSE=(docker compose -p operator --env-file "$OPERATOR_ENV" -f compose/docker-compose.operator-public.yml)
+
+# ADR-115 Option A secret delivery (mirrors the player stack). When
+# OPERATOR_SECRETS_VIA_FILES=1 the operator runtime secrets are delivered as files in host
+# tmpfs /dev/shm/operator-secrets/ (staged from GH Secrets by deploy-operator.yml, never on
+# disk), mounted via the secrets overlay -> /run/secrets/*, and exported by the image's
+# baked shim. Default off = today's .env.operator env-var behaviour. Fail loudly if the flag
+# is on but the files never arrived (exit 5) — never boot with silently-missing secrets.
+if [ "${OPERATOR_SECRETS_VIA_FILES:-}" = "1" ]; then
+  if [ ! -d /dev/shm/operator-secrets ] || [ -z "$(ls -A /dev/shm/operator-secrets 2>/dev/null)" ]; then
+    echo "ERROR: OPERATOR_SECRETS_VIA_FILES=1 but /dev/shm/operator-secrets/ is empty/missing — refusing to boot the operator surface with missing secrets." >&2
+    exit 5
+  fi
+  COMPOSE+=(-f compose/docker-compose.operator-secrets.yml)
+  echo "[$(date -u +%FT%TZ)] secrets: file-mounted from /dev/shm/operator-secrets ($(ls -1 /dev/shm/operator-secrets | wc -l | tr -d ' ') files)"
+fi
+
+# Ensure the host bind-mount source for per-user data exists and is writable by the
+# container's non-root ``podcast`` uid (1000) before compose up. #3.
+APPDATA_DIR="${OPERATOR_APPDATA_HOST_PATH:-/srv/podcast-scraper/operator-appdata}"
+install -d -m 0750 "$APPDATA_DIR" 2>/dev/null || mkdir -p "$APPDATA_DIR"
+chown -R 1000:1000 "$APPDATA_DIR" 2>/dev/null || sudo -n chown -R 1000:1000 "$APPDATA_DIR" || true
+
+echo "[$(date -u +%FT%TZ)] building + starting operator-public..."
+"${COMPOSE[@]}" up -d --build --remove-orphans || {
+  echo "ERROR: docker compose up failed" >&2
+  exit 1
+}
+
+# Drop the operator Caddy vhost into the shared sites dir (deploy-owned) with the real
+# domain substituted, VALIDATE the merged config once, then restart — roll back on failure
+# (ADR-114 validate-before-reload contract).
+# operator.caddy hardcodes `operator.closelistening.app` (the real domain), so the domain
+# sed is a no-op unless OPERATOR_DOMAIN differs — kept for parity with the player pattern.
+# The __OPERATOR_PREVIEW_COOKIE__ substitution IS required: the caddy file carries the
+# placeholder that must be swapped for the live gate secret.
+echo "[$(date -u +%FT%TZ)] installing operator Caddy vhost for ${OPERATOR_DOMAIN}..."
+sed -e "s/operator\.example\.com/${OPERATOR_DOMAIN}/g" \
+    -e "s|__OPERATOR_PREVIEW_COOKIE__|${OPERATOR_PREVIEW_COOKIE}|g" \
+    "infra/caddy/operator.caddy" >"/etc/caddy/sites/operator.caddy"
+# umask 077 makes the `>` land 0600/deploy-owned; the `caddy` user (User=caddy) cannot
+# read a 0600 file -> import "permission denied" -> restart fails (prod incident
+# 2026-07-23). Match the 0644 sibling vhosts so the caddy user can read the drop-in.
+chmod 0644 "/etc/caddy/sites/operator.caddy"
+_rollback_operator_vhost() { rm -f "/etc/caddy/sites/operator.caddy"; }
+# Validate with `caddy adapt` (Caddyfile -> JSON, reports real config/syntax errors)
+# — NOT `caddy validate`, which also PROVISIONS (opens the caddy-owned access.log) and
+# false-fails with "permission denied" when run as the deploy user, even on a valid
+# config (prod incident 2026-07-23). adapt does not touch the log writer.
+if ! caddy adapt --config /etc/caddy/Caddyfile --adapter caddyfile >/dev/null 2>&1; then
+  echo "ERROR: Caddy config invalid after adding operator vhost; rolling back" >&2
+  caddy adapt --config /etc/caddy/Caddyfile --adapter caddyfile 2>&1 | head -5 >&2
+  _rollback_operator_vhost
+  exit 2
+fi
+# RESTART, not reload: the base Caddyfile sets `admin off` (T-02), so admin-API-based
+# `caddy reload` fails — a vhost change needs a restart (task #27). If caddy doesn't
+# come back active, roll back the vhost + restart to the last-good config. (A missing LE
+# cert for a not-yet-DNS'd domain is NON-fatal — caddy still starts and retries issuance
+# in the background.)
+if ! sudo -n /usr/bin/systemctl restart caddy || ! systemctl is-active --quiet caddy; then
+  echo "ERROR: caddy failed to restart with operator vhost; rolling back" >&2
+  _rollback_operator_vhost
+  sudo -n /usr/bin/systemctl restart caddy || true
+  exit 2
+fi
+
+# Ship the operator stack's container logs to Grafana/Loki via the shared node Alloy
+# (ADR-121): drop operator.alloy into the deploy-writable config.d + hot-reload Alloy
+# (`docker kill -s HUP alloy`, no sudo — deploy is in the docker group). NON-fatal: a
+# logging hiccup must not fail the operator deploy. operator.alloy does not exist yet —
+# guard against its absence so this step is forward-compatible.
+ALLOY_DIR=/opt/vps-observability/config.d
+if [ -d "$ALLOY_DIR" ]; then
+  if [ -f infra/observability/operator.alloy ]; then
+    echo "[$(date -u +%FT%TZ)] installing operator.alloy log rules + reloading Alloy..."
+    cp infra/observability/operator.alloy "$ALLOY_DIR/operator.alloy"
+    chmod 0644 "$ALLOY_DIR/operator.alloy"
+    docker kill -s HUP alloy >/dev/null 2>&1 \
+      || echo "WARN: could not HUP alloy — operator logs may lag until its next reload" >&2
+  else
+    echo "WARN: infra/observability/operator.alloy absent — skipping Alloy rules (not created yet)" >&2
+  fi
+else
+  echo "WARN: $ALLOY_DIR absent — skipping operator.alloy (node Alloy not deployed here?)" >&2
+fi
+
+echo "[$(date -u +%FT%TZ)] health check (operator-read backend, in-container)..."
+ok=0
+for _ in $(seq 1 30); do
+  code=$("${COMPOSE[@]}" exec -T api curl -fsS -o /dev/null -w '%{http_code}' \
+    http://127.0.0.1:8000/api/health 2>/dev/null || echo 000)
+  if [ "$code" = "200" ]; then
+    ok=1
+    break
+  fi
+  sleep 2
+done
+[ "$ok" = "1" ] || {
+  echo "ERROR: operator backend /api/health did not return 200" >&2
+  exit 3
+}
+
+# ADR-115 Option A: when delivering via files, assert the secrets actually reached the
+# operator-api container as non-empty /run/secrets/* (mirrors the player exit-6 gate) —
+# a green /api/health must not mask a keyless app (bad DSN / no session secret / OAuth
+# broken). Only checks the flag-on path.
+if [ "${OPERATOR_SECRETS_VIA_FILES:-}" = "1" ]; then
+  _missing=""
+  for s in app_oauth_google_client_secret app_session_secret podcast_sentry_dsn_api; do
+    if ! "${COMPOSE[@]}" exec -T api sh -c "[ -s /run/secrets/$s ]" 2>/dev/null; then
+      _missing="$_missing $s"
+    fi
+  done
+  if [ -n "$_missing" ]; then
+    echo "ERROR: OPERATOR_SECRETS_VIA_FILES=1 but the operator-api container is missing non-empty /run/secrets:${_missing}." >&2
+    exit 6
+  fi
+  echo "[$(date -u +%FT%TZ)] secrets: verified /run/secrets present + non-empty in operator-api"
+fi
+echo "[$(date -u +%FT%TZ)] operator-public up + healthy; vhost live for https://${OPERATOR_DOMAIN}"


### PR DESCRIPTION
The gated deploy for `operator.closelistening.app`, mirroring the player deploy.

- `deploy-operator.yml` — `confirm=OPERATOR_DEPLOY`, `environment: prod`, tailnet join via **OAuth**, engine-sha pinned to the running operator api (one engine, two surfaces), `.env.operator` render, external health probe.
- `deploy-operator.sh` — isolated `-p operator` compose → `docker-compose.operator-public.yml`, drops `operator.caddy` with the coming-soon cookie substitution, caddy adapt-validate → restart → rollback.

Completes the **in-repo** epic core. **Gated on operator-side prep before a deploy:** CF DNS `operator.closelistening.app` (#45) + the Google redirect URI `https://operator.closelistening.app/api/app/auth/callback` on the existing client.

actionlint + shellcheck clean. Follows #1322 (design) / #1325 (serve mode + compose + Caddy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)