### PR TITLE
chore(o11y): retire Grafana Cloud — observability fully self-hosted on homelab

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -208,12 +208,8 @@ jobs:
           PROD_SENTRY_DSN_API:          ${{ secrets.PROD_SENTRY_DSN_API }}
           PROD_SENTRY_DSN_PIPELINE:     ${{ secrets.PROD_SENTRY_DSN_PIPELINE }}
           PROD_SENTRY_DSN_VIEWER:       ${{ secrets.PROD_SENTRY_DSN_VIEWER }}
-          # Grafana Cloud — separate Prom + Loki user IDs
-          PROD_GRAFANA_CLOUD_API_KEY:   ${{ secrets.PROD_GRAFANA_CLOUD_API_KEY }}
-          PROD_GRAFANA_CLOUD_LOKI_URL:  ${{ secrets.PROD_GRAFANA_CLOUD_LOKI_URL }}
-          PROD_GRAFANA_CLOUD_LOKI_USER: ${{ secrets.PROD_GRAFANA_CLOUD_LOKI_USER }}
-          PROD_GRAFANA_CLOUD_PROM_URL:  ${{ secrets.PROD_GRAFANA_CLOUD_PROM_URL }}
-          PROD_GRAFANA_CLOUD_PROM_USER: ${{ secrets.PROD_GRAFANA_CLOUD_PROM_USER }}
+          # (Grafana Cloud retired — o11y is self-hosted homelab VictoriaMetrics/VictoriaLogs
+          # via the /opt/vps-observability Alloy container; nothing staged into .env here.)
           # Optional outbound webhook
           PROD_JOB_WEBHOOK_URL:         ${{ secrets.PROD_JOB_WEBHOOK_URL }}
         run: |
@@ -254,12 +250,8 @@ jobs:
             # Viewer DSN is a build-time FRONTEND var (baked into the viewer image),
             # not a runtime container secret — always keep it in .env.
             printf '%s=%s\n' VITE_SENTRY_DSN_VIEWER      "$PROD_SENTRY_DSN_VIEWER"
-            # Grafana Cloud
-            printf '%s=%s\n' GRAFANA_CLOUD_API_KEY   "$PROD_GRAFANA_CLOUD_API_KEY"
-            printf '%s=%s\n' GRAFANA_CLOUD_LOKI_URL  "$PROD_GRAFANA_CLOUD_LOKI_URL"
-            printf '%s=%s\n' GRAFANA_CLOUD_LOKI_USER "$PROD_GRAFANA_CLOUD_LOKI_USER"
-            printf '%s=%s\n' GRAFANA_CLOUD_PROM_URL  "$PROD_GRAFANA_CLOUD_PROM_URL"
-            printf '%s=%s\n' GRAFANA_CLOUD_PROM_USER "$PROD_GRAFANA_CLOUD_PROM_USER"
+            # (No Grafana Cloud creds staged — o11y ships to self-hosted homelab; the
+            # /opt/vps-observability Alloy container owns REMOTE_WRITE_URL/LOGS_WRITE_URL.)
             # Webhook
             printf '%s=%s\n' PODCAST_JOB_WEBHOOK_URL "$PROD_JOB_WEBHOOK_URL"
           } > "$ENVTMP"

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -180,13 +180,8 @@ jobs:
               additional_authorized_keys   = ["ssh-ed25519 AAAAORRERY gha-orrery-deploy"]
               tailscale_advertise_tags_cli = "tag:prod"
               alloy_enabled                = false
-              grafana_cloud_metrics_remote_write_url = ""
-              grafana_cloud_metrics_username         = ""
-              grafana_cloud_metrics_password         = ""
               podcast_tailscale_serve_body = indent(6, chomp(file("infra/cloud-init/podcast-tailscale-serve.sh")))
               orrery_tailscale_serve_body  = indent(6, chomp(file("infra/cloud-init/orrery-tailscale-serve.sh")))
-              grafana_cloud_logs_url       = ""
-              grafana_cloud_logs_username  = ""
               decrypt_secrets_body = indent(6, chomp(file("infra/cloud-init/decrypt-secrets.sh")))
               caddy_base_body      = indent(6, chomp(file("infra/cloud-init/Caddyfile")))
             })

