### PR TITLE
feat(player): wire the weekly-digest scheduler into the prod deploy (#1412/#1415)

### DIFF
--- a/compose/docker-compose.player-public.yml
+++ b/compose/docker-compose.player-public.yml
@@ -27,6 +27,12 @@ services:
       - "${PLAYER_OUTBOX_LISTEN:-127.0.0.1}:${PLAYER_OUTBOX_PORT:-8099}:8000"
     environment:
       PODCAST_SERVE_APP_ONLY: "1"
+      # Digest scheduler (#1412/#1415): the image CMD already runs `serve --enable-jobs-api`,
+      # so the scheduler service is live — it just reads its job set from the operator YAML.
+      # Pin it to the committed, deploy-controlled player config (weekly-digest job) instead
+      # of the shared read-only corpus viewer_operator.yaml (which carries no jobs). Mounted
+      # below; consumed via the --config-file env fallback. Reproducible on a fresh box.
+      PODCAST_SERVE_CONFIG_FILE: /app/config/viewer_operator.player.yaml
       # Real Google OIDC in prod (NEVER APP_OAUTH_PROVIDER=mock). provider_from_env()
       # selects Google when these creds are present. Redirect URI to register in Google:
       #   https://<player-domain>/api/app/auth/callback
@@ -110,6 +116,10 @@ services:
     volumes:
       # Corpus is READ-ONLY here — the consumer plane reads it; per-user data is separate.
       - corpus_data:/app/output:ro
+      # Deploy-controlled scheduler config (weekly-digest job), pinned via
+      # PODCAST_SERVE_CONFIG_FILE above. Committed in-repo → present on every box after the
+      # deploy's `git reset --hard origin/<ref>`; read-only into the container.
+      - ../config/player/viewer_operator.player.yaml:/app/config/viewer_operator.player.yaml:ro
       # Per-user consumer data (playback/notes/favorites) — a HOST bind mount (like the
       # corpus) so it lives on the host FS: backupable (backup-player-appdata-prod.yml),
       # survives a container/volume prune, and operator-visible. #3.

--- a/config/player/viewer_operator.player.yaml
+++ b/config/player/viewer_operator.player.yaml
@@ -1,0 +1,18 @@
+# Player operator-config — the scheduler job set for the PUBLIC consumer player
+# (#1412 / #1415, ADR-116). DEPLOY-CONTROLLED + committed so it is reproducible on a fresh
+# box: the player deploy mounts this file and pins it via PODCAST_SERVE_CONFIG_FILE, instead
+# of the shared operator corpus <corpus>/viewer_operator.yaml (read-only to the player, and
+# operator-owned). The player's digest schedule is a player concern, not operator corpus data.
+#
+# The `digest` job fires the per-user "Your Week" digest assembler (app_digest_personal.
+# enqueue_due_digests): it reads each consented user's captures/resurfacing from the player's
+# app-data + the shared corpus, assembles the extractive graph-carrying payload, and enqueues
+# a DeliveryEnvelope to the outbox — which the homelab delivery worker (#1412) drains + sends.
+# The assembler itself gates on cadence + consent; this cron only wakes it hourly-ish.
+scheduled_jobs:
+  - name: weekly-digest
+    kind: digest
+    # Mondays 13:00 UTC — the "Your Week" weekly cadence. The assembler's own cadence gate
+    # is the source of truth for who is due; a mis-set cron only changes when it checks.
+    cron: "0 13 * * 1"
+    enabled: true


### PR DESCRIPTION
## The proper, durable fix for auto-firing digests (no image rebuild)
The delivery loop is live (worker draining the prod outbox), but the **digest never
auto-enqueues**. Diagnosis: the player image already runs `serve --enable-jobs-api` (the
scheduler *service* is running) **and already reads `$PODCAST_SERVE_CONFIG_FILE`** for its
operator YAML — but nothing set it, so the scheduler fell back to the shared **read-only
corpus** `viewer_operator.yaml`, where `scheduled_jobs:` is commented out. Zero jobs, no digest.

Fix = give the player a **deploy-controlled, committed** scheduler config. **Config + compose
only — works with the currently deployed image (`sha-d852226`), no rebuild:**

- **`config/player/viewer_operator.player.yaml`** (committed) — a `weekly-digest` job
  (`kind: digest`, Mon 13:00 UTC). `enqueue_due_digests` is already wired to the `digest`
  kind in the scheduler (#1415); the assembler gates on per-user consent + cadence.
- **player-public compose** — mount it read-only + set `PODCAST_SERVE_CONFIG_FILE` to it.

Verified on the live prod player: `serve_feature_kwargs_from_environ()` already resolves the
env → `operator_config_file`. Additive: unset env = today's behaviour. Committed config →
present on every box after the deploy's `git reset --hard origin/<ref>` → **reproducible on a
fresh box**.

## After merge
Re-run the player deploy → the scheduler picks up the weekly-digest job → consented users get
"Your Week" automatically, delivered by the homelab worker. For today's demo, manual
`enqueue_due_digests` still works on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)