### PR TITLE
fix(compose): forward VM URL to control-plane api so the #53 spend card renders

### DIFF
--- a/compose/docker-compose.stack.yml
+++ b/compose/docker-compose.stack.yml
@@ -99,6 +99,11 @@ services:
       OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-}
       OTEL_RESOURCE_ATTRIBUTES: deployment.environment=${PODCAST_ENV:-dev}
+      # VictoriaMetrics READ endpoint for the Ops /api/ops/llm-gateway spend card (#53,
+      # ADR-142): the tailnet control-plane api reads per-key LiteLLM spend from homelab
+      # VictoriaMetrics via podcast_obs. No-op unless prod .env sets it (deploy-prod.yml
+      # sets homelab:8428). Without this passthrough the route returns configured=false.
+      PODCAST_OBS_VICTORIAMETRICS_URL: ${PODCAST_OBS_VICTORIAMETRICS_URL:-}
       # G1: put the active trace_id/span_id on every request log line (LoggingInstrumentor)
       # so an operator API log pivots to its trace. G4: drop /health spans so probe traffic
       # doesn't drown real requests in VictoriaTraces. Both are inert when exporter=none


### PR DESCRIPTION
**Hotfix** — the #53 Ops "Prod LLM gateway" card renders in prod but shows `configured:false`.

`deploy-prod.yml` writes `PODCAST_OBS_VICTORIAMETRICS_URL` into the host `.env`, but the api
service forwards env by an explicit allowlist (`${VAR:-}`), not `env_file` — so the var never
reached the container (host `.env` has it; `docker exec api env` didn't). This adds the
passthrough on the **api service only** (pipelines don't serve ops routes), next to OTEL.
Inert unless prod sets it.

Verified: `docker compose config` renders `http://homelab:8428` into the api env; the endpoint
was already proven to return live spend when the var is present. Compose-only, 5 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)