--- a/.github/workflows/prod-restore-corpus.yml
+++ b/.github/workflows/prod-restore-corpus.yml
@@ -153,11 +153,7 @@ jobs:
           PROD_SENTRY_DSN_API:          ${{ secrets.PROD_SENTRY_DSN_API }}
           PROD_SENTRY_DSN_PIPELINE:     ${{ secrets.PROD_SENTRY_DSN_PIPELINE }}
           PROD_SENTRY_DSN_VIEWER:       ${{ secrets.PROD_SENTRY_DSN_VIEWER }}
-          PROD_GRAFANA_CLOUD_API_KEY:   ${{ secrets.PROD_GRAFANA_CLOUD_API_KEY }}
-          PROD_GRAFANA_CLOUD_LOKI_URL:  ${{ secrets.PROD_GRAFANA_CLOUD_LOKI_URL }}
-          PROD_GRAFANA_CLOUD_LOKI_USER: ${{ secrets.PROD_GRAFANA_CLOUD_LOKI_USER }}
-          PROD_GRAFANA_CLOUD_PROM_URL:  ${{ secrets.PROD_GRAFANA_CLOUD_PROM_URL }}
-          PROD_GRAFANA_CLOUD_PROM_USER: ${{ secrets.PROD_GRAFANA_CLOUD_PROM_USER }}
+          # (Grafana Cloud retired — o11y is self-hosted homelab; nothing staged here.)
           PROD_JOB_WEBHOOK_URL:         ${{ secrets.PROD_JOB_WEBHOOK_URL }}
         run: |
           set -euo pipefail
@@ -180,11 +176,7 @@ jobs:
             printf '%s=%s\n' PODCAST_SENTRY_DSN_API      "$PROD_SENTRY_DSN_API"
             printf '%s=%s\n' PODCAST_SENTRY_DSN_PIPELINE "$PROD_SENTRY_DSN_PIPELINE"
             printf '%s=%s\n' VITE_SENTRY_DSN_VIEWER      "$PROD_SENTRY_DSN_VIEWER"
-            printf '%s=%s\n' GRAFANA_CLOUD_API_KEY   "$PROD_GRAFANA_CLOUD_API_KEY"
-            printf '%s=%s\n' GRAFANA_CLOUD_LOKI_URL  "$PROD_GRAFANA_CLOUD_LOKI_URL"
-            printf '%s=%s\n' GRAFANA_CLOUD_LOKI_USER "$PROD_GRAFANA_CLOUD_LOKI_USER"
-            printf '%s=%s\n' GRAFANA_CLOUD_PROM_URL  "$PROD_GRAFANA_CLOUD_PROM_URL"
-            printf '%s=%s\n' GRAFANA_CLOUD_PROM_USER "$PROD_GRAFANA_CLOUD_PROM_USER"
+            # (No Grafana Cloud creds — o11y ships to self-hosted homelab.)
             printf '%s=%s\n' PODCAST_JOB_WEBHOOK_URL "$PROD_JOB_WEBHOOK_URL"
           } > "$ENVTMP"
           scp -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \

--- a/config/observability.example.yaml
+++ b/config/observability.example.yaml
@@ -5,12 +5,10 @@
 # this target doesn't wire (Sentry/Grafana on a local stack) simply report "not configured".
 # Secrets never live in this file — use `<field>_env: ENV_VAR_NAME` indirection.
 #
-# NOTE (2026-07): the stack now ships to SELF-HOSTED VictoriaMetrics/VictoriaLogs +
-# Grafana on the DGX (tailnet-only), not Grafana Cloud — see ADR-119 +
-# docs/guides/OBSERVABILITY_ARCHITECTURE.md. The `grafana:` Cloud examples below
-# (grafana.net URLs, glc_/glsa_ tokens) are LEGACY: for self-hosted, set
-# `url: http://<dgx-tailnet-ip>:3000` with a Grafana service-account token, and read
-# logs from VictoriaLogs (:9428) rather than a Cloud Loki access-policy token.
+# NOTE (2026-07): the stack ships to SELF-HOSTED VictoriaMetrics/VictoriaLogs + Grafana on
+# the HOMELAB box (tailnet-only) — Grafana Cloud is RETIRED (no SaaS egress). See ADR-117
+# (amended) + ADR-119. Point `grafana.url` at the homelab Grafana with a service-account
+# token, and read logs from homelab VictoriaLogs (:9428); errors go to homelab GlitchTip.
 
 default_target: local
 
