### PR TITLE
tailscale(acl): grant :8445 (GlitchTip UI) + tidy serve-port comment

### DIFF
--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -123,30 +123,20 @@
     // telemetry to it. These grants were previously hand-added in the admin
     // console and got wiped by a `tofu apply` (they lived nowhere in-repo);
     // pinned here so they survive future applies.
-    //   :443  Umami over HTTPS via `tailscale serve` (homelab.<tailnet>/umami).
-    //         The operator viewer is served HTTPS-over-tailscale, so it can't load
-    //         the http://homelab:3001 script (mixed-content-blocked); this tailnet-
-    //         only HTTPS entry point is the fix. NO public surface (serve, not funnel).
     //   :3000 Grafana  :3001 Umami  :4000 Langfuse  :8090 GlitchTip
     //   :8428 VictoriaMetrics  :9428 VictoriaLogs  :10428 VictoriaTraces
-    //   :8443 Langfuse over HTTPS via `tailscale serve` (dedicated TLS port —
-    //         Langfuse/Next.js can't serve under a stripped subpath, so it gets
-    //         its own TLS port: homelab.<tailnet>:8443). serve, not funnel.
-    //         Independent of tag:prod:8443 (orrery on the VPS) — different host.
-    //   :8444 Umami over HTTPS via `tailscale serve` (dedicated TLS port — same
-    //         reason as Langfuse: Umami/Next.js emits root-absolute /_next assets
-    //         that 404 under the stripped /umami subpath. Root-mounted on :8444 so
-    //         they resolve: homelab.<tailnet>:8444). serve, not funnel. The /umami
-    //         :443 path mount stays as a redirect-only crumb; :8444 is the real UI.
     //   :8888 homelab start page (service links + creds; basic-auth, tailnet-only)
     //   :4001 LiteLLM gateway API (the homelab's LLM proxy — fleets today, any
     //         project/box tomorrow; auth = per-consumer virtual keys w/ budgets)
-    //   :10000 LiteLLM admin UI over HTTPS via `tailscale serve` (macOS serve
-    //         allows only 443/8443/10000; 8443 taken by Langfuse). serve, not funnel.
+    //   Dedicated HTTPS `tailscale serve` TLS ports (root-mounted, tailnet-only,
+    //   serve NOT funnel) for web UIs whose Next.js/Angular frontends emit
+    //   root-absolute assets that 404 under a stripped /path subpath:
+    //     :8443 Langfuse   :8444 Umami   :8445 GlitchTip   :10000 LiteLLM admin UI
+    //   (:8443 here is independent of tag:prod:8443 = orrery on the VPS.)
     {
       "action": "accept",
       "src":    ["autogroup:admin"],
-      "dst":    ["tag:homelab-host:22,443,3000,3001,4000,4001,8090,8428,8443,8444,8888,9428,10000,10428"]
+      "dst":    ["tag:homelab-host:22,443,3000,3001,4000,4001,8090,8428,8443,8444,8445,8888,9428,10000,10428"]
     },
     {
       // prod (the box) also reaches Umami :3001 — it proxies public analytics


### PR DESCRIPTION
## Why
GlitchTip's Angular admin UI can't run under the stripped `/glitchtip` :443 subpath — it emits `<base href="/">`, so `/static/*.js|css` resolve to root and **404** (blank page). Same class as Umami/Langfuse. Fix: dedicated root-mounted TLS port **`:8445`**, with `GLITCHTIP_DOMAIN=https://homelab.<tailnet>:8445` (mini `.env`) so Django CSRF/ALLOWED_HOSTS accept the origin.

## What
- Grant `:8445` to `autogroup:admin` on `tag:homelab-host`.
- Serve mount captured in `agentic-ai-homelab/infra/homelab-serve/serve-map.sh`; already live on the mini.
- Homepage GlitchTip link repointed to `:8445`.
- **Comment cleanup:** dropped the stale `/umami :443` lines (that mount was turned off), the false "redirect-only crumb" note, and the outdated "macOS serve allows only 443/8443/10000" claim. Dedicated UI ports now listed compactly.

## Apply
PR runs the ACL `test` dry-run; merge to `main` applies (ADR-128).