### PR TITLE
chore(deps): batch-adopt 7 Dependabot updates (+ mypy 2.3.0 type fix)

### DIFF
--- a/.github/workflows/ai-experiment-pipeline.yml
+++ b/.github/workflows/ai-experiment-pipeline.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11.8'
           cache: pip

--- a/.github/workflows/autoresearch-eval-nightly.yml
+++ b/.github/workflows/autoresearch-eval-nightly.yml
@@ -76,7 +76,7 @@ jobs:
       - name: '[Setup] Set up Python 3.11'
         id: setup_python
         timeout-minutes: 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11.8"
           cache: pip
@@ -356,7 +356,7 @@ jobs:
       - name: '[Setup] Set up Python 3.11'
         id: setup_python
         timeout-minutes: 2
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11.8"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11.8"
           cache: "pip"

--- a/.github/workflows/ml-benchmark.yml
+++ b/.github/workflows/ml-benchmark.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11.8'
           cache: pip

--- a/.github/workflows/nightly-data-baseline.yml
+++ b/.github/workflows/nightly-data-baseline.yml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11.8'
           cache: pip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,7 +92,7 @@ jobs:
           ml-models-nightly-${{ runner.os }}-
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -146,14 +146,14 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
         cache-dependency-path: pyproject.toml
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: "20"
 
@@ -182,7 +182,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -224,7 +224,7 @@ jobs:
         df -h
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -257,7 +257,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -290,7 +290,7 @@ jobs:
         df -h
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -360,7 +360,7 @@ jobs:
     needs: [nightly-lint, nightly-build]
     steps:
     - uses: actions/checkout@v7
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: "22"
         cache: "npm"
@@ -397,7 +397,7 @@ jobs:
         df -h
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -486,7 +486,7 @@ jobs:
         df -h
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -556,7 +556,7 @@ jobs:
       needs.nightly-test-e2e.result == 'success'
     steps:
     - uses: actions/checkout@v7
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: "22"
         cache: "npm"
@@ -599,14 +599,14 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "npm"
@@ -840,14 +840,14 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python 3.11 (for the real API server)
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "npm"
@@ -1018,7 +1018,7 @@ jobs:
         df -h
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -1109,7 +1109,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -187,7 +187,7 @@ jobs:
       needs.viewer-unit.result == 'success'
     steps:
     - uses: actions/checkout@v7
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: "22"
         cache: "npm"
@@ -209,13 +209,13 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
         cache-dependency-path: pyproject.toml
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: "20"
     - name: Install lint dependencies (no ML packages)
@@ -267,7 +267,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -339,7 +339,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -493,7 +493,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -515,7 +515,7 @@ jobs:
     needs: [lint, build]
     steps:
     - uses: actions/checkout@v7
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         # Vite 8 requires ^20.19 || >=22.12; bare "20" on the runner can be older and breaks Vite
         node-version: "22"
@@ -552,7 +552,7 @@ jobs:
     if: needs.detect-changes.outputs.app == 'true'
     steps:
     - uses: actions/checkout@v7
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: "22"
         cache: "npm"
@@ -581,7 +581,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python 3.11 (for the real API server the app e2e boots)
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -592,7 +592,7 @@ jobs:
         .venv/bin/pip install --upgrade pip
         # [dev] pulls FastAPI + uvicorn — needed for `podcast_scraper serve`.
         .venv/bin/pip install -e ".[dev]"
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: "22"
         cache: "npm"
@@ -621,7 +621,7 @@ jobs:
       needs.app-unit.result == 'success'
     steps:
     - uses: actions/checkout@v7
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: "22"
         cache: "npm"