@@ -30,9 +28,8 @@ targets:
     #   projects: [api, pipeline, viewer]   # real slugs (Settings → Projects), not DSN names
     #   environment: prod
     #   token_env: PODCAST_OBS_SENTRY_TOKEN
-    # grafana:
-    #   url: https://your-stack.grafana.net
-    #   token_env: PODCAST_OBS_GRAFANA_TOKEN     # service-account token (glsa_) for alerting
-    #   loki_url: https://logs-prod-xxx.grafana.net
-    #   loki_user: "123456"
-    #   loki_token_env: PODCAST_OBS_LOKI_TOKEN   # access-policy token (glc_), logs:read
+    # grafana:   # self-hosted homelab Grafana over the tailnet (NOT Grafana Cloud)
+    #   url: http://homelab:3000
+    #   token_env: PODCAST_OBS_GRAFANA_TOKEN     # homelab Grafana service-account token
+    #   loki_url: http://homelab:9428            # homelab VictoriaLogs (Loki-compatible read)
+    #   # no loki_user/token — homelab VictoriaLogs is tailnet-gated, no auth

--- a/docs/adr/ADR-117-multi-tenant-observability-gitops.md
+++ b/docs/adr/ADR-117-multi-tenant-observability-gitops.md
@@ -1,6 +1,6 @@
 # ADR-117: Multi-tenant observability — common box/edge plane + per-tenant app telemetry, GitOps
 
