### PR TITLE
deploy(player): expose /internal/outbox on the tailnet for the delivery worker

### DIFF
--- a/compose/docker-compose.player-public.yml
+++ b/compose/docker-compose.player-public.yml
@@ -17,6 +17,14 @@ services:
   api:
     image: ghcr.io/chipi/podcast-scraper-stack-api:${PODCAST_IMAGE_TAG:-main}
     restart: unless-stopped
+    ports:
+      # Tailnet-only delivery-outbox seam (#1412 / ADR-145): the homelab delivery worker
+      # polls /internal/outbox/* here over the tailnet (token-gated by INTERNAL_OUTBOX_TOKEN).
+      # PLAYER_OUTBOX_LISTEN is set to the box's OWN tailnet IP by deploy-player.sh; the
+      # loopback default means NO exposure when unset. This is the low-privilege app-only api
+      # (no docker.sock, no LLM keys — the separate least-privilege plane), so binding it to
+      # the trusted tailnet is safe and is the sanctioned seam transport (NOT the public edge).
+      - "${PLAYER_OUTBOX_LISTEN:-127.0.0.1}:${PLAYER_OUTBOX_PORT:-8099}:8000"
     environment:
       PODCAST_SERVE_APP_ONLY: "1"
       # Real Google OIDC in prod (NEVER APP_OAUTH_PROVIDER=mock). provider_from_env()

--- a/infra/deploy/deploy-player.sh
+++ b/infra/deploy/deploy-player.sh
@@ -77,6 +77,22 @@ else
   echo "WARN: could not resolve 'homelab' tailnet IP; player OTEL traces will not reach VictoriaTraces" >&2
 fi
 
+# Delivery seam (#1412 / ADR-145): the homelab delivery worker polls this player-api's
+# /internal/outbox/* over the tailnet (token-gated). Publish the low-privilege player-api on
+# the BOX'S OWN tailnet IP so the worker can reach it — tailnet-only, NOT the public edge.
+# Resolve fresh (never hardcoded); loopback default = no exposure if it can't resolve.
+BOX_IP="$(tailscale ip -4 2>/dev/null | head -1 || true)"
+if [ -n "$BOX_IP" ]; then
+  if grep -qE '^PLAYER_OUTBOX_LISTEN=' "$PLAYER_ENV"; then
+    sed -i "s#^PLAYER_OUTBOX_LISTEN=.*#PLAYER_OUTBOX_LISTEN=$BOX_IP#" "$PLAYER_ENV"
+  else
+    echo "PLAYER_OUTBOX_LISTEN=$BOX_IP" >>"$PLAYER_ENV"
+  fi
+  echo "[$(date -u +%FT%TZ)] published player-api outbox on tailnet IP ${BOX_IP}:8099 (worker → /internal/outbox/*)"
+else
+  echo "WARN: could not resolve the box tailnet IP; player-api outbox stays loopback-only (delivery worker cannot reach it)" >&2
+fi
+
 # Pin the api image to a CURRENT sha — NEVER the literal :main tag. CI stopped updating
 # :main 2026-05-28, so it is 8 weeks stale: pre-ADR-116, with no /api/app/* consumer
 # surface, which makes the player 404 every API call (prod incident 2026-07-23). The


### PR DESCRIPTION
## Why (the last gap to close the delivery loop)
The homelab delivery worker (#1412) polls the player-api's `/internal/outbox/*` over the
tailnet — the sanctioned seam transport (RFC-110 / ADR-145: *"tailnet-only shared token
`INTERNAL_OUTBOX_TOKEN`"*). But the deployed `player-api:8000` is **docker-internal only**
(no `ports:` publish), so the worker on the homelab has **no network path** to it. This
publishes it on the tailnet.

## What
- **compose** — the `api` service gains `ports: "${PLAYER_OUTBOX_LISTEN:-127.0.0.1}:${PLAYER_OUTBOX_PORT:-8099}:8000"`. **Loopback default = no exposure when unset** (safe no-op).
- **deploy-player.sh** — resolves the box's own tailnet IP fresh (`tailscale ip -4`) → `PLAYER_OUTBOX_LISTEN`, mirroring the existing `HOMELAB_TAILNET_IP` resolution.

The worker then points `tenants.yaml` at `http://<vps-tailnet-ip>:8099`.

## Security
Tailnet-only, **not** the public edge. `player-api` is the deliberately **separate
least-privilege plane** (no `docker.sock`, no LLM keys — that's why it's safe on the public
consumer surface), so binding *it* to the trusted tailnet does **not** touch **T-01** (which
is about the *privileged operator api* on the *public* edge). `/internal/*` stays token-gated.

## Deploy order
Merge this → then the player deploy (`workflow_dispatch`, `override_image_sha=d852226` — the
image already carries the seam) picks up the compose + the deploy-script resolution and
publishes the outbox. Then the worker is wired + verified.

+24 lines, additive. Part of the delivery arc (epic #1413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)