@@ -694,7 +694,7 @@ jobs:
           ml-models-${{ runner.os }}-
     - name: Set up Python 3.11 (only if cache miss - needed for model download)
       if: (needs.detect-changes.outputs.docs-only != 'true' || needs.detect-changes.outputs.code == 'true') && steps.cache-models.outputs.cache-hit != 'true'
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -756,7 +756,7 @@ jobs:
         sudo rm -rf /var/lib/apt/lists/*
         df -h
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -888,7 +888,7 @@ jobs:
         sudo rm -rf /var/lib/apt/lists/*
         df -h
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -1008,7 +1008,7 @@ jobs:
         sudo rm -rf /var/lib/apt/lists/*
         df -h
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -1135,7 +1135,7 @@ jobs:
         sudo rm -rf /var/lib/apt/lists/*
         df -h
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -1266,7 +1266,7 @@ jobs:
         sudo rm -rf /var/lib/apt/lists/*
         df -h
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -1316,7 +1316,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -1350,7 +1350,7 @@ jobs:
         # Full history required for wily (code quality trends) on main/release
         fetch-depth: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/2.4' || github.ref == 'refs/heads/release/2.5' || github.ref == 'refs/heads/release/2.6') && 0 || 1 }}
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"
@@ -1669,7 +1669,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.11.8"
         cache: "pip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11.8'
           cache: pip
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 0   # need full history for prev-tag lookup
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11.8'
 

--- a/.github/workflows/smoke-operator.yml
+++ b/.github/workflows/smoke-operator.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: web/gi-kg-viewer
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm

--- a/.github/workflows/smoke-player.yml
+++ b/.github/workflows/smoke-player.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: web/learning-player
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -51,7 +51,7 @@ jobs:
           df -h
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11.8"
           cache: "pip"
@@ -205,7 +205,7 @@ jobs:
           df -h
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11.8"
           cache: "pip"

--- a/.github/workflows/stack-test.yml
+++ b/.github/workflows/stack-test.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "python-dotenv>=1.2.2,<2.0.0",  # For .env file support (RFC-013)
   "zipp>=4.1.0,<5.0.0",  # Security fix: CVE-2024-50208 (infinite loop vulnerability)
   "jinja2>=3.1.6,<4.0.0",  # For prompt templating (RFC-017)
-  "filelock>=3.29.0,<4.0.0",  # Security fix: CVE-2025-68146 (TOCTOU race condition)
+  "filelock>=3.29.7,<4.0.0",  # Security fix: CVE-2025-68146 (TOCTOU race condition)
   # CVE-2026-4539 (ReDoS in AdlLexer, NVD/GHSA: 2.19.0–2.19.2): stay on 2.18.x until 2.19.3+; pip-audit still needs --ignore-vuln until OSV range matches
   # TODO(CVE-2026-4539): After pygments ships a fixed release and pip-audit/OSV match NVD ranges, bump the cap and drop Makefile ignore.
   "pygments>=2.20.0,<2.21.0",
@@ -150,7 +150,7 @@ ml = [
   # Neural speaker diarization (RFC-058): pyannote after local Whisper transcribe.
   # 4.x switched audio I/O to torchcodec (no torchaudio.AudioMetaData) so it works
   # with torch>=2.11/torchaudio>=2.9; 3.x is import-broken against that torchaudio.
-  "pyannote.audio>=4.0,<5.0",
+  "pyannote.audio>=4.0.7,<5.0",
   "torchaudio",
   # torchcodec is transitive (torchaudio 4.x / pyannote 4.x). Cap <0.15: 0.15.0
   # is part of the 2026-07-17 native teardown SIGSEGV drift (see transformers
@@ -171,7 +171,7 @@ llm = [
   # 1.x: ThinkingConfig.thinking_budget for gemini-2.5-flash (Issue #572); 0.x lacked the field
   "google-genai>=1.0.0,<2.0.0",
   "google-api-core>=2.30.3,<3.0.0",  # Required by google-genai for some operations
-  "anthropic>=0.111.0,<1.0.0",  # Anthropic API provider (Issue #106)
+  "anthropic>=0.116.0,<1.0.0",  # Anthropic API provider (Issue #106)
   # Mistral API provider (Issue #106). PyPI ``mistralai`` is quarantined (no installable
   # files on https://pypi.org/simple/mistralai/ as of 2026-05). Pin the official v2.4.5
   # tree (commit matches tag v2.4.5) until PyPI restores the project.
@@ -225,7 +225,7 @@ dev = [
   "prometheus-fastapi-instrumentator>=8.0.0,<9.0.0",
   # In-process feed-sweep scheduler (#708); no-op unless ``scheduled_jobs:`` in viewer_operator.yaml.
   "apscheduler>=3.11.2,<4.0.0",
-  "black>=23.0.0,<27.0.0",
+  "black>=26.5.1,<27.0.0",
   "isort>=8.0.1,<9.0.0",
   "flake8>=7.3.0,<8.0.0",
   "pytest>=9.0.3,<10.0.0",
@@ -234,7 +234,7 @@ dev = [
   "pytest-rerunfailures>=16.3,<17.0",  # Flaky test reruns (RFC-018)
   "pytest-socket>=0.8.0,<1.0.0",  # Network blocking for E2E tests (RFC-019)
   "pytest-json-report>=1.5.0,<2.0.0",  # JSON test reports for metrics (RFC-025)
-  "mypy==2.1.0",  # pinned exactly: a floating range let CI drift to 2.2.0 (differing jinja2 inference)
+  "mypy==2.3.0",  # pinned exactly: a floating range let CI drift to 2.2.0 (differing jinja2 inference)
   "types-PyYAML>=6.0.12,<7.0.0",
   "bandit>=1.9.4,<2.0.0",
   "pip-audit>=2.10.1,<3.0.0",
@@ -255,7 +255,7 @@ dev = [
   # Diarization stack pins (RFC-058) — lazy-imported; keeps CI/dev venv aligned with [ml].
   # Must mirror the [ml] pin: pyannote 3.x is import-broken under torchaudio>=2.9
   # (AudioMetaData removed), which is exactly why [ml] moved to 4.x (#901).
-  "pyannote.audio>=4.0,<5.0",
+  "pyannote.audio>=4.0.7,<5.0",
   "torchaudio",
 ]
 # Documentation - see docs/requirements.txt

--- a/src/podcast_scraper/prompts/store.py
+++ b/src/podcast_scraper/prompts/store.py
@@ -127,7 +127,10 @@ def _load_template(name: str) -> Template:
     rel_path = _rel_path_for_name(name)
     path = _template_path_or_raise(prompt_dir, rel_path, name)
     text = path.read_text(encoding="utf-8")
-    return Template(text)
+    # Explicit annotation: mypy 2.3.0's jinja2 stubs infer Template(...) as Any, which
+    # trips no-any-return on the declared -> Template signature.
+    template: Template = Template(text)
+    return template
 
 
 def render_prompt(name: str, **params: Any) -> str:


### PR DESCRIPTION
Consolidates the 7 open Dependabot PRs onto one branch — each assessed, adopted, and validated together. Supersedes **#1183, #1184, #1185, #1186, #1187, #1223, #1224** (close them when this merges).

## What's in + how each was assessed
| Dep | Change | Assessment |
|---|---|---|
| `filelock` | `>=3.29.0` → `>=3.29.7` | Security floor (CVE-2025-68146 TOCTOU) — adopt |
| `pyannote.audio` | `>=4.0` → `>=4.0.7` | Patch floor bump — adopt |
| `anthropic` | `>=0.111.0` → `>=0.116.0` | Imports OK at installed 0.120.0 |
| `black` | `>=23.0.0` → `>=26.5.1` | `black --check`: **1714 files unchanged** (no reformat) |
| `mypy` | `2.1.0` → `2.3.0` | Surfaced 1 new type error → fixed (below) |
| `actions/setup-node` | v6 → v7 (14 uses) | Safe: workflows pin explicit `node-version` |
| `actions/setup-python` | v6 → v7 (36 uses) | Safe: workflows pin explicit `python-version` |

## Code change (mypy 2.3.0)
`prompts/store.py`: mypy 2.3.0's stricter jinja2 `Template` inference flagged `no-any-return` on `get_template`. Fixed with an **explicit local annotation** (not a `type: ignore` suppression). This is exactly the jinja2-inference drift the mypy exact-pin comment warned about.

## Validation
- `make type` (mypy 2.3.0): **Success, no issues in 1495 files**
- `black --check` (26.5.1): clean, no reformatting
- `actionlint`: clean · workflows pin node 20/22 + python 3.11.8 → v7 default changes are moot
- `pip check`: only the **pre-existing** `wily/radon` note (unrelated to these bumps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)