-- **Status**: Accepted
+- **Status**: Accepted — **amended 2026-07-27: backend is self-hosted homelab, NOT Grafana Cloud**
 - **Date**: 2026-07-09
 - **Authors**: Marko Dragoljevic, Claude (Opus 4.8)
 - **Related ADRs**: [ADR-114](ADR-114-shared-multi-tenant-public-edge-caddy.md) (edge
@@ -8,6 +8,22 @@
   (secret delivery), [ADR-096](ADR-096-dgx-spark-prod-primary-with-fallback.md) / RFC-081 (o11y layer)
 - **Security SSOT**: [Threat model](../security/THREAT_MODEL.md) **T-11** (detection gap) — this ADR is its home
 - **Tracking**: #1160 (hardening); #1158 / orrery#381 (edge programme)
+
+> **Amendment (2026-07-27) — Grafana Cloud retired; observability is fully self-hosted on
+> homelab.** This ADR was written with **Grafana Cloud** (SaaS Prom/Loki) + Sentry SaaS as the
+> backends. Since then the whole stack moved **on-prem to the homelab box** over the tailnet,
+> and Grafana Cloud is removed entirely (no SaaS egress):
+>
+> - **Metrics** → homelab **VictoriaMetrics** `http://homelab:8428/api/v1/write`
+> - **Logs** (sshd/fail2ban/Caddy) → homelab **VictoriaLogs** `http://homelab:9428/insert/loki/api/v1/push`
+> - **Traces** → homelab **VictoriaTraces** `http://homelab:10428/...` (ADR-119)
+> - **Errors** → homelab **GlitchTip** `http://homelab:8090` (Sentry-compatible)
+>
+> The collector is the **Alloy container** at `/opt/vps-observability/` on the VPS (env-driven
+> `REMOTE_WRITE_URL`/`LOGS_WRITE_URL` → homelab). The old systemd-Alloy→Grafana-Cloud path and
+> the `GRAFANA_CLOUD_*` / `PROD_GRAFANA_CLOUD_*` credentials are deleted. Wherever the body
+> below says "Grafana Cloud", read "homelab VictoriaMetrics/VictoriaLogs". The tenant-label
+> routing (§Decision) still applies — it just routes within the self-hosted backend.
 
 ## Context
 

--- a/docs/guides/PROD_RUNBOOK.md
+++ b/docs/guides/PROD_RUNBOOK.md
@@ -290,14 +290,14 @@ Repo Settings → Secrets → Actions → New repository secret. Stage these
 | `PROD_DEEPSEEK_API_KEY` | LLM (DeepSeek) | platform.deepseek.com → API keys |
 | `PROD_GROK_API_KEY` | LLM (Grok) | console.x.ai → API keys |
 | `PROD_SENTRY_DSN_API` | Sentry (api project) | sentry.io → project settings → Client Keys (DSN) |
-| `PROD_SENTRY_DSN_PIPELINE` | Sentry (pipeline project) | sentry.io → project settings → Client Keys (DSN) |
-| `PROD_SENTRY_DSN_VIEWER` | Sentry (viewer SPA — baked into Vite bundle) | sentry.io → project settings → Client Keys (DSN) |
-| `PROD_GRAFANA_CLOUD_API_KEY` | Grafana Cloud auth | grafana.com → My Account → Access Policies / Tokens |
-| `PROD_GRAFANA_CLOUD_LOKI_URL` | Loki push URL | grafana.com → My Account → Details (per-stack) |
-| `PROD_GRAFANA_CLOUD_LOKI_USER` | Loki tenant ID | grafana.com → My Account → Details (per-stack) |
-| `PROD_GRAFANA_CLOUD_PROM_URL` | Prom remote_write URL | grafana.com → My Account → Details (per-stack) |
-| `PROD_GRAFANA_CLOUD_PROM_USER` | Prom tenant ID | grafana.com → My Account → Details (per-stack) |
+| `PROD_SENTRY_DSN_PIPELINE` | Error DSN (pipeline project) | homelab **GlitchTip** (`http://homelab:8090`) → project → Client Keys (DSN) |
+| `PROD_SENTRY_DSN_VIEWER` | Error DSN (viewer SPA — baked into Vite bundle) | homelab **GlitchTip** → project → Client Keys (DSN) |
 | `PROD_JOB_WEBHOOK_URL` | Outbound pipeline-completion webhook (optional) | your config |
+
+> **Grafana Cloud retired (2026-07-27).** The `PROD_GRAFANA_CLOUD_*` secrets are **removed** —
+> observability is fully self-hosted on homelab (VictoriaMetrics `:8428` + VictoriaLogs `:9428`
+> via the `/opt/vps-observability` Alloy container; traces → VictoriaTraces `:10428`; errors →
+> GlitchTip `:8090`). No SaaS egress. See [ADR-117](../adr/ADR-117-multi-tenant-observability-gitops.md) (amended).
 
 Missing secret → empty value in `.env` → compose `${VAR:-}` default → that
 feature is off (stack still starts). Stage incrementally as needed.

--- a/scripts/ops/apply-edge.sh
+++ b/scripts/ops/apply-edge.sh
@@ -13,7 +13,8 @@
 #   - fail2ban: sshd jail + Caddy-access jail (T-11)
 #   - metadata-egress SSRF guard (T-07 / review H8 — folds in Phase 3.3)
 #   - Caddy shared edge engine + base Caddyfile (ADR-114) incl. ADR-118 CF real-IP
-#   - Grafana Alloy host metrics + security logs -> Grafana Cloud (ADR-117)
+#   (o11y collector is NOT managed here — the /opt/vps-observability Alloy container
+#    ships host metrics + security logs to the homelab backend; Grafana Cloud retired)
 #
 # EXPLICITLY OUT OF SCOPE (do NOT let this script do these):
 #   - Opening the firewall (80/443) — that is Phase 4, Terraform, the exposure
@@ -28,26 +29,22 @@
 # Caddyfile IS shared — this script copies it from the repo checkout).
 #
 # Usage:
-#   sudo ./apply-edge.sh [--dry-run] [--repo-dir DIR] [--with-alloy]
+#   sudo ./apply-edge.sh [--dry-run] [--repo-dir DIR]
 #   DRY_RUN=1 sudo -E ./apply-edge.sh
 #
 #   --dry-run       Print what would change; make no changes. (or DRY_RUN=1)
 #   --repo-dir DIR  Repo checkout to source the Caddyfile from (default /srv/podcast-scraper).
-#   --with-alloy    Force Alloy enable even without creds present (config still
-#                   needs /etc/alloy/grafana-cloud.env — normally set in Phase 2.1).
 #
 # Idempotent: safe to re-run. Each step converges only on drift.
 set -euo pipefail
 
 DRY_RUN="${DRY_RUN:-0}"
 REPO_DIR="${REPO_DIR:-/srv/podcast-scraper}"
-WITH_ALLOY=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run) DRY_RUN=1 ;;
     --repo-dir) REPO_DIR="${2:?--repo-dir needs a path}"; shift ;;
