### PR TITLE
tailscale(acl): open DGX :8003 (vLLM) + :8004 (MOSS) — ADR-144 airgapped pipeline

### DIFF
--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -80,6 +80,9 @@
     //   :8001  = pyannote diarization service (#926; #943 adds /metrics).
     //   :8002  = openai-whisper service (first-party Whisper code; #953).
     //            Runs alongside speaches:8000 until #952 picks the winner.
+    //   :8003  = vLLM autoresearch slot (ADR-144: naming/summary/GI/KG/grounding
+    //            + the in-pipeline value gate; the fully-airgapped DGX profiles).
+    //   :8004  = MOSS transcribe-diarize (ASR coverage failover; #1273 / ADR-123).
     // #943 observability sidecars:
     //   :8080  = cAdvisor (per-container resource use).
     //   :9100  = node-exporter (host CPU/mem/disk/net).
@@ -88,7 +91,7 @@
     {
       "action": "accept",
       "src":    ["autogroup:admin", "tag:gha-deployer"],
-      "dst":    ["tag:dgx-llm-host:11434", "tag:dgx-llm-host:8000", "tag:dgx-llm-host:8001", "tag:dgx-llm-host:8002", "tag:dgx-llm-host:8080", "tag:dgx-llm-host:9100", "tag:dgx-llm-host:9400"]
+      "dst":    ["tag:dgx-llm-host:11434", "tag:dgx-llm-host:8000", "tag:dgx-llm-host:8001", "tag:dgx-llm-host:8002", "tag:dgx-llm-host:8003", "tag:dgx-llm-host:8004", "tag:dgx-llm-host:8080", "tag:dgx-llm-host:9100", "tag:dgx-llm-host:9400"]
     },
     {
       "action": "accept",
@@ -98,7 +101,7 @@
     {
       "action": "accept",
       "src":    ["tag:prod"],
-      "dst":    ["tag:dgx-llm-host:11434", "tag:dgx-llm-host:8000", "tag:dgx-llm-host:8001", "tag:dgx-llm-host:8002", "tag:dgx-llm-host:8080", "tag:dgx-llm-host:9100", "tag:dgx-llm-host:9400"]
+      "dst":    ["tag:dgx-llm-host:11434", "tag:dgx-llm-host:8000", "tag:dgx-llm-host:8001", "tag:dgx-llm-host:8002", "tag:dgx-llm-host:8003", "tag:dgx-llm-host:8004", "tag:dgx-llm-host:8080", "tag:dgx-llm-host:9100", "tag:dgx-llm-host:9400"]
     },
     {
       // homelab Mac mini (tag:homelab-host) scrapes DGX telemetry over the TAILNET


### PR DESCRIPTION
Opens the two DGX ports the fully-airgapped ADR-144 pipeline needs but the ACL was missing:

- `:8003` — vLLM autoresearch slot (naming/summary/GI/KG/grounding + in-pipeline value gate).
- `:8004` — MOSS transcribe-diarize (ASR coverage failover, #1273/ADR-123).

Added to the **admin** (operator devices) + **prod** grants; `:11434/:8000/:8001/:8002/:8080/:9100/:9400` were already open. dr-drill unchanged (no vLLM in the drill).

Inventory cross-check — DGX listens on `:8000 :8001 :8003 :8004 :8005 :11434`; `:8005` is intentionally NOT opened (no pipeline consumer). Merge to `main` applies via the GitOps `tailscale-acl` action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)