### PR TITLE
test(hotfix): classify llm_gateway as tailnet-only operator route (green main after #1367)

### DIFF
--- a/tests/integration/server/test_operator_public_mode.py
+++ b/tests/integration/server/test_operator_public_mode.py
@@ -85,11 +85,19 @@ def test_operator_public_subset_excludes_the_mutating_operator_routes() -> None:
     public = set(app_mod._OPERATOR_PUBLIC_READ_ROUTES)
     full = set(app_mod._OPERATOR_READ_ROUTES)
     assert public < full, "public subset must be strictly smaller than the full read set"
+    # The excluded set = the mutating/control routes PLUS the tailnet-only observability
+    # routes. `llm_gateway` (ADR-142, #53) is read-only but carries per-key LLM *spend* —
+    # cost data that stays on the tailnet control plane, exactly like `ops`, never the
+    # public operator surface.
     assert full - public == {
         app_mod.index_rebuild,
         app_mod.ops,
         app_mod.resilience_routes,
-    }, "operator-public must exclude the mutating/control routes (index_rebuild, ops, resilience)"
+        app_mod.llm_gateway,
+    }, (
+        "operator-public must exclude the mutating/control routes (index_rebuild, ops, "
+        "resilience) and the tailnet-only spend route (llm_gateway)"
+    )
 
 
 def test_operator_public_curated_subset_has_no_mutating_operator_writes() -> None:


### PR DESCRIPTION
**Hotfix for main** — #1367's `test-integration` failed on the full main suite (the PR's
`-fast` subset doesn't run `test_operator_public_mode.py`, so it was green there / red on main).

`#53` correctly added `llm_gateway` to `_OPERATOR_READ_ROUTES` (tailnet-only; per-key LLM
spend is cost data, like `ops`) but not the public subset — so the completeness-guard test's
hardcoded expected-excluded set was stale. This updates that set to include `llm_gateway`.
The guard did its job (forcing conscious classification); this is the classification.

Verified locally: `11 passed` across `test_operator_public_mode` + `test_app_only_mode`.
`test-e2e` was already green on main. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)