### PR TITLE
tailnet(acl): allow homelab delivery worker → tag:prod:8099 (outbox seam)

### DIFF
--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -70,6 +70,16 @@
       "dst":    ["tag:prod:22,443,8443"]
     },
 
+    // Delivery worker (#1412 / ADR-145): the homelab delivery worker polls the player-api
+    // outbox (`/internal/outbox/*`, token-gated by INTERNAL_OUTBOX_TOKEN) published on the
+    // prod VPS tailnet IP at :8099 by deploy-player.sh. Tailnet-only seam transport; the
+    // token is the capability, the ACL scopes reachability to just the homelab host.
+    {
+      "action": "accept",
+      "src":    ["tag:homelab-host"],
+      "dst":    ["tag:prod:8099"]
+    },
+
     // DR drill VPS — operator + GHA reach SSH and viewer/api over HTTPS.
     // MagicDNS https://<host>.<tailnet>/ requires `tailscale serve` on the
     // node (cloud-init wires ExecStartPost on podcast-scraper.service); ACL


### PR DESCRIPTION
## The final blocker to close the delivery loop
With the player deploy live (`sha-d852226`, outbox published on the VPS tailnet IP `:8099`,
token + VAPID set), the homelab worker still **times out** reaching it — verified the
homelab host can't reach `100.124.111.115:8099`. Cause: the **default-deny tailnet ACL** only
permits `tag:prod:22,80,443,4001,8443`; port **8099 isn't allowed**, so `homelab→prod:8099`
is dropped.

## Fix
Add one accept rule: `tag:homelab-host` → `tag:prod:8099` (the worker runs on the homelab;
the outbox is on prod). Token-gated at the app (`INTERNAL_OUTBOX_TOKEN`); the ACL scopes
reachability to just the homelab host — least-privilege, tailnet-only (ADR-145).

Merges → the `tailscale-acl.yml` `apply` job syncs it to the live tailnet. Then the worker
drains the outbox and the loop closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)