### PR TITLE
deploy(player): wire delivery-seam secrets into prod (INTERNAL_OUTBOX_TOKEN + APP_VAPID_PUBLIC_KEY)

### DIFF
--- a/.github/workflows/deploy-player.yml
+++ b/.github/workflows/deploy-player.yml
@@ -166,6 +166,12 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ vars.PLAYER_GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.PLAYER_GOOGLE_CLIENT_SECRET }}
           APP_SESSION_SECRET: ${{ secrets.PLAYER_APP_SESSION_SECRET }}
+          # Delivery seam (#1412/#1415): shared token the infra worker presents on
+          # /internal/outbox/* (X-Internal-Token) — a runtime SECRET (tmpfs under Option A).
+          # APP_VAPID_PUBLIC_KEY is the PUBLIC half of the worker's VAPID key (served to the
+          # browser by /api/app/push/vapid-key) — not secret, always written to .env.player.
+          INTERNAL_OUTBOX_TOKEN: ${{ secrets.PLAYER_INTERNAL_OUTBOX_TOKEN }}
+          APP_VAPID_PUBLIC_KEY: ${{ secrets.PLAYER_APP_VAPID_PUBLIC_KEY }}
           # Player error DSNs → self-hosted GlitchTip project 5. SPLIT per surface (like the
           # operator's _API / _VIEWER) for flexibility: _WEB is the BROWSER DSN (dashless key,
           # via the public telemetry edge, baked into the bundle); _API is the BACKEND DSN
@@ -217,12 +223,15 @@ jobs:
             echo "PODCAST_IMAGE_TAG=${PODCAST_IMAGE_TAG}"
             echo "APP_OAUTH_PROVIDER=google"
             echo "APP_OAUTH_GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}"
+            # VAPID PUBLIC key — not secret (the browser fetches it); always written.
+            echo "APP_VAPID_PUBLIC_KEY=${APP_VAPID_PUBLIC_KEY}"
             # Runtime secrets (ADR-115 Option A): under PLAYER_SECRETS_VIA_FILES=1 these are
             # delivered as /run/secrets files + exported by the shim, so DROPPED from
             # .env.player (no secrets at rest on disk). Flag off = today's env behaviour.
             if [ "${PLAYER_SECRETS_VIA_FILES:-}" != "1" ]; then
               echo "APP_OAUTH_GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}"
               echo "APP_SESSION_SECRET=${APP_SESSION_SECRET}"
+              echo "INTERNAL_OUTBOX_TOKEN=${INTERNAL_OUTBOX_TOKEN}"
             fi
             echo "PLAYER_PORT=8092"
             # Build-time BROWSER DSN for the player bundle (compose build-arg reads this from
@@ -268,6 +277,7 @@ jobs:
           GOOGLE_CLIENT_SECRET: ${{ secrets.PLAYER_GOOGLE_CLIENT_SECRET }}
           APP_SESSION_SECRET: ${{ secrets.PLAYER_APP_SESSION_SECRET }}
           PROD_SENTRY_DSN_PLAYER_API: ${{ secrets.PROD_SENTRY_DSN_PLAYER_API }}
+          INTERNAL_OUTBOX_TOKEN: ${{ secrets.PLAYER_INTERNAL_OUTBOX_TOKEN }}
         run: |
           set -euo pipefail
           STAGE=$(mktemp -d -p /dev/shm plsecstage.XXXXXX)
@@ -275,6 +285,9 @@ jobs:
           printf '%s' "$GOOGLE_CLIENT_SECRET"       > "$STAGE/app_oauth_google_client_secret"
           printf '%s' "$APP_SESSION_SECRET"         > "$STAGE/app_session_secret"
           printf '%s' "$PROD_SENTRY_DSN_PLAYER_API" > "$STAGE/podcast_sentry_dsn_api"