-    --with-alloy) WITH_ALLOY=1 ;;
     -h|--help) sed -n '2,40p' "$0"; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
@@ -348,10 +345,13 @@ elif CADDY_BIND_ADDRS="$BIND_ADDRS" GLITCHTIP_UPSTREAM="$GT_UPSTREAM" caddy vali
   ok "  Caddyfile valid"
   if ! systemctl is-active --quiet caddy; then
     enable_now caddy
-  elif [ "$bind_changed" = 1 ] || [ "$glitchtip_changed" = 1 ]; then
-    change "  restart caddy (public-bind / glitchtip-upstream env changed)"; run systemctl restart caddy
-  elif [ "$caddy_changed" = 1 ]; then
-    change "  reload caddy"; run systemctl reload caddy
+  elif [ "$bind_changed" = 1 ] || [ "$glitchtip_changed" = 1 ] || [ "$caddy_changed" = 1 ]; then
+    # RESTART, not reload: the base Caddyfile sets ``admin off`` (T-02), so the admin-API
+    # based ``caddy reload`` fails ("admin endpoint disabled"). Any config/env change needs
+    # a restart (mirrors deploy-operator.sh / deploy-player.sh). A bind/glitchtip env change
+    # needs it anyway (systemd reads Environment at start, not reload).
+    change "  restart caddy (config/env changed; reload needs admin API which is off)"
+    run systemctl restart caddy
   else
     skip "  caddy running"
   fi
@@ -364,98 +364,15 @@ info "5) re-arm fail2ban (attach caddy jail)"
 run systemctl reload-or-restart fail2ban
 
 # =============================================================================
-# 6. Grafana Alloy — host metrics + security logs -> Grafana Cloud (ADR-117)
-#    Config is staged unconditionally; the service is only enabled when the
-#    Grafana Cloud creds are present (normally set in Phase 2.1).
+# 6. Observability collector — NOT managed here.
+#    Host metrics + security logs ship to the SELF-HOSTED homelab backend
+#    (VictoriaMetrics :8428 + VictoriaLogs :9428) via the Alloy CONTAINER at
+#    /opt/vps-observability/ (docker compose, REMOTE_WRITE_URL/LOGS_WRITE_URL →
+#    homelab over the tailnet). That is the canonical collector. This script used
+#    to install a SECOND, systemd Alloy that shipped to Grafana Cloud — removed:
+#    Grafana Cloud is retired, everything is homelab-local (no SaaS egress).
 # =============================================================================
