### PR TITLE
test+docs(resolidify): 2nd interlude — validate operator.caddy + reconcile o11y/ADR drift

### DIFF
--- a/docs/adr/ADR-118-cloudflare-additive-front.md
+++ b/docs/adr/ADR-118-cloudflare-additive-front.md
@@ -72,8 +72,12 @@ owns the CF account + DNS; the origin-side prep is minimal and lands here:
 **Negative**
 
 - CF terminates TLS → CF sees plaintext. Acceptable for public **static /
-  consumer** content; the **operator / api plane stays tailnet-only and is never
-  CF-fronted** (T-01). This ADR must not be read as license to expose api.
+  consumer** content; the **privileged operator / api plane stays tailnet-only and is never
+  CF-fronted** (T-01). This ADR must not be read as license to expose the *privileged* api.
+  **Update ([RFC-108](../rfc/RFC-108-operator-public-gated-surface.md)):** a *separate
+  least-privilege* operator **read** plane (`operator.closelistening.app`) IS public +
+  CF-fronted — behind the coming-soon gate + OAuth + ≥creator role — while the privileged
+  plane (`docker.sock`/keys/`index_rebuild`/`ops`/triggers) stays tailnet-only, so T-01 holds.
 - CF IP ranges are baked in **two** places (Caddyfile `trusted_proxies` + TF
   `cloudflare_ip_ranges`) and need a ~yearly refresh from
   <https://www.cloudflare.com/ips/>.

--- a/docs/guides/OBSERVABILITY_RUNBOOK.md
+++ b/docs/guides/OBSERVABILITY_RUNBOOK.md
@@ -131,7 +131,10 @@ curl -sG http://homelab:9428/select/logsql/query \
    not fixable by flag. Tracked separately.
 6. **GlitchTip client-side reachability** — browsers can't reach tailnet-only GlitchTip, so
    the **player** frontend ships errors via a **public ingest edge** (`telemetry.closelistening.app`).
-   The **operator** frontend has no such edge → its client-side errors are **not captured**.
+   The **operator** frontend was previously mis-routed via *orrery's* edge (bug); #49 repointed
+   the viewer DSN to `telemetry.closelistening.app/1`, and RFC-108 / #1320 makes the operator a
+   public+gated surface with its own closelistening ingest — so operator client-side errors land
+   on the podcast's own project (1) once the next viewer build + operator-public deploy land.
 
 **Doc drift (fix or distrust):**
 7. `OBSERVABILITY_ARCHITECTURE.md` still says the backend is on the **DGX**

--- a/tests/integration/server/test_infra_config_validates.py
+++ b/tests/integration/server/test_infra_config_validates.py
@@ -23,6 +23,7 @@ REPO = Path(__file__).resolve().parents[3]
 NGINX_CONF = REPO / "web" / "learning-player" / "nginx.conf"
 CADDYFILE = REPO / "infra" / "cloud-init" / "Caddyfile"
 PLAYER_CADDY = REPO / "infra" / "caddy" / "player.caddy"
+OPERATOR_CADDY = REPO / "infra" / "caddy" / "operator.caddy"
 PROD_USER_DATA = REPO / "infra" / "cloud-init" / "prod.user-data"
 SHELL_SCRIPTS = [
     REPO / "infra" / "cloud-init" / "decrypt-secrets.sh",
@@ -107,6 +108,9 @@ def test_caddy_config_validates(tmp_path: Path) -> None:
     sites = tmp_path / "sites"
     sites.mkdir()
     (sites / "player.caddy").write_text(PLAYER_CADDY.read_text())
+    # RFC-108: the operator-public vhost is validated alongside the player (distinct host,
+    # so they coexist; the __*_PREVIEW_COOKIE__ placeholders are valid literal values).
+    (sites / "operator.caddy").write_text(OPERATOR_CADDY.read_text())
     proc = subprocess.run(  # noqa: S603
         [
             "docker",


### PR DESCRIPTION
Second resolidify pass for epic #1320 (operator-public), before execution.

**Test:** `test_infra_config_validates` now caddy-validates `operator.caddy` in a real caddy:2 container (catches an edge-breaking syntax error pre-deploy). Note: `deploy-operator.yml` is auto-covered by the OAuth-migration guard once #1326 merges; the operator-public compose + serve mode already have dedicated tests.

**Docs drift fixed:** `OBSERVABILITY_RUNBOOK` (operator errors now captured — #49 repoint + RFC-108); `ADR-118` (RFC-108 supersedes 'never public' for the least-privilege read plane; privileged plane stays tailnet-only, T-01 holds).

Strict docs build green; pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)