### PR TITLE
observability: trace_id extraction in podcast + player Alloy drop-ins

### DIFF
--- a/infra/observability/player.alloy
+++ b/infra/observability/player.alloy
@@ -61,4 +61,16 @@ loki.process "player_denoise" {
 		expression          = "\"(GET|HEAD) /(api/(app/)?)?(health|metrics) HTTP/1[^\"]*\" 2"
 		drop_counter_reason = "healthcheck_noise"
 	}
+
+	// homelab log standard (agentic-ai-homelab/infra/observability/LOG-STANDARD.md):
+	// extract the 32-hex trace id from a traceparent/sentry-trace pattern into
+	// structured_metadata (a queryable field, NOT a high-cardinality stream label).
+	// Inlined here (rather than referencing base's homelab_std) so this drop-in
+	// deploys independently of a base.alloy rollout.
+	stage.regex {
+		expression = "(?:00-)?(?P<trace_id>[a-f0-9]{32})-[a-f0-9]{16}"
+	}
+	stage.structured_metadata {
+		values = {trace_id = ""}
+	}
 }

--- a/infra/observability/podcast.alloy
+++ b/infra/observability/podcast.alloy
@@ -64,4 +64,16 @@ loki.process "podcast_denoise" {
 		expression          = "\"(GET|HEAD) /(api/(app/)?)?(health|metrics) HTTP/1[^\"]*\" 2"
 		drop_counter_reason = "healthcheck_noise"
 	}
+
+	// homelab log standard (agentic-ai-homelab/infra/observability/LOG-STANDARD.md):
+	// extract the 32-hex trace id from a traceparent/sentry-trace pattern into
+	// structured_metadata (a queryable field, NOT a high-cardinality stream label).
+	// Inlined here (rather than referencing base's homelab_std) so this drop-in
+	// deploys independently of a base.alloy rollout.
+	stage.regex {
+		expression = "(?:00-)?(?P<trace_id>[a-f0-9]{32})-[a-f0-9]{16}"
+	}
+	stage.structured_metadata {
+		values = {trace_id = ""}
+	}
 }


### PR DESCRIPTION
Moves the homelab log-standard `trace_id` extraction from the `production` branch onto `main` (single commit).

## What
`podcast.alloy` + `player.alloy` each get a `stage.regex` + `stage.structured_metadata` in their denoise `loki.process`, extracting the 32-hex trace id (`traceparent` / `sentry-trace`) into a **`trace_id` structured-metadata field** (queryable, not a high-cardinality stream label) — for log↔trace correlation in Grafana. Spec: [agentic-ai-homelab LOG-STANDARD.md](https://github.com/chipi/agentic-ai-homelab/blob/main/infra/observability/LOG-STANDARD.md).

- `app`/`surface` labels unchanged.
- **Inlined** (not referencing base's `homelab_std`) so each drop-in deploys **independently of a base.alloy rollout**.

## Deploy (automated route)
Config-only — **no image rebuild**. The drop-ins are cp'd from the repo checkout at deploy time + hot-reloaded:
- `podcast.alloy` → ride `deploy.sh` (prod deploy) → `/opt/vps-observability/config.d/podcast.alloy` + `docker kill -s HUP alloy`
- `player.alloy` → ride `deploy-player.sh` → `config.d/player.alloy` + HUP

`env=prod` label + the Caddy-edge trace_id live in `base.alloy` (infra-owned, separate manual VPS path) — not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)