### PR TITLE
deps: fold Dependabot bumps; fix fastapi-0.141 + o11y test regressions

### DIFF
--- a/.github/workflows/obs-image.yml
+++ b/.github/workflows/obs-image.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Image metadata (tags + labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/podcast-obs
           tags: |

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -64,9 +64,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --upgrade pip \
     && pip install torch --index-url https://download.pytorch.org/whl/cpu \
     && pip install \
-         "fastapi>=0.115.0,<0.137.0" \
+         "fastapi>=0.141.1,<0.142.0" \
          "uvicorn[standard]>=0.48.0,<1.0.0" \
-         "prometheus-fastapi-instrumentator>=8.0.0,<9.0.0" \
+         "prometheus-fastapi-instrumentator>=8.0.1,<9.0.0" \
          "apscheduler>=3.11.2,<4.0.0" \
          ".[search,sentry]" "numpy>=1.24.0" \
     && pip install --force-reinstall --no-deps torch --index-url https://download.pytorch.org/whl/cpu \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ ml = [
 compare = [
   "streamlit>=1.41.0,<2.0.0",
   "plotly>=6.7.0,<7.0.0",
-  "pandas>=2.0.0,<3.0.0",
+  "pandas>=2.3.3,<3.0.0",
   "rouge-score>=0.1.2,<1.0.0",
 ]
 # LLM API providers - grouped for CI/test convenience
@@ -169,7 +169,7 @@ llm = [
   "openai>=1.0.0,<3.0.0",  # OpenAI API provider (RFC-013, Issue #405)
   # Google Gemini (GeminiProvider); no [gemini] extra — install via .[llm]
   # 1.x: ThinkingConfig.thinking_budget for gemini-2.5-flash (Issue #572); 0.x lacked the field
-  "google-genai>=1.0.0,<2.0.0",
+  "google-genai>=2.16.0,<3.0.0",
   "google-api-core>=2.30.3,<3.0.0",  # Required by google-genai for some operations
   "anthropic>=0.116.0,<1.0.0",  # Anthropic API provider (Issue #106)
   # Mistral API provider (Issue #106). PyPI ``mistralai`` is quarantined (no installable
@@ -208,11 +208,12 @@ dev = [
   # via simulated absence. Runtime stays a no-op unless each service's secrets are set.
   "podcast-scraper[sentry]",
   "podcast-scraper[langfuse]",
-  # Cap <0.137 (#1029): fastapi 0.137 added the internal ``_IncludedRouter`` route
-  # type, which prometheus-fastapi-instrumentator 8.0.0 (latest) cannot resolve
-  # (``'_IncludedRouter' object has no attribute 'path'``) -> /api/health 500 when
-  # metrics are enabled (prod default). Lift once the instrumentator supports it.
-  "fastapi>=0.115.0,<0.137.0",
+  # Cap <0.137 lifted (#1029 → Dependabot #1375): prometheus-fastapi-instrumentator 8.0.1
+  # added handling for FastAPI's internal ``_IncludedRouter`` route type (the 0.137
+  # regression that returned /api/health 500 when metrics are enabled). Instrumentator
+  # floor is raised to >=8.0.1 below to guarantee that fix is present. Verified
+  # /api/health green on fastapi 0.141 + instrumentator 8.0.2.
+  "fastapi>=0.141.1,<0.142.0",
   # Generic MCP server (PRD-034 / RFC-095) — a core dev/server capability, not a separate
   # extra. The official MCP Python SDK bundles FastMCP; the retrieval tools also need
   # [search] (ML deps) at runtime, same as the viewer.
@@ -222,7 +223,7 @@ dev = [
   "httpx>=0.28.1,<1.0.0",
   "uvicorn[standard]>=0.49.0,<1.0.0",
   # Prometheus exporter for /metrics (gated on PODCAST_METRICS_ENABLED in app.py).
-  "prometheus-fastapi-instrumentator>=8.0.0,<9.0.0",
+  "prometheus-fastapi-instrumentator>=8.0.1,<9.0.0",
   # In-process feed-sweep scheduler (#708); no-op unless ``scheduled_jobs:`` in viewer_operator.yaml.
   "apscheduler>=3.11.2,<4.0.0",
   "black>=26.5.1,<27.0.0",
@@ -231,7 +232,7 @@ dev = [
   "pytest>=9.0.3,<10.0.0",
   "pytest-cov>=4.1.0,<8.0.0",
   "pytest-xdist>=3.8.0,<4.0.0",  # Parallel test execution (RFC-018)
-  "pytest-rerunfailures>=16.3,<17.0",  # Flaky test reruns (RFC-018)
+  "pytest-rerunfailures>=16.4,<17.0",  # Flaky test reruns (RFC-018)
   "pytest-socket>=0.8.0,<1.0.0",  # Network blocking for E2E tests (RFC-019)
   "pytest-json-report>=1.5.0,<2.0.0",  # JSON test reports for metrics (RFC-025)
   "mypy==2.3.0",  # pinned exactly: a floating range let CI drift to 2.2.0 (differing jinja2 inference)
@@ -241,7 +242,15 @@ dev = [
   "build",
   "rouge-score>=0.1.2,<1.0.0",  # Required for ROUGE computation in evaluation loop
   "jiwer>=3.0.0,<5.0.0",  # Required for WER (Word Error Rate) computation
-  "nltk>=3.9.4,<4.0.0",  # Required for BLEU computation
+  # Floor >=3.10 (Dependabot #1373, taken): 3.10 fixes 3 download/pathsec CVEs that
+  # ``pip_audit`` (make quality) flags against 3.9.4 — CVE-2026-12061 / 12074 / 12075
+  # (zip-slip, signature bypass, SSRF in ``nltk.download`` / ``data.load``). 3.10 also
+  # ships ``nltk.inisec``, a CWD import-security hook that is incompatible with our
+  # in-tree ``.venv`` (it blocks NLTK-initiated dep imports resolving inside the CWD →
+  # breaks eval/BLEU collection from repo root). We disable ONLY that hook via
+  # ``NLTK_DISABLE_IMPORT_SECURITY=1`` (set in evaluation/scorer.py, the sole nltk import
+  # site) — the pathsec CVE fixes are in a different module and stay in effect.
+  "nltk>=3.10.0,<4.0.0",  # Required for BLEU computation
   # Code complexity analysis (RFC-031, #424). wily dropped (#1014) — it pinned radon<5.2 and was
   # near-vestigial (CI/dashboard read radon directly; only local make complexity-track used it).
   "radon>=6.0.1,<6.1",

--- a/src/podcast_scraper/evaluation/scorer.py
+++ b/src/podcast_scraper/evaluation/scorer.py
@@ -12,10 +12,21 @@ from __future__ import annotations
 import json
 import logging
 import math
+import os
 import re
 import statistics
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+# nltk >=3.10 installs ``nltk.inisec``, a CWD import-security MetaPathFinder that blocks
+# NLTK-initiated imports of any module resolving *inside* the current working directory. Our
+# ``.venv`` is in-tree, so every nltk dependency (regex, …) counts as "in CWD" and the hook
+# raises ImportError on ``from nltk.tokenize import word_tokenize`` when run from the repo root
+# (breaks eval/BLEU collection). Disable only that import hook — it must be set before the first
+# nltk import, and this module is the sole nltk import site. The 3.10 download/pathsec CVE fixes
+# (CVE-2026-12061 / 12074 / 12075) live in ``nltk.pathsec``, NOT ``inisec``, so disabling the
+# hook does not weaken them; ``setdefault`` lets an operator re-enable it by exporting =0.
+os.environ.setdefault("NLTK_DISABLE_IMPORT_SECURITY", "1")
 
 from podcast_scraper.evaluation.gi_scorer import (
     compute_gil_prediction_stats,

--- a/tests/e2e_observability/test_control_plane_e2e.py
+++ b/tests/e2e_observability/test_control_plane_e2e.py
@@ -1,8 +1,8 @@
 """Live E2E for the observability control plane (#803) — closes the loop against real APIs.
 
 Why a sibling dir (not ``tests/e2e/``): that suite's conftest blocks sockets and injects a
-pipeline ``e2e_server``; these tests need *real* network to GitHub/Sentry/Grafana/Loki and the
-target deploy. Run them explicitly (real sockets, no ``--disable-socket``)::
+pipeline ``e2e_server``; these tests need *real* network to GitHub/Sentry/Grafana/VictoriaLogs
+and the target deploy. Run them explicitly (real sockets, no ``--disable-socket``)::
 
     .venv/bin/python -m pytest tests/e2e_observability/ -q --no-cov -p no:cacheprovider
 
@@ -30,21 +30,13 @@ import pytest
 
 from podcast_obs import aggregate
 from podcast_obs.config import ObservabilityConfig, TargetConfig
-from podcast_obs.sources import github, grafana, langfuse, loki, prod_api, sentry
+from podcast_obs.sources import github, grafana, langfuse, prod_api, sentry, victoria
 
 pytestmark = pytest.mark.e2e
 
-_ALL_LABELS = {
-    "health",
-    "version",
-    "runs",
-    "deploys",
-    "cost",
-    "logs",
-    "errors",
-    "alerts",
-    "traces",
-}
+# Derived from aggregate's canonical probe list so this never drifts when a source is
+# added or removed (e.g. #1355's Loki→VictoriaLogs swap and the RFC-088 enrichment probes).
+_ALL_LABELS = {label for label, _ in aggregate._PROBES}
 
 
 def _gh_cli_token() -> str | None:
@@ -101,17 +93,24 @@ def test_github_deploys_live() -> None:
         assert deploy["conclusion"] is None or isinstance(deploy["conclusion"], str)
 
 
-def test_loki_cost_today_live() -> None:
-    data = _live_or_skip(loki.cost_today(_live_target()), "loki.cost")
-    cost = data["estimated_cost_usd"]
-    assert cost is None or (isinstance(cost, (int, float)) and cost >= 0)
+def test_victoria_cost_events_live() -> None:
+    # #1355 migrated the control-plane cost signal off Loki onto VictoriaLogs: cost is now the
+    # raw ``llm_cost`` emit_event stream (``aggregate`` maps the "cost" label to this), not a
+    # server-side ``estimated_cost_usd`` sum. Assert the wrapper shape, not values (live data).
+    data = _live_or_skip(
+        victoria.events(_live_target(), "llm_cost", window="24h", limit=5), "victoria.cost"
+    )
+    assert data["event_type"] == "llm_cost"
+    assert isinstance(data["events"], list)
+    assert data["count"] == len(data["events"])
 
 
-def test_loki_recent_logs_live() -> None:
-    data = _live_or_skip(loki.recent_logs(_live_target(), window="1h", limit=10), "loki.logs")
+def test_victoria_recent_logs_live() -> None:
+    data = _live_or_skip(
+        victoria.recent_logs(_live_target(), window="1h", limit=10), "victoria.logs"
+    )
     assert isinstance(data["lines"], list)
-    for line in data["lines"]:
-        assert {"ts", "service", "line"} <= set(line)
+    assert data["count"] == len(data["lines"])
 
 
 def test_grafana_alerts_live() -> None:

--- a/tests/integration/server/test_app_only_mode.py
+++ b/tests/integration/server/test_app_only_mode.py
@@ -22,7 +22,24 @@ pytestmark = [pytest.mark.integration]
 
 def _api_paths(output_dir: Path) -> set[str]:
     app = create_app(output_dir=output_dir)
-    return {getattr(r, "path", "") for r in app.routes if getattr(r, "path", "").startswith("/api")}
+    # fastapi >=0.137 / starlette 1.x nest each ``include_router`` call under an internal
+    # ``_IncludedRouter`` node instead of flattening its child routes into ``app.routes``,
+    # so a plain ``r.path`` scan no longer sees the mounted API routes. Pull the effective
+    # (prefixed) child paths back out via ``effective_route_contexts``; top-level routes
+    # (and older fastapi's flat routes) still expose ``.path`` directly.
+    paths: set[str] = set()
+    for route in app.routes:
+        path = getattr(route, "path", "")
+        if path:
+            paths.add(path)
+        contexts = getattr(route, "effective_route_contexts", None)
+        if callable(contexts):
+            for ctx in contexts():
+                child = getattr(ctx, "route", ctx)
+                child_path = getattr(child, "path", None)
+                if child_path:
+                    paths.add(child_path)
+    return {p for p in paths if p.startswith("/api")}
 
 
 def test_full_mode_mounts_operator_read_api(tmp_path: Path, monkeypatch) -> None:

--- a/tests/integration/server/test_operator_public_mode.py
+++ b/tests/integration/server/test_operator_public_mode.py
@@ -22,7 +22,24 @@ pytestmark = [pytest.mark.integration]
 
 def _api_paths(output_dir: Path) -> set[str]:
     app = create_app(output_dir=output_dir)
-    return {getattr(r, "path", "") for r in app.routes if getattr(r, "path", "").startswith("/api")}
+    # fastapi >=0.137 / starlette 1.x nest each ``include_router`` call under an internal
+    # ``_IncludedRouter`` node instead of flattening its child routes into ``app.routes``,
+    # so a plain ``r.path`` scan no longer sees the mounted API routes. Pull the effective
+    # (prefixed) child paths back out via ``effective_route_contexts``; top-level routes
+    # (and older fastapi's flat routes) still expose ``.path`` directly.
+    paths: set[str] = set()
+    for route in app.routes:
+        path = getattr(route, "path", "")
+        if path:
+            paths.add(path)
+        contexts = getattr(route, "effective_route_contexts", None)
+        if callable(contexts):
+            for ctx in contexts():
+                child = getattr(ctx, "route", ctx)
+                child_path = getattr(child, "path", None)
+                if child_path:
+                    paths.add(child_path)
+    return {p for p in paths if p.startswith("/api")}
 
 
 def test_operator_public_mounts_curated_read_subset(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Folds **all 6** open Dependabot dependency PRs into one owned, jointly-tested upgrade. Supersedes the individual Dependabot PRs (all closed) — we own this upgrade here.

## Bumps
| PR | Bump | Notes |
|----|------|-------|
| #1372 | google-genai 1.x → **2.16** | SDK surface we use is unchanged in 2.x (the 2.0 breaks are the new interactions API + `.to_dict()`; we use neither). Verified by surface introspection + import + gemini unit tests. |
| #1375 | fastapi `<0.137` → **0.141** | Cap existed only because fastapi 0.137's internal `_IncludedRouter` broke prometheus-fastapi-instrumentator 8.0.0; **8.0.1 fixed it** → instrumentator floor raised to `>=8.0.1`, cap lifted. `/api/health` + `/metrics` verified green with metrics enabled. `docker/api/Dockerfile` pins synced. |
| #1376 | pandas floor 2.0 → **2.3.3** | Floor only; cap unchanged. |
| #1374 | pytest-rerunfailures 16.3 → **16.4** | Patch floor. |
| #1377 | docker/metadata-action v5 → **v6** | Only break is Node 24 runtime; `obs-image.yml` runs on `ubuntu-latest` (GitHub-hosted). |
| #1373 | nltk 3.9.4 → **3.10** | **Required by the security gate** — `pip_audit` (CI `security-quality`) flags 3 download/pathsec CVEs against 3.9.4 (`CVE-2026-12061`/`12074`/`12075`: zip-slip, signature bypass, SSRF in `nltk.download`/`data.load`), all fixed in 3.10. 3.10 also ships `nltk.inisec`, a CWD import-security hook incompatible with our **in-tree `.venv`** (blocks NLTK-initiated dep imports resolving inside the CWD → breaks eval/BLEU collection from repo root). We disable **only that hook** via `NLTK_DISABLE_IMPORT_SECURITY=1`, set in `evaluation/scorer.py` (the sole nltk import site) before the first nltk import — the pathsec CVE fixes live in a different module and stay in effect. |

## Secondary effects (surfaced by full `make ci`, fixed at cause)
- **fastapi 0.141 / starlette 1.x** nest `include_router()` under an internal `_IncludedRouter`, so the app-only / operator-public route-mounting tests' flat `app.routes` scan saw no `/api` routes. Made `_api_paths` `_IncludedRouter`-aware; the behavioral sibling tests (TestClient 404s) already proved the app itself is correct. **Assertions unchanged.**
- **`tests/e2e_observability/test_control_plane_e2e.py`** still imported the `loki` source removed in #1355 (Loki → VictoriaLogs). Migrated to `victoria` and derived `_ALL_LABELS` from `aggregate._PROBES` so it can't drift when probes change.

## Validation
- **Full `make ci` green end-to-end** (twice — before and after the nltk reversal), including the docker `stack-test-ml-ci` gate (api image rebuilt on fastapi 0.141; stack up healthy; 27 stack Playwright tests pass).
- **`make quality` (pip_audit) green** on nltk 3.10 — the 3 nltk CVEs are gone.
- Repo collects with **zero collection errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)