-info "6) Grafana Alloy (o11y)"
-if command -v alloy >/dev/null 2>&1; then
-  skip "  alloy installed"
-else
-  change "  install alloy (apt.grafana.com)"
-  if [ "$DRY_RUN" != 1 ]; then
-    curl -fsSL https://apt.grafana.com/gpg.key | gpg --dearmor -o /etc/apt/keyrings/grafana.gpg
-    chmod a+r /etc/apt/keyrings/grafana.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" > /etc/apt/sources.list.d/grafana.list
-    apt-get update
-  fi
-  run apt-get install -y alloy
-fi
-
-alloy_changed=0
-write_file /etc/alloy/config.alloy 0640 root:alloy <<'EOF' && alloy_changed=1 || true
-prometheus.exporter.unix "host" {}
-
-prometheus.scrape "host_metrics" {
-  targets    = prometheus.exporter.unix.host.targets
-  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
-}
-
-prometheus.remote_write "grafana_cloud" {
-  endpoint {
-    url = sys.env("GRAFANA_CLOUD_REMOTE_WRITE_URL")
-    basic_auth {
-      username = sys.env("GRAFANA_CLOUD_PROM_USER")
-      password = sys.env("GRAFANA_CLOUD_API_KEY")
-    }
-  }
-}
-
-// Security logs -> Loki (T-11 / ADR-117, tenant=common): sshd + fail2ban from the
-// journal, the Caddy access log from file. Feeds the common security alert rules.
-loki.relabel "journal" {
-  forward_to = []
-  rule {
-    source_labels = ["__journal__systemd_unit"]
-    target_label  = "unit"
-  }
-}
-
-loki.source.journal "security" {
-  forward_to    = [loki.process.tenant_common.receiver]
-  relabel_rules = loki.relabel.journal.rules
-  labels        = { job = "systemd-journal" }
-}
-
-loki.source.file "caddy" {
-  targets    = [{ __path__ = "/var/log/caddy/access.log", job = "caddy" }]
-  forward_to = [loki.process.tenant_common.receiver]
-}
-
-loki.process "tenant_common" {
-  forward_to = [loki.write.grafana_cloud.receiver]
-  stage.static_labels {
-    values = { tenant = "common" }
-  }
-}
-
-loki.write "grafana_cloud" {
-  endpoint {
-    url = sys.env("GRAFANA_CLOUD_LOKI_URL")
-    basic_auth {
-      username = sys.env("GRAFANA_CLOUD_LOKI_USER")
-      password = sys.env("GRAFANA_CLOUD_API_KEY")
-    }
-  }
-}
-EOF
-
-write_file /etc/systemd/system/alloy.service.d/grafana-cloud-env.conf 0644 root:root <<'EOF' && alloy_changed=1 || true
-[Service]
-EnvironmentFile=/etc/alloy/grafana-cloud.env
-EOF
-
-# Let Alloy read the journal (sshd/fail2ban) + the Caddy access log.
-run usermod -aG systemd-journal alloy || true
-run usermod -aG caddy alloy 2>/dev/null || true
-[ "$alloy_changed" = 1 ] && run systemctl daemon-reload
-
-if [ -s /etc/alloy/grafana-cloud.env ] || [ "$WITH_ALLOY" = 1 ]; then
-  enable_now alloy
-else
-  warn "  /etc/alloy/grafana-cloud.env absent/empty — Alloy config staged but NOT started."
-  warn "  Set the 5 GRAFANA_CLOUD_* values there (Phase 2.1) then: systemctl enable --now alloy"
-fi
+info "6) o11y collector — managed by the /opt/vps-observability container (homelab), not here"
 
 # =============================================================================
 # 7. Verify + summary

--- a/scripts/ops/verify-edge.sh
+++ b/scripts/ops/verify-edge.sh
@@ -126,19 +126,25 @@ else
   skip "drift check (missing $SRC or /etc/caddy/Caddyfile)"
 fi
 
-# --- 6. Grafana Alloy --------------------------------------------------------
-section "6) Grafana Alloy (ADR-117)"
-if command -v alloy >/dev/null 2>&1; then
-  [ -f /etc/alloy/config.alloy ] && pass "config.alloy staged" || fail "config.alloy missing"
-  if systemctl is-active --quiet alloy; then
-    pass "alloy service active (shipping to Grafana Cloud)"
-  elif [ -s /etc/alloy/grafana-cloud.env ]; then
-    warn "grafana-cloud.env present but alloy not active — start it: systemctl enable --now alloy"
+# --- 6. o11y collector (homelab, container) ----------------------------------
+# Canonical collector is the Alloy CONTAINER at /opt/vps-observability/ shipping host
+# metrics + security logs to the self-hosted homelab backend (VictoriaMetrics :8428 +
+# VictoriaLogs :9428) over the tailnet. Grafana Cloud is retired — no SaaS egress.
+section "6) o11y collector (homelab container)"
+if docker ps --format '{{.Names}} {{.Image}}' 2>/dev/null | grep -qiE 'alloy'; then
+  pass "alloy collector container running (ships to homelab VM :8428 / VL :9428)"
+  if grep -qE 'REMOTE_WRITE_URL=.*homelab' /opt/vps-observability/.env 2>/dev/null; then
+    pass "collector targets homelab (REMOTE_WRITE_URL → homelab)"
   else