+          # Delivery seam shared token → /run/secrets/internal_outbox_token; the shim
+          # exports it as INTERNAL_OUTBOX_TOKEN (filename = lowercase of the env var).
+          printf '%s' "$INTERNAL_OUTBOX_TOKEN"       > "$STAGE/internal_outbox_token"
           chmod 400 "$STAGE"/*
           ssh -i "$SSH_PROD_IDENTITY" -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$SSH_TARGET" \

--- a/compose/docker-compose.player-public.yml
+++ b/compose/docker-compose.player-public.yml
@@ -30,6 +30,13 @@ services:
       APP_OAUTH_GOOGLE_CLIENT_ID: ${APP_OAUTH_GOOGLE_CLIENT_ID:-}
       APP_OAUTH_GOOGLE_CLIENT_SECRET: ${APP_OAUTH_GOOGLE_CLIENT_SECRET:-}
       APP_SESSION_SECRET: ${APP_SESSION_SECRET:-}
+      # Delivery seam (#1412/#1415): the infra worker authenticates to /internal/outbox/*
+      # with this shared token (X-Internal-Token); empty → the endpoints 503 (disabled).
+      # APP_VAPID_PUBLIC_KEY is the PUBLIC half of the worker's VAPID key, served to the
+      # browser by GET /api/app/push/vapid-key so push subscriptions bind to the worker's
+      # keypair (the private half never leaves the homelab worker). Public value.
+      INTERNAL_OUTBOX_TOKEN: ${INTERNAL_OUTBOX_TOKEN:-}
+      APP_VAPID_PUBLIC_KEY: ${APP_VAPID_PUBLIC_KEY:-}
       APP_SESSION_COOKIE_SECURE: "true"
       # Trust X-Forwarded-* — this backend is only reachable via its own nginx proxy on
       # the compose network, so uvicorn can honor the forwarded scheme/host and derive the

--- a/compose/docker-compose.player-secrets.yml
+++ b/compose/docker-compose.player-secrets.yml
@@ -23,6 +23,7 @@ services:
       - app_oauth_google_client_secret
       - app_session_secret
       - podcast_sentry_dsn_api
+      - internal_outbox_token
 
 secrets:
   app_oauth_google_client_secret:
@@ -31,3 +32,6 @@ secrets:
     file: /dev/shm/player-secrets/app_session_secret
   podcast_sentry_dsn_api:
     file: /dev/shm/player-secrets/podcast_sentry_dsn_api
+  # Delivery seam shared token (#1412/#1415) → shim exports INTERNAL_OUTBOX_TOKEN.
+  internal_outbox_token:
+    file: /dev/shm/player-secrets/internal_outbox_token


### PR DESCRIPTION
## Why
#1441 added the internal-outbox seam + reads `INTERNAL_OUTBOX_TOKEN` and
`APP_VAPID_PUBLIC_KEY` from env, but **never wired them into the player prod deploy**. So on
the running player-api: `/internal/outbox/*` 404/503s (no token) and `GET /push/vapid-key`
503s (no key) — the homelab delivery worker (agentic-ai-homelab `infra/delivery/`) can't
drain the outbox or serve push. This closes that gap.

## What
Delivers the two values via the **existing ADR-115 pattern** (mirrors `app_session_secret`):
- **`INTERNAL_OUTBOX_TOKEN`** — runtime SECRET → tmpfs `/run/secrets/internal_outbox_token`,
  shim-exported (+ env-path fallback + compose env). Value = GH secret
  `PLAYER_INTERNAL_OUTBOX_TOKEN`, set to **match** the worker's `PODCAST_INTERNAL_OUTBOX_TOKEN`.
- **`APP_VAPID_PUBLIC_KEY`** — PUBLIC (the browser fetches it) → always written to
  `.env.player` + compose env. Value = GH secret `PLAYER_APP_VAPID_PUBLIC_KEY` = the public
  half of the worker's VAPID keypair (private half never leaves the homelab worker).

3 files, +24 lines, additive. **No behaviour change when unset** (seam stays 503 / push no-op),
so it's safe to merge ahead of the worker being pointed at prod.

## Verify after deploy
```
docker exec player-api-1 sh -c 'env | grep -E "INTERNAL_OUTBOX_TOKEN|APP_VAPID_PUBLIC_KEY" | sed "s/=.*/=<set>/"'
docker exec player-api-1 curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8000/internal/outbox/pending?channel=email   # expect 401 (no token header), not 404
curl -s https://<player-domain>/api/app/push/vapid-key   # expect {"key":"BIvs576y..."}
```

## Context
Part of the delivery arc (epic #1413). Worker side is merged + deployed on the homelab; this
is the last app-deploy wiring so the seam authenticates end-to-end. GH secrets already set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)