### PR TITLE
tailscale(acl): grant :8444 — Umami dedicated TLS serve port

### DIFF
--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -129,6 +129,11 @@
     //         Langfuse/Next.js can't serve under a stripped subpath, so it gets
     //         its own TLS port: homelab.<tailnet>:8443). serve, not funnel.
     //         Independent of tag:prod:8443 (orrery on the VPS) — different host.
+    //   :8444 Umami over HTTPS via `tailscale serve` (dedicated TLS port — same
+    //         reason as Langfuse: Umami/Next.js emits root-absolute /_next assets
+    //         that 404 under the stripped /umami subpath. Root-mounted on :8444 so
+    //         they resolve: homelab.<tailnet>:8444). serve, not funnel. The /umami
+    //         :443 path mount stays as a redirect-only crumb; :8444 is the real UI.
     //   :8888 homelab start page (service links + creds; basic-auth, tailnet-only)
     //   :4001 LiteLLM gateway API (the homelab's LLM proxy — fleets today, any
     //         project/box tomorrow; auth = per-consumer virtual keys w/ budgets)
@@ -137,7 +142,7 @@
     {
       "action": "accept",
       "src":    ["autogroup:admin"],
-      "dst":    ["tag:homelab-host:22,443,3000,3001,4000,4001,8090,8428,8443,8888,9428,10000,10428"]
+      "dst":    ["tag:homelab-host:22,443,3000,3001,4000,4001,8090,8428,8443,8444,8888,9428,10000,10428"]
     },
     {
       // prod (the box) also reaches Umami :3001 — it proxies public analytics


### PR DESCRIPTION
## Why
Umami's admin UI is unreachable from the homelab start page. Umami (Next.js) emits root-absolute `/_next/...` assets that **404 under the stripped `/umami` :443 subpath** (page shell loads, app never boots). Verified: `/umami/_next/...`=200 but `/_next/...`=404.

Same failure mode as Langfuse → same fix: a dedicated **root-mounted TLS port** (`:8444`, `tailscale serve --https=8444 → 127.0.0.1:3001`) so absolute assets resolve.

## What
- Grant `:8444` to `autogroup:admin` on `tag:homelab-host` (this PR).
- Serve mount captured in `agentic-ai-homelab/infra/homelab-serve/serve-map.sh` (already live on the mini).
- Homepage link repointed `$H/umami` → `$H:8444` (agentic-ai-homelab).

macOS Tailscale accepts `:8444` (the "only 443/8443/10000" note was outdated — verified `serve --https=8444` EXIT=0).

## Apply
PR runs the ACL `test` dry-run. Merge to `main` applies to the live tailnet (ADR-128).