-    skip "alloy staged, not started — expected until Phase 2.1 sets GRAFANA_CLOUD_* creds"
+    warn "collector .env REMOTE_WRITE_URL not pointed at homelab — check /opt/vps-observability/.env"
+  fi
+  if grep -qiE 'grafana\.net|glc_' /opt/vps-observability/.env 2>/dev/null; then
+    fail "collector .env still references Grafana Cloud (grafana.net / glc_) — must be homelab-only"
+  else
+    pass "no Grafana Cloud reference in the collector .env"
   fi
 else
-  warn "alloy not installed (run apply-edge.sh, or defer o11y to Phase 2)"
+  warn "no alloy collector container running (expected /opt/vps-observability compose up)"
 fi
 
 # --- summary -----------------------------------------------------------------


### PR DESCRIPTION
Removes all Grafana Cloud usage from prod. Everything already ships to the **self-hosted homelab** backend over the tailnet — Grafana Cloud was vestigial from ADR-117's original design.

## Validated live (before this PR — proves the running system is already homelab-only)
| Target | Evidence (queried over tailnet) |
|---|---|
| VictoriaMetrics `:8428` | **2104 series** from `instance=prod-podcast`; `up{job=api}` + `up{job=integrations/unix}` = 1 |
| VictoriaLogs `:9428` | `instance=prod-podcast` — caddy 133k, journal (sshd/fail2ban) 57k, app logs |
| VictoriaTraces `:10428` | live spans; services `operator-public-api`, `player-api`, `pipeline`, `podcast-api` |
| GlitchTip `:8090` | `/_health/` → 200 |

The canonical collector is the **Alloy container** at `/opt/vps-observability/` (`REMOTE_WRITE_URL`/`LOGS_WRITE_URL` → homelab). This PR removes the *dead* second path (systemd-Alloy → Grafana Cloud) + the staged credentials.

## Changes
**Code**
- `deploy-prod.yml` / `prod-restore-corpus.yml` — stop staging `GRAFANA_CLOUD_*` into the prod `.env` (5 vars each).
- `apply-edge.sh` — remove the dead systemd-Alloy→Grafana-Cloud section entirely; **also fixes the Caddy reload→restart bug** (base Caddyfile sets `admin off`, so `caddy reload` can never succeed — a config change needs `restart`, matching the deploy scripts; this bit us live during the edge-hardening apply).
- `verify-edge.sh` — replace the Grafana-Cloud Alloy check with a homelab-collector check that **fails** if `grafana.net`/`glc_` reappears.
- `infra-ci.yml` — drop dead `grafana_cloud_*` templatefile vars (`prod.user-data` doesn't reference them; real `main.tf` never passed them).

**Docs**
- ADR-117 amended (backend = homelab, not Grafana Cloud) · PROD_RUNBOOK drops the 5 secret rows + fixes Sentry→GlitchTip provenance · observability example points at homelab.

## Operator-side
- ✅ **Done:** deleted the 5 `PROD_GRAFANA_CLOUD_*` env secrets.
- ⚠️ **TODO (you):** **rotate the `glc_` Grafana Cloud key** — it was surfaced in a terminal during triage, so treat as exposed (grafana.com → Access Policies).
- ℹ️ The box `/srv/podcast-scraper/.env` still holds the old `GRAFANA_CLOUD_*` lines until the next **prod deploy** (which now stages without them). The running collector already ignores them (reads its own `/opt/vps-observability/.env`), so no data-flow impact.

## Validation
`shellcheck` + `bash -n` (edge scripts) · `actionlint` (3 workflows) · `make docs` · pre-commit ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)