### PR TITLE
feat(mcp): full observability (traces/logs/metrics/GlitchTip/Umami) + OAuth hardening (#1505)

### DIFF
--- a/.github/workflows/deploy-player.yml
+++ b/.github/workflows/deploy-player.yml
@@ -183,6 +183,10 @@ jobs:
           # (e.g. a distinct backend project, or the tailnet host for _API). Empty → no-op.
           PROD_SENTRY_DSN_PLAYER_WEB: ${{ secrets.PROD_SENTRY_DSN_PLAYER_WEB }}
           PROD_SENTRY_DSN_PLAYER_API: ${{ secrets.PROD_SENTRY_DSN_PLAYER_API }}
+          # MCP-surface backend DSN (#1505). Its own GlitchTip project (per-surface split);
+          # empty until the project + secret exist → GlitchTip no-op for the MCP, traces + logs
+          # still flow.
+          PROD_SENTRY_DSN_PLAYER_MCP: ${{ secrets.PROD_SENTRY_DSN_PLAYER_MCP }}
           # Umami website UUID (public — ships in the bundle; a var, not a secret).
           PLAYER_UMAMI_WEBSITE_ID: ${{ vars.PLAYER_UMAMI_WEBSITE_ID }}
           # ADR-115 Option A: when '1', the RUNTIME secrets (client secret, session secret,
@@ -265,6 +269,9 @@ jobs:
             if [ "${PLAYER_SECRETS_VIA_FILES:-}" != "1" ]; then
               echo "PODCAST_SENTRY_DSN_API=${PROD_SENTRY_DSN_PLAYER_API}"
             fi
+            # MCP-surface backend DSN (#1505) → its own GlitchTip project. Written to .env.player
+            # (the mcp service isn't on the tmpfs-secret shim); empty until the project exists.
+            echo "PODCAST_SENTRY_DSN_MCP=${PROD_SENTRY_DSN_PLAYER_MCP}"
             # Umami analytics build args. website-id from a GH var; the tracking
             # script URL is derived from the player domain (analytics.<domain>).
             # Both empty -> the bundle's Umami injection stays a no-op.

--- a/.github/workflows/deploy-player.yml
+++ b/.github/workflows/deploy-player.yml
@@ -272,9 +272,10 @@ jobs:
             if [ "${PLAYER_SECRETS_VIA_FILES:-}" != "1" ]; then
               echo "PODCAST_SENTRY_DSN_API=${PROD_SENTRY_DSN_PLAYER_API}"
             fi
-            # MCP-surface backend DSN (#1505) → its own GlitchTip project. Written to .env.player
-            # (the mcp service isn't on the tmpfs-secret shim); empty until the project exists.
-            echo "PODCAST_SENTRY_DSN_MCP=${PROD_SENTRY_DSN_PLAYER_MCP}"
+            # MCP-surface backend DSN (#1505). Falls back to the player API DSN so MCP errors land
+            # in the shared GlitchTip project tagged `component=mcp` + `environment` (no new project
+            # / UI needed) until a dedicated PROD_SENTRY_DSN_PLAYER_MCP is set to repoint it.
+            echo "PODCAST_SENTRY_DSN_MCP=${PROD_SENTRY_DSN_PLAYER_MCP:-${PROD_SENTRY_DSN_PLAYER_API}}"
             # Umami analytics build args. website-id from a GH var; the tracking
             # script URL is derived from the player domain (analytics.<domain>).
             # Both empty -> the bundle's Umami injection stays a no-op.

--- a/.github/workflows/deploy-player.yml
+++ b/.github/workflows/deploy-player.yml
@@ -239,6 +239,9 @@ jobs:
             # homelab tailnet IP for extra_hosts is resolved on the box by deploy-player.sh.
             echo "OTEL_TRACES_EXPORTER=otlp"
             echo "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://homelab:10428/insert/opentelemetry/v1/traces"
+            # Env-tag every span (api + mcp) so staging (laptop) and prod (VPS) split in Grafana —
+            # parity with the GlitchTip `environment` tag (#1505 staging↔prod separation).
+            echo "OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod"
             # Pin the api image to the resolved newest-published sha (never stale :main).
             echo "PODCAST_IMAGE_TAG=${PODCAST_IMAGE_TAG}"
             echo "APP_OAUTH_PROVIDER=google"
@@ -277,6 +280,11 @@ jobs:
             # Both empty -> the bundle's Umami injection stays a no-op.
             echo "VITE_UMAMI_WEBSITE_ID=${PLAYER_UMAMI_WEBSITE_ID}"
             echo "VITE_UMAMI_SRC=${PLAYER_UMAMI_WEBSITE_ID:+https://analytics.${PLAYER_DOMAIN}/script.js}"
+            # MCP server-side analytics (#1505): reuse the player Umami site — MCP events are named
+            # `mcp_tool:<tool>` (distinct from page views), POSTed to the public beacon collect API.
+            # A dedicated MCP site can be split later; env split comes from deployment.environment.
+            echo "PODCAST_MCP_UMAMI_WEBSITE_ID=${PLAYER_UMAMI_WEBSITE_ID}"
+            echo "PODCAST_MCP_UMAMI_URL=${PLAYER_UMAMI_WEBSITE_ID:+https://analytics.${PLAYER_DOMAIN}/api/send}"
             # Remote MCP (RFC-112). The shared verify-seam secret (empty → MCP inert + mcp vhost
             # skipped by deploy-player.sh). Issuer = the player apex (hosts the OAuth AS); resource
             # = the mcp subdomain (its own vhost). MCP_PORT is the loopback the Caddy mcp vhost

--- a/compose/docker-compose.player-public.yml
+++ b/compose/docker-compose.player-public.yml
@@ -166,6 +166,23 @@ services:
       APP_MCP_ALLOWED_ORIGINS: ${APP_MCP_ALLOWED_ORIGINS:-}
       PODCAST_ENV: ${PODCAST_ENV:-dev}
       PODCAST_SENTRY_DSN_API: ${PODCAST_SENTRY_DSN_API:-}
+      # o11y parity with the api (#1505). Traces: init_otel() + inbound ASGI spans + per-tool
+      # spans (mcp/telemetry.py) export over http/protobuf to the homelab VictoriaTraces OTLP
+      # ingest. Errors: its own GlitchTip DSN (per-surface split). Default `none`/empty = off;
+      # deploy-player.sh stages the exporter + endpoint + DSN host-side (never hardcoded).
+      OTEL_SERVICE_NAME: player-mcp
+      OTEL_TRACES_EXPORTER: ${OTEL_TRACES_EXPORTER:-none}
+      OTEL_METRICS_EXPORTER: none
+      OTEL_LOGS_EXPORTER: none
+      OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-}
+      OTEL_PYTHON_LOG_CORRELATION: "true"
+      PODCAST_SENTRY_DSN_MCP: ${PODCAST_SENTRY_DSN_MCP:-}
+    extra_hosts:
+      # VictoriaTraces + GlitchTip via Tailscale MagicDNS `homelab` (Docker DNS can't resolve it);
+      # static hosts entry, IP staged fresh at deploy. Loopback default so interpolation never
+      # fails when tracing is off. Mirrors the api service.
+      - "homelab:${HOMELAB_TAILNET_IP:-127.0.0.1}"
     ports:
       # Loopback only — the Caddy edge (mcp.caddy) is the public front (ADR-114).
       - "127.0.0.1:${MCP_PORT:-8009}:8009"

--- a/compose/docker-compose.player-public.yml
+++ b/compose/docker-compose.player-public.yml
@@ -177,7 +177,15 @@ services:
       OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-}
       OTEL_PYTHON_LOG_CORRELATION: "true"
+      # Env-tag traces so staging (laptop) and prod (VPS) split in Grafana (parity with the
+      # GlitchTip `environment` tag, which init_sentry already sets from PODCAST_ENV).
+      OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-}
       PODCAST_SENTRY_DSN_MCP: ${PODCAST_SENTRY_DSN_MCP:-}
+      # Umami server-side analytics (#1505): each tool call is an event, like a page view. Website
+      # id + collect URL from deploy; both empty → no-op. Hostname stamps the event's origin.
+      PODCAST_MCP_UMAMI_WEBSITE_ID: ${PODCAST_MCP_UMAMI_WEBSITE_ID:-}
+      PODCAST_MCP_UMAMI_URL: ${PODCAST_MCP_UMAMI_URL:-}
+      PODCAST_MCP_UMAMI_HOSTNAME: ${APP_MCP_RESOURCE_URL:-mcp}
     extra_hosts:
       # VictoriaTraces + GlitchTip via Tailscale MagicDNS `homelab` (Docker DNS can't resolve it);
       # static hosts entry, IP staged fresh at deploy. Loopback default so interpolation never

--- a/compose/docker-compose.player-public.yml
+++ b/compose/docker-compose.player-public.yml
@@ -165,7 +165,6 @@ services:
       # this empty is safe; set it (e.g. https://claude.ai) to lock the browser surface down.
       APP_MCP_ALLOWED_ORIGINS: ${APP_MCP_ALLOWED_ORIGINS:-}
       PODCAST_ENV: ${PODCAST_ENV:-dev}
-      PODCAST_SENTRY_DSN_API: ${PODCAST_SENTRY_DSN_API:-}
       # o11y parity with the api (#1505). Traces: init_otel() + inbound ASGI spans + per-tool
       # spans (mcp/telemetry.py) export over http/protobuf to the homelab VictoriaTraces OTLP
       # ingest. Errors: its own GlitchTip DSN (per-surface split). Default `none`/empty = off;

--- a/docs/wip/DESIGN-GAPS-2026-08-08.md
+++ b/docs/wip/DESIGN-GAPS-2026-08-08.md
@@ -1,0 +1,107 @@
+# Design / product gaps — 2026-08-08
+
+Running list of design + product gaps to close. Append new gaps as `## GAP-N`.
+
+---
+
+## GAP-1 — Universal brand icon (player + MCP connector, one asset everywhere)
+
+**Need.** A single, recognizable "Close Listening" icon that works **across every surface** —
+the player app *and* the remote MCP connector — so the brand is consistent wherever it appears.
+
+### Where it has to render (all from one master)
+| Surface | Sizes / form | Notes |
+|---|---|---|
+| Player PWA install icon | 192², 512², **maskable** (≥20% safe padding) | `web/learning-player/public` manifest icons |
+| Favicon (browser tab, claude.ai connector list often uses the domain favicon) | 16², 32², 48² (+ SVG) | must stay legible at 16px |
+| iOS / Android app icon (Capacitor mobile shell, #1310) | 1024² master → platform sets | square, no transparency for iOS |
+| **MCP connector logo in claude.ai** | small square, light + dark bg | how claude.ai sources it is an OPEN QUESTION (below) |
+| Social / OG card (optional) | 1200×630 lockup | icon + wordmark |
+
+### Requirements
+- **One SVG master** → deterministic export to all raster sizes (script it, don't hand-cut).
+- **Square, centered, safe margins** so the maskable/rounded variants don't clip.
+- **Legible at 16px** (favicon + connector list) AND clean at 512px+ (app icon).
+- **Light- and dark-background safe** (connector lists + tabs vary); consider a mono/flat variant
+  for tiny sizes and a full-color variant for large.
+- **No text inside the glyph** (text is unreadable at 16px) — wordmark is a separate lockup.
+
+### Open questions (need answers before finalizing)
+1. **How does claude.ai pick the connector icon?** Domain favicon of `mcp.closelistening.app`,
+   an MCP server-metadata field, or the `/.well-known` doc? → determines what we must serve and
+   where. (Action: confirm from the MCP/claude.ai connector docs.)
+2. Concept direction — the glyph motif. Options to explore (pick one):
+   - listening/audio: soundwave, headphones, an ear
+   - knowledge/graph: nodes+edges (ties to the KG/GI product), a "listening → understanding" mark
+   - a hybrid (waveform that resolves into a graph)
+3. Palette + does it need to match the existing player theme tokens?
+
+### Acceptance
+- `assets/brand/icon.svg` master committed + an export script producing every size above.
+- Player manifest + favicons wired to the new icon; mobile app icon set regenerated.
+- MCP connector shows the icon in claude.ai (once we know how it's sourced).
+- Renders cleanly at 16px and 512px on both light and dark backgrounds.
+
+---
+
+## GAP-2 — iOS app splash / launch screen (graphical, on-brand)
+
+**Need.** A **graphical splash screen** for the iOS app (the Capacitor mobile shell, #1310),
+shown on launch — something visually rich and **in tune with the player's design tokens**
+(palette / theme), and coherent with the GAP-1 icon so launch → app feels like one brand.
+
+### Requirements
+- **On-brand + graphical**, driven by the **existing player design tokens** (colors/theme in
+  `web/learning-player`), not a plain logo-on-white. Should feel like a designed screen.
+- **Capacitor convention:** a single **2732×2732** master with all key content in the centered
+  **safe zone** (the tooling center-crops it to every device size / aspect ratio), or a native
+  launch storyboard. Wire via `@capacitor/splash-screen` + `capacitor.config`.
+- **Light + dark variants** (iOS honours a dark launch screen).
+- **Reuse the GAP-1 icon/glyph** as the focal element for brand continuity.
+- Keep it lightweight (launch assets ship in the bundle).
+
+### Open questions
+1. Static image vs. a subtle branded gradient/pattern behind the icon? (No animation at true
+   launch — the OS shows a static launch image; any motion is a post-launch in-app splash.)
+2. Android splash too, or iOS-only for now? (Capacitor can do both from the same master —
+   cheap to include; confirm scope.)
+
+### Acceptance
+- Splash master (2732², light + dark) committed under `assets/brand/`; export/config wired via
+  Capacitor.
+- Renders correctly on iOS launch across device sizes (centered safe zone, no clipping) in both
+  light and dark mode.
+- Visually consistent with the GAP-1 icon + the player theme tokens.
+
+---
+
+## GAP-3 — Build the Android app + validate on iOS **and** Android
+
+**Need.** The mobile shell (Capacitor, #1310) has been built for **iOS**; **Android is missing**.
+Add the Android target, build it, and validate the app on **both** platforms.
+
+### Requirements
+- Capacitor **Android** target: `npx cap add android`, gradle build → debug APK (dev) and a
+  signed release AAB (store).
+- **Both platforms tested:** app launches, the **Google OAuth deep-link** works (native callback
+  uses the custom scheme `closelistening://auth` — `NATIVE_AUTH_SCHEME` in `app_auth.py`), and
+  core flows (feed, player, Your Week) work on iOS + Android.
+- Android must register the **`closelistening://` intent-filter** so the OAuth deep-link callback
+  returns into the app (parity with the iOS custom-scheme handling).
+- Reuse GAP-1 (app icon) + GAP-2 (splash) once those land.
+
+### Dependency / handover
+- Needs the **build runbook/handover**. If there is no existing iOS-build handover to adapt,
+  the operator will supply an **Android-build handover from another app/worktree**. → this GAP is
+  effectively **blocked on that handover doc** landing here.
+
+### Open questions
+- Android **signing**: keystore creation + where it's stored (never in git).
+- min/target SDK; Android Studio/gradle locally vs. CI build.
+- Emulator vs. real-device test matrix.
+- Note (ops): a prior **iOS build hung ~5.5h** — set a realistic kill-deadline + live progress
+  watch on the Android/gradle build too; don't let it run unbounded.
+
+### Acceptance
+- Android app builds (APK debug + signed AAB), launches, Google OAuth deep-link works, core flows
+  validated; iOS re-validated green; the build steps documented as a runbook in `docs/`.

--- a/docs/wip/VALIDATION-BACKLOG-2026-08-08.md
+++ b/docs/wip/VALIDATION-BACKLOG-2026-08-08.md
@@ -1,0 +1,57 @@
+# Validation backlog & delivery plan — 2026-08-08
+
+Session context: this session shipped the remote MCP Host-header fix + pip-audit ignore
+(deployed `sha-0f3cd36`), the tailnet self-devices ACL, and the DGX diarization guardrail
+cherry-pick (on main `24a41d3c`, direct-to-main). It also fixed the prod corpus's `no_index`
+(reindex) + relational/enrichment tool gaps (enrich-edges + enrichment, run live on the May-05
+corpus). Branch/stash hygiene done (5 merged branches + 3 stashes deleted).
+
+This doc is the **validation backlog** — what we did but haven't fully validated — plus the
+delivery order. **DGX is down; do not depend on it.** Focus order: **Player "Your Week" → Remote
+MCP → Corpus prep (on operator go)**.
+
+## Priority 1 — Player #1487 "Your Week" (live validation)
+Merged + CI-green, but **prod is still `sha-0f3cd36`** (before it). Deliver:
+- Redeploy prod to the `sha-24a41d3c` image (gated) — carries #1487 + the DGX guardrail (guardrail
+  is inert on the player runtime).
+- Verify: "Your Week" renders in-app; the hardened `digest-scheduler` sidecar auto-fires the weekly
+  digest (heartbeat healthy, a digest actually enqueues).
+- Agent-doable except the prod gate approval.
+
+## Priority 2 — Remote MCP: the claude.ai OAuth connector flow
+Validated with a **PAT** only. The **browser OAuth path is unproven**: DCR → authorize →
+**consent** → token.
+- Operator: add the connector at `https://mcp.closelistening.app/mcp`, complete the OAuth flow.
+- Agent: watch the mcp/api logs during the flow; fix any DCR/consent/callback failure.
+
+## Priority 3 — Corpus prep + deploy (ON OPERATOR GO; no DGX/Whisper)
+Reuse the local **diarized DeepSeek corpus** `v2.5-deepseek-fixed-100ep` (in the
+`podcast_scraper-ai-ml-improvements` worktree). All prep is deterministic:
+- `enrich-edges` (adds `HAS_EPISODE`), deterministic enrichment stage (`enrichments/`), dedup to
+  newest run per feed, regen `feeds.spec.yaml` if export needs it.
+- `export-corpus` → transfer → `restore-corpus-prod` → **redeploy** (NEVER `docker restart` — it
+  drops the tmpfs `/dev/shm/player-secrets` and crashed player-api this session).
+- Then **re-validate all 38 MCP tools** on the DeepSeek corpus (speaker tools should light up —
+  82% quotes have `speaker_id`).
+- Note: the live May-05 prod corpus is currently **hand-modified** (enrich-edges + enrichment run
+  directly on the volume); it has relational + enrichment data but **no diarization**. Replaced by
+  this deploy.
+
+## Priority 4 — `consensus_search` ML enricher
+Needs the `topic_consensus` enricher, which needs (a) CLI **provider-wiring** (EmbeddingProvider /
+ConsensusScorer injection — the CLI auto-registers deterministic enrichers only), (b) an offline
+NLI model. Code change + model. Tracked in #1497.
+
+## Priority 5 — Prevention (#1494 / #1497) — unbuilt
+Deploy-time **staleness guard** (index schema + edge-vocabulary), a **reprocess-GI-from-existing-
+transcripts** flag, incremental/embed-free indexing. Prevents the drift recurring.
+
+## Deferred — DGX-dependent (box is DOWN)
+- Validate the DGX diarization guardrail (`flock` cross-process single-flight) against a **live
+  DGX** — unit-tested only.
+- Reconcile `production` branch (in `-infra`) — it still holds the 2 original DGX commits now on
+  main; rebase/clean when convenient.
+
+## Related issues
+- #1494 — scalable + incremental search indexing.
+- #1497 — MCP relational tools empty on prod (edge-vocabulary drift + diarization root cause).

--- a/infra/caddy/mcp.caddy
+++ b/infra/caddy/mcp.caddy
@@ -21,9 +21,20 @@ mcp.player.example.com {
 	# Per-site ACME email — info@<player domain> (the deploy seds player.example.com).
 	tls info@player.example.com
 
-	# Everything proxies to the MCP server. Streamable HTTP responses can stream (chunked / SSE),
-	# so disable response buffering (flush_interval -1) — otherwise a long tool call would buffer.
-	reverse_proxy 127.0.0.1:8009 {
-		flush_interval -1
+	# ONLY the MCP endpoint + the public RFC 9728 discovery doc are exposed. Everything else —
+	# notably /metrics (the o11y Prometheus registry, served UNGATED on :8009) — must NOT be public:
+	# Alloy scrapes :8009/metrics HOST-INTERNALLY over the docker network, never through this edge
+	# (advisor review H1, #1505). A bare `reverse_proxy` forwarded ALL paths incl. /metrics.
+	@mcp path /mcp /mcp/* /.well-known/*
+	handle @mcp {
+		# Streamable HTTP responses can stream (chunked / SSE), so disable response buffering
+		# (flush_interval -1) — otherwise a long tool call would buffer.
+		reverse_proxy 127.0.0.1:8009 {
+			flush_interval -1
+		}
+	}
+	# Default-deny everything else on this public surface (no /metrics, no stray paths).
+	handle {
+		respond "Not Found" 404
 	}
 }

--- a/src/podcast_scraper/mcp/server.py
+++ b/src/podcast_scraper/mcp/server.py
@@ -89,7 +89,14 @@ def _enveloped(fn: Callable[..., Any]) -> Callable[..., dict]:
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> dict:
-        return _safe(lambda: fn(*args, **kwargs))
+        # Per-tool observability (#1505): span + structured log + metric, best-effort. The tool
+        # NAME comes from the wrapped fn; user_id from the auth contextvar. Never breaks the call.
+        from .telemetry import observe_tool_call
+
+        with observe_tool_call(fn.__name__) as call:
+            result = _safe(lambda: fn(*args, **kwargs))
+            call.set_result(result)
+            return result
 
     return wrapper
 
@@ -676,4 +683,36 @@ def run_server(
         raise ValueError(f"unsupported transport: {transport!r} (use 'stdio' or 'http')")
     import uvicorn
 
-    uvicorn.run(build_http_app(corpus_dir), host=host, port=port)
+    # o11y parity with the api (#1505): OTel traces + GlitchTip errors + inbound request spans.
+    # All best-effort — telemetry never blocks the server from starting (ADR-120). No-ops unless
+    # the OTEL_*/PODCAST_SENTRY_DSN_MCP env is set (dev + tests stay silent).
+    try:
+        from podcast_scraper.utils.otel_init import init_otel
+
+        init_otel()
+    except Exception:  # noqa: BLE001 - never block serving on tracing
+        logger.debug("mcp otel init skipped", exc_info=True)
+    try:
+        from podcast_scraper.utils.sentry_init import init_sentry
+
+        init_sentry("mcp")
+    except Exception:  # noqa: BLE001 - never block serving on error reporting
+        logger.debug("mcp sentry init skipped", exc_info=True)
+
+    uvicorn.run(_instrument_asgi(build_http_app(corpus_dir)), host=host, port=port)
+
+
+def _instrument_asgi(app: Any) -> Any:
+    """Wrap the ASGI app with OTel inbound-request spans (so every ``/mcp`` gets a ``trace_id``).
+
+    No-op if the OTel ASGI instrumentation isn't installed or tracing isn't configured. The tool
+    spans (:mod:`mcp.telemetry`) nest under these server spans, and the trace propagates onward to
+    the api's ``/internal/mcp/verify`` via the auto-instrumented outbound HTTP client.
+    """
+    try:
+        from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
+
+        return OpenTelemetryMiddleware(app)
+    except Exception:  # noqa: BLE001 - no ASGI instrumentor → serve un-instrumented
+        logger.debug("mcp ASGI instrumentation skipped", exc_info=True)
+        return app

--- a/src/podcast_scraper/mcp/server.py
+++ b/src/podcast_scraper/mcp/server.py
@@ -699,7 +699,36 @@ def run_server(
     except Exception:  # noqa: BLE001 - never block serving on error reporting
         logger.debug("mcp sentry init skipped", exc_info=True)
 
-    uvicorn.run(_instrument_asgi(build_http_app(corpus_dir)), host=host, port=port)
+    uvicorn.run(_instrument_asgi(_with_metrics(build_http_app(corpus_dir))), host=host, port=port)
+
+
+def _with_metrics(app: Any) -> Any:
+    """Serve Prometheus ``/metrics`` (the per-tool counters) UNGATED, delegating everything else.
+
+    Wrapped OUTSIDE the auth middleware so a scraper needs no bearer; the mcp binds loopback
+    (:8009, Caddy fronts ``/mcp`` publicly), so ``/metrics`` is internal-only. No-op if
+    prometheus_client isn't installed.
+    """
+    try:
+        from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+    except Exception:  # noqa: BLE001 - no client → no /metrics endpoint
+        return app
+
+    async def _asgi(scope: dict, receive: Any, send: Any) -> None:
+        if scope.get("type") == "http" and scope.get("path") == "/metrics":
+            body = generate_latest()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", CONTENT_TYPE_LATEST.encode())],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+            return
+        await app(scope, receive, send)
+
+    return _asgi
 
 
 def _instrument_asgi(app: Any) -> Any:

--- a/src/podcast_scraper/mcp/telemetry.py
+++ b/src/podcast_scraper/mcp/telemetry.py
@@ -14,14 +14,25 @@ leave the process — never query args, corpus content, or transcripts.
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import threading
 import time
+import urllib.request
 from contextlib import contextmanager
 from typing import Any, Iterator, Optional
 
 from .auth import current_mcp_user
 
 _LOGGER = logging.getLogger("podcast_scraper.mcp.tool")
+
+# Umami server-side analytics (#1505): a tool call is a "page view" for the MCP surface. We POST an
+# event to Umami's collect API (parity with the browser beacon). Website id + collect URL come from
+# env; both unset → no-op. Umami REQUIRES a User-Agent header (it drops UA-less events).
+_UMAMI_WEBSITE_ID = "PODCAST_MCP_UMAMI_WEBSITE_ID"
+_UMAMI_COLLECT_URL = "PODCAST_MCP_UMAMI_URL"  # e.g. https://analytics.<domain>/api/send
+_UMAMI_HOSTNAME = "PODCAST_MCP_UMAMI_HOSTNAME"  # the MCP public host, for the event hostname
 
 # Prometheus metrics — module-level singletons; a missing prometheus_client (or duplicate
 # registration under test reload) degrades to no-op rather than breaking tool calls.
@@ -120,5 +131,52 @@ def _emit(tool: str, ok: bool, duration_s: float, user: Optional[str], span: Any
             ok,
             duration_s * 1000.0,
         )
+    except Exception:  # noqa: BLE001
+        pass
+    _emit_umami(tool, ok)
+
+
+def _emit_umami(tool: str, ok: bool) -> None:
+    """Fire-and-forget a tool-call event to Umami (server-side beacon). No-op unless configured.
+
+    Runs on a daemon thread so a slow/unreachable analytics host never delays a tool call, and
+    every failure is swallowed (ADR-120). Privacy: sends the tool name + ok only — no user_id
+    (analytics is aggregate, not per-user), no query args, no corpus content.
+    """
+    website = os.environ.get(_UMAMI_WEBSITE_ID, "").strip()
+    url = os.environ.get(_UMAMI_COLLECT_URL, "").strip()
+    if not website or not url:
+        return
+    hostname = os.environ.get(_UMAMI_HOSTNAME, "").strip() or "mcp"
+    body = json.dumps(
+        {
+            "type": "event",
+            "payload": {
+                "website": website,
+                "hostname": hostname,
+                "name": f"mcp_tool:{tool}",
+                "data": {"tool": tool, "ok": ok},
+            },
+        }
+    ).encode()
+
+    def _send() -> None:
+        try:
+            req = urllib.request.Request(
+                url,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    # Umami drops events without a User-Agent; identify the server-side sender.
+                    "User-Agent": "podcast-mcp/1.0 (+server-side)",
+                },
+                method="POST",
+            )
+            urllib.request.urlopen(req, timeout=4)  # noqa: S310 - fixed https collect URL from env
+        except Exception:  # noqa: BLE001 - analytics never breaks a tool call
+            pass
+
+    try:
+        threading.Thread(target=_send, name="umami-mcp", daemon=True).start()
     except Exception:  # noqa: BLE001
         pass

--- a/src/podcast_scraper/mcp/telemetry.py
+++ b/src/podcast_scraper/mcp/telemetry.py
@@ -1,0 +1,124 @@
+"""Per-tool observability for the remote MCP surface (#1505).
+
+Every registered tool call emits three signals, all best-effort and NEVER able to break the
+call (ADR-120 — telemetry never downs the app):
+
+- **trace**: an OTel span ``mcp.tool.<name>`` (child of the inbound ``POST /mcp`` server span),
+  attributed with the tool, the authenticated ``user_id``, and ``ok``.
+- **log**: a structured line (tool, user_id, duration_ms, ok) with ``trace_id`` correlation.
+- **metric**: ``mcp_tool_calls_total{tool,ok}`` + ``mcp_tool_duration_seconds{tool}``.
+
+Privacy (mirrors the MCP no-leak review): only the tool NAME, the ``user_id``, ``ok`` and timing
+leave the process — never query args, corpus content, or transcripts.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+from .auth import current_mcp_user
+
+_LOGGER = logging.getLogger("podcast_scraper.mcp.tool")
+
+# Prometheus metrics — module-level singletons; a missing prometheus_client (or duplicate
+# registration under test reload) degrades to no-op rather than breaking tool calls.
+try:  # pragma: no cover - exercised via the metrics endpoint
+    from prometheus_client import Counter, Histogram
+
+    _CALLS: Optional[Any] = Counter(
+        "mcp_tool_calls_total", "MCP tool calls by tool + outcome", ["tool", "ok"]
+    )
+    _DURATION: Optional[Any] = Histogram(
+        "mcp_tool_duration_seconds", "MCP tool call wall-clock duration", ["tool"]
+    )
+except Exception:  # noqa: BLE001 - metrics are optional; never break import
+    _CALLS = None
+    _DURATION = None
+
+
+class _ToolCall:
+    """Mutable handle so the caller can hand back the result envelope for the ``ok`` verdict."""
+
+    __slots__ = ("tool", "ok")
+
+    def __init__(self, tool: str) -> None:
+        self.tool = tool
+        self.ok = True
+
+    def set_result(self, result: Any) -> None:
+        # Tools return the uniform ``{ok, data, note}`` envelope; a raised exception (ok stays
+        # False via the except branch below) or ``ok=False`` both count as not-ok.
+        if isinstance(result, dict) and "ok" in result:
+            self.ok = bool(result.get("ok"))
+
+
+@contextmanager
+def _maybe_span(tool: str) -> Iterator[Any]:
+    """Yield an OTel span for the tool call, or ``None`` when tracing isn't wired.
+
+    The span context manager is resolved OUTSIDE any ``except`` so an exception thrown into the
+    ``yield`` (a failing tool body) propagates cleanly — yielding from within an ``except`` would
+    raise ``RuntimeError: generator didn't stop after throw()``.
+    """
+    span_cm = None
+    try:
+        from opentelemetry import trace
+
+        span_cm = trace.get_tracer("podcast_scraper.mcp").start_as_current_span(f"mcp.tool.{tool}")
+    except Exception:  # noqa: BLE001 - no OTel API installed → run un-spanned
+        span_cm = None
+    if span_cm is None:
+        yield None
+        return
+    with span_cm as span:
+        yield span
+
+
+@contextmanager
+def observe_tool_call(tool: str) -> Iterator[_ToolCall]:
+    """Wrap a tool call so it emits span + structured log + metric. Best-effort throughout."""
+    call = _ToolCall(tool)
+    start = time.perf_counter()
+    with _maybe_span(tool) as span:
+        try:
+            yield call
+        except Exception:
+            call.ok = False
+            raise
+        finally:
+            duration_s = time.perf_counter() - start
+            try:
+                user = current_mcp_user.get()
+            except Exception:  # noqa: BLE001
+                user = None
+            _emit(tool, call.ok, duration_s, user, span)
+
+
+def _emit(tool: str, ok: bool, duration_s: float, user: Optional[str], span: Any) -> None:
+    if span is not None:
+        try:
+            span.set_attribute("mcp.tool", tool)
+            span.set_attribute("mcp.ok", ok)
+            if user:
+                span.set_attribute("mcp.user_id", user)
+        except Exception:  # noqa: BLE001
+            pass
+    if _CALLS is not None and _DURATION is not None:
+        try:
+            _CALLS.labels(tool=tool, ok=str(ok).lower()).inc()
+            _DURATION.labels(tool=tool).observe(duration_s)
+        except Exception:  # noqa: BLE001
+            pass
+    try:
+        _LOGGER.info(
+            "mcp tool call tool=%s user=%s ok=%s duration_ms=%.1f",
+            tool,
+            user or "-",
+            ok,
+            duration_s * 1000.0,
+        )
+    except Exception:  # noqa: BLE001
+        pass

--- a/src/podcast_scraper/mcp/telemetry.py
+++ b/src/podcast_scraper/mcp/telemetry.py
@@ -148,6 +148,11 @@ def _emit_umami(tool: str, ok: bool) -> None:
     if not website or not url:
         return
     hostname = os.environ.get(_UMAMI_HOSTNAME, "").strip() or "mcp"
+    # The env often carries the full resource URL (APP_MCP_RESOURCE_URL); Umami wants a bare host.
+    if "://" in hostname:
+        from urllib.parse import urlparse
+
+        hostname = urlparse(hostname).hostname or hostname
     body = json.dumps(
         {
             "type": "event",

--- a/src/podcast_scraper/mcp/telemetry.py
+++ b/src/podcast_scraper/mcp/telemetry.py
@@ -14,6 +14,7 @@ leave the process — never query args, corpus content, or transcripts.
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import logging
 import os
@@ -26,6 +27,12 @@ from typing import Any, Iterator, Optional
 from .auth import current_mcp_user
 
 _LOGGER = logging.getLogger("podcast_scraper.mcp.tool")
+
+# Umami sender: a SMALL bounded pool (not one daemon thread per call — advisor L1). A semaphore
+# caps queued+running sends so a hung/slow analytics host can't accumulate threads under load; past
+# the cap we DROP the event (analytics is best-effort; a tool call must never wait on it).
+_UMAMI_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=2, thread_name_prefix="umami-mcp")
+_UMAMI_INFLIGHT = threading.BoundedSemaphore(8)
 
 # Umami server-side analytics (#1505): a tool call is a "page view" for the MCP surface. We POST an
 # event to Umami's collect API (parity with the browser beacon). Website id + collect URL come from
@@ -165,6 +172,11 @@ def _emit_umami(tool: str, ok: bool) -> None:
         }
     ).encode()
 
+    # Backpressure: if too many sends are already in flight (slow/hung Umami), drop this event
+    # rather than queue unboundedly. Released in _send's finally.
+    if not _UMAMI_INFLIGHT.acquire(blocking=False):
+        return
+
     def _send() -> None:
         try:
             req = urllib.request.Request(
@@ -180,8 +192,10 @@ def _emit_umami(tool: str, ok: bool) -> None:
             urllib.request.urlopen(req, timeout=4)  # noqa: S310 - fixed https collect URL from env
         except Exception:  # noqa: BLE001 - analytics never breaks a tool call
             pass
+        finally:
+            _UMAMI_INFLIGHT.release()
 
     try:
-        threading.Thread(target=_send, name="umami-mcp", daemon=True).start()
-    except Exception:  # noqa: BLE001
-        pass
+        _UMAMI_POOL.submit(_send)
+    except Exception:  # noqa: BLE001 - pool shutdown/full → drop, don't break the call
+        _UMAMI_INFLIGHT.release()

--- a/src/podcast_scraper/server/app_oauth_server.py
+++ b/src/podcast_scraper/server/app_oauth_server.py
@@ -40,6 +40,9 @@ _SUPPORTED_SCOPES = frozenset({"mcp:read"})  # v1: read-only; room for mcp:expor
 
 _MAX_CLIENTS = 2000  # disk-fill guard on unauthenticated DCR (H4)
 _MAX_REDIRECT_URIS = 10  # per-client cap (L2)
+# Prune DCR clients that never completed a flow (no live grant) after this age, so an
+# unauthenticated registration flood can't PERMANENTLY fill the store at _MAX_CLIENTS (advisor LOW).
+_CLIENT_UNUSED_TTL_S = 7 * 24 * 3600
 
 _ACCESS_PREFIX = "clp_mcpat_"
 _REFRESH_PREFIX = "clp_mcprt_"
@@ -102,6 +105,11 @@ def register_client(
     }
     with _lock(data_dir, _CLIENTS_FILE):
         clients = _read(data_dir, _CLIENTS_FILE)
+        # Drop stale never-used clients first (advisor LOW): a client with NO live grant that is
+        # older than the unused-TTL is a registration that never completed a flow — reclaim it so a
+        # DCR flood can't permanently wedge the store at the cap. Clients with a live grant (active
+        # code/access/refresh) are always kept.
+        clients = _prune_stale_clients(clients, _read(data_dir, _GRANTS_FILE))
         if len(clients) >= _MAX_CLIENTS:
             # Unauthenticated DCR: refuse once the store is full rather than grow without bound.
             raise ValueError("client registration limit reached")
@@ -241,6 +249,10 @@ def create_authorization_code(
 
 def _pkce_ok(verifier: str, challenge: str) -> bool:
     """S256: base64url(sha256(verifier)) == challenge (no padding)."""
+    # RFC 7636 §4.1: the verifier is 43–128 chars. Enforce the length bounds so a lazy/malicious
+    # client can't self-downgrade to a low-entropy verifier (advisor MED #1505).
+    if not (43 <= len(verifier) <= 128):
+        return False
     try:
         raw = verifier.encode("ascii")  # PKCE verifiers are ASCII (RFC 7636); non-ASCII → reject
     except UnicodeEncodeError:
@@ -254,6 +266,26 @@ def _prune_expired(grants: dict[str, Any]) -> dict[str, Any]:
     """Drop expired codes/access/refresh records so ``oauth_grants.json`` stays bounded (M2)."""
     now = _now()
     return {h: rec for h, rec in grants.items() if int(rec.get("expires_at", 0)) >= now}
+
+
+def _prune_stale_clients(clients: dict[str, Any], grants: dict[str, Any]) -> dict[str, Any]:
+    """Drop DCR clients with no LIVE grant that are older than the unused-TTL (advisor LOW).
+
+    A client is kept if it has any non-expired grant (code/access/refresh → an active connection)
+    OR it was registered within the unused-TTL (give an in-flight authorize time to complete).
+    Everything else is a registration that never completed a flow — reclaim its slot.
+    """
+    now = _now()
+    active = {
+        str(rec.get("client_id"))
+        for rec in _prune_expired(grants).values()
+        if isinstance(rec, dict) and rec.get("client_id")
+    }
+    return {
+        cid: c
+        for cid, c in clients.items()
+        if cid in active or (now - int(c.get("created_at", 0))) < _CLIENT_UNUSED_TTL_S
+    }
 
 
 def _resource_aud() -> str:

--- a/src/podcast_scraper/utils/sentry_init.py
+++ b/src/podcast_scraper/utils/sentry_init.py
@@ -28,11 +28,13 @@ from typing import Literal, Optional
 
 _LOGGER = logging.getLogger(__name__)
 
-Component = Literal["api", "pipeline"]
+Component = Literal["api", "pipeline", "mcp"]
 
 _DSN_ENV = {
     "api": "PODCAST_SENTRY_DSN_API",
     "pipeline": "PODCAST_SENTRY_DSN_PIPELINE",
+    # The remote MCP server (RFC-112) — its own GlitchTip project, per the per-surface DSN split.
+    "mcp": "PODCAST_SENTRY_DSN_MCP",
 }
 
 # Dev rung of the env ladder (dev → prod; the backend has no staging). On the
@@ -63,6 +65,8 @@ def _use_dev_default() -> bool:
 _DEFAULT_TRACES_SAMPLE_RATE: dict[Component, float] = {
     "api": 0.1,
     "pipeline": 0.0,
+    # Long-lived server like the api, low request volume at hobby scale — same 10% sample.
+    "mcp": 0.1,
 }
 
 # Substrings that mark a key as sensitive — scrubbed from anything we send.

--- a/tests/unit/mcp/test_http_app_serving.py
+++ b/tests/unit/mcp/test_http_app_serving.py
@@ -64,3 +64,105 @@ def test_http_app_serves_discovery_and_gates_unauth(monkeypatch: pytest.MonkeyPa
     )
     assert status == 401
     assert b"resource_metadata=" in headers[b"www-authenticate"]
+
+
+def test_run_server_http_wires_otel_sentry_and_serves(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The http path inits OTel + GlitchTip, then serves the metrics-wrapped instrumented app."""
+    import podcast_scraper.mcp.server as srv
+    import podcast_scraper.utils.otel_init as otel_init
+    import podcast_scraper.utils.sentry_init as sentry_init
+
+    seen: dict = {"otel": 0, "sentry": None, "served": None}
+
+    monkeypatch.setattr(srv, "build_http_app", lambda corpus: {"app": corpus})
+    monkeypatch.setattr(otel_init, "init_otel", lambda: seen.__setitem__("otel", seen["otel"] + 1))
+    monkeypatch.setattr(sentry_init, "init_sentry", lambda comp: seen.__setitem__("sentry", comp))
+
+    import uvicorn
+
+    monkeypatch.setattr(
+        uvicorn,
+        "run",
+        lambda app, host, port: seen.__setitem__("served", (callable(app), host, port)),
+    )
+
+    srv.run_server(_CORPUS, transport="http", host="127.0.0.1", port=8009)
+
+    assert seen["otel"] == 1
+    assert seen["sentry"] == "mcp"  # GlitchTip component tag
+    assert seen["served"] == (True, "127.0.0.1", 8009)  # a callable ASGI app was served
+
+
+def test_run_server_http_survives_observability_init_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Serving never blocks on a failing OTel/GlitchTip init — both except branches (ADR-120)."""
+    import podcast_scraper.mcp.server as srv
+    import podcast_scraper.utils.otel_init as otel_init
+    import podcast_scraper.utils.sentry_init as sentry_init
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise RuntimeError("observability backend down")
+
+    monkeypatch.setattr(srv, "build_http_app", lambda corpus: {"app": corpus})
+    monkeypatch.setattr(otel_init, "init_otel", _boom)
+    monkeypatch.setattr(sentry_init, "init_sentry", _boom)
+
+    import uvicorn
+
+    served: dict = {}
+    monkeypatch.setattr(uvicorn, "run", lambda app, host, port: served.update(ok=callable(app)))
+    srv.run_server(_CORPUS, transport="http", host="127.0.0.1", port=8009)
+    assert served == {"ok": True}  # served despite both inits raising
+
+
+def test_with_metrics_noop_when_prometheus_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No prometheus_client → /metrics not served, the app passes through unchanged (714-715)."""
+    import sys
+    import types
+
+    from podcast_scraper.mcp.server import _with_metrics
+
+    broken = types.ModuleType("prometheus_client")  # lacks generate_latest / CONTENT_TYPE_LATEST
+    monkeypatch.setitem(sys.modules, "prometheus_client", broken)
+
+    async def _app(scope: dict, receive: object, send: object) -> None:  # pragma: no cover - marker
+        return None
+
+    assert _with_metrics(_app) is _app
+
+
+def test_instrument_asgi_returns_app_when_instrumentor_absent() -> None:
+    """No OTel ASGI instrumentation installed → the app is served un-wrapped (the except path)."""
+    from podcast_scraper.mcp.server import _instrument_asgi
+
+    async def _app(scope: dict, receive: object, send: object) -> None:  # pragma: no cover - marker
+        return None
+
+    assert _instrument_asgi(_app) is _app
+
+
+def test_instrument_asgi_wraps_when_instrumentor_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the instrumentor IS importable, the app is wrapped in OpenTelemetryMiddleware."""
+    import sys
+    import types
+
+    from podcast_scraper.mcp import server as srv
+
+    pkg = types.ModuleType("opentelemetry.instrumentation")
+    asgi = types.ModuleType("opentelemetry.instrumentation.asgi")
+
+    class _FakeMW:
+        def __init__(self, app: object) -> None:
+            self.app = app
+
+    asgi.OpenTelemetryMiddleware = _FakeMW  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "opentelemetry.instrumentation", pkg)
+    monkeypatch.setitem(sys.modules, "opentelemetry.instrumentation.asgi", asgi)
+
+    async def _app(scope: dict, receive: object, send: object) -> None:  # pragma: no cover - marker
+        return None
+
+    wrapped = srv._instrument_asgi(_app)
+    assert isinstance(wrapped, _FakeMW)
+    assert wrapped.app is _app

--- a/tests/unit/mcp/test_telemetry.py
+++ b/tests/unit/mcp/test_telemetry.py
@@ -49,3 +49,77 @@ def test_observe_carries_user_id_when_set(caplog: pytest.LogCaptureFixture) -> N
     finally:
         current_mcp_user.reset(token)
     assert any("user=u_test123" in m for m in _messages(caplog))
+
+
+def test_umami_noop_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    import podcast_scraper.mcp.telemetry as tele
+
+    monkeypatch.delenv("PODCAST_MCP_UMAMI_WEBSITE_ID", raising=False)
+    monkeypatch.delenv("PODCAST_MCP_UMAMI_URL", raising=False)
+
+    def _boom(*a: object, **k: object) -> None:
+        raise AssertionError("must not spawn a sender when Umami is unconfigured")
+
+    monkeypatch.setattr(tele.threading, "Thread", _boom)
+    tele._emit_umami("search_corpus", True)  # returns early — no thread, no raise
+
+
+def test_umami_posts_event_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    import json as _json
+    import types
+
+    import podcast_scraper.mcp.telemetry as tele
+
+    monkeypatch.setenv("PODCAST_MCP_UMAMI_WEBSITE_ID", "site-abc")
+    monkeypatch.setenv("PODCAST_MCP_UMAMI_URL", "https://analytics.example/api/send")
+    captured: dict = {}
+
+    def fake_urlopen(req: object, timeout: object = None) -> None:
+        captured["url"] = req.full_url  # type: ignore[attr-defined]
+        captured["body"] = _json.loads(req.data)  # type: ignore[attr-defined]
+        captured["ua"] = req.headers.get("User-agent")  # type: ignore[attr-defined]
+
+    # Run the sender inline (no real thread) so the assertion is deterministic.
+    monkeypatch.setattr(
+        tele.threading,
+        "Thread",
+        lambda target, name=None, daemon=None: types.SimpleNamespace(start=target),
+    )
+    monkeypatch.setattr(tele.urllib.request, "urlopen", fake_urlopen)
+
+    tele._emit_umami("who_said_about_topic", False)
+
+    assert captured["url"] == "https://analytics.example/api/send"
+    assert captured["body"]["payload"]["name"] == "mcp_tool:who_said_about_topic"
+    assert captured["body"]["payload"]["website"] == "site-abc"
+    assert captured["body"]["payload"]["data"] == {"tool": "who_said_about_topic", "ok": False}
+    assert captured["ua"]  # Umami drops UA-less events
+
+
+def test_metrics_endpoint_serves_prometheus_and_delegates_else() -> None:
+    import asyncio
+
+    from podcast_scraper.mcp.server import _with_metrics
+
+    delegated = {"hit": False}
+
+    async def _downstream(scope: dict, receive: object, send: object) -> None:
+        delegated["hit"] = True
+
+    app = _with_metrics(_downstream)
+    sent: list = []
+
+    async def _send(m: dict) -> None:
+        sent.append(m)
+
+    async def _receive() -> dict:
+        return {"type": "http.request"}
+
+    asyncio.run(app({"type": "http", "path": "/metrics"}, _receive, _send))
+    assert sent[0]["status"] == 200
+    assert any(h == (b"content-type",) or h[0] == b"content-type" for h in sent[0]["headers"])
+    assert not delegated["hit"]  # /metrics handled here, not delegated
+
+    delegated["hit"] = False
+    asyncio.run(app({"type": "http", "path": "/mcp"}, _receive, _send))
+    assert delegated["hit"]  # everything else passes through to the auth-gated app

--- a/tests/unit/mcp/test_telemetry.py
+++ b/tests/unit/mcp/test_telemetry.py
@@ -96,6 +96,33 @@ def test_umami_posts_event_when_configured(monkeypatch: pytest.MonkeyPatch) -> N
     assert captured["ua"]  # Umami drops UA-less events
 
 
+def test_umami_hostname_is_bare_host_from_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Umami wants a bare host; the env often carries the full resource URL (advisor M2)."""
+    import types
+
+    import podcast_scraper.mcp.telemetry as tele
+
+    monkeypatch.setenv("PODCAST_MCP_UMAMI_WEBSITE_ID", "site-abc")
+    monkeypatch.setenv("PODCAST_MCP_UMAMI_URL", "https://analytics.example/api/send")
+    monkeypatch.setenv("PODCAST_MCP_UMAMI_HOSTNAME", "https://mcp.closelistening.app")
+    captured: dict = {}
+
+    def fake_urlopen(req: object, timeout: object = None) -> None:
+        import json as _json
+
+        payload = _json.loads(req.data)["payload"]  # type: ignore[attr-defined]
+        captured["hostname"] = payload["hostname"]
+
+    monkeypatch.setattr(
+        tele.threading,
+        "Thread",
+        lambda target, name=None, daemon=None: types.SimpleNamespace(start=target),
+    )
+    monkeypatch.setattr(tele.urllib.request, "urlopen", fake_urlopen)
+    tele._emit_umami("corpus_trending", True)
+    assert captured["hostname"] == "mcp.closelistening.app"  # scheme stripped
+
+
 def test_metrics_endpoint_serves_prometheus_and_delegates_else() -> None:
     import asyncio
 

--- a/tests/unit/mcp/test_telemetry.py
+++ b/tests/unit/mcp/test_telemetry.py
@@ -112,6 +112,130 @@ def test_umami_hostname_is_bare_host_from_url(monkeypatch: pytest.MonkeyPatch) -
     assert captured["hostname"] == "mcp.closelistening.app"  # scheme stripped
 
 
+def test_set_result_ignores_non_envelope() -> None:
+    """A bare (non-envelope) return value leaves ok=True — the set_result early exit."""
+    with observe_tool_call("bridge") as call:
+        call.set_result("plain-string")
+        call.set_result({"data": 1})  # dict without an "ok" key
+    assert call.ok is True
+
+
+def test_emit_sets_span_attributes_and_metric() -> None:
+    """_emit stamps the span + increments the counter when a span + prometheus are present."""
+    import podcast_scraper.mcp.telemetry as tele
+
+    class _FakeSpan:
+        def __init__(self) -> None:
+            self.attrs: dict = {}
+
+        def set_attribute(self, k: str, v: object) -> None:
+            self.attrs[k] = v
+
+    span = _FakeSpan()
+    tele._emit("search_corpus", True, 0.01, "u_1", span)
+    assert span.attrs["mcp.tool"] == "search_corpus"
+    assert span.attrs["mcp.ok"] is True
+    assert span.attrs["mcp.user_id"] == "u_1"
+
+
+def test_maybe_span_yields_none_when_tracer_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A raising tracer degrades to an un-spanned call rather than breaking it (89-93)."""
+    from opentelemetry import trace
+
+    import podcast_scraper.mcp.telemetry as tele
+
+    def _boom(_name: str) -> object:
+        raise RuntimeError("no tracer provider")
+
+    monkeypatch.setattr(trace, "get_tracer", _boom)
+    with tele._maybe_span("resolve_entity") as span:
+        assert span is None
+
+
+def test_umami_backpressure_drops_when_inflight_full(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Past the in-flight cap the event is dropped at the semaphore guard — never queued (178)."""
+    import podcast_scraper.mcp.telemetry as tele
+
+    monkeypatch.setenv("PODCAST_MCP_UMAMI_WEBSITE_ID", "s")
+    monkeypatch.setenv("PODCAST_MCP_UMAMI_URL", "https://a/api/send")
+
+    def _must_not_submit(_fn: object) -> None:
+        raise AssertionError("must not submit a sender under backpressure")
+
+    monkeypatch.setattr(tele._UMAMI_POOL, "submit", _must_not_submit)
+    held = [tele._UMAMI_INFLIGHT.acquire(blocking=False) for _ in range(8)]
+    try:
+        assert all(held)
+        tele._emit_umami("corpus_trending", True)  # returns at the guard, no submit, no raise
+    finally:
+        for _ in held:
+            tele._UMAMI_INFLIGHT.release()
+
+
+def test_umami_send_swallows_transport_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unreachable Umami host is swallowed in _send and the semaphore released (193-196)."""
+    import podcast_scraper.mcp.telemetry as tele
+
+    monkeypatch.setenv("PODCAST_MCP_UMAMI_WEBSITE_ID", "s")
+    monkeypatch.setenv("PODCAST_MCP_UMAMI_URL", "https://a/api/send")
+    monkeypatch.setattr(tele._UMAMI_POOL, "submit", lambda fn: fn())  # run inline
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise OSError("unreachable analytics host")
+
+    monkeypatch.setattr(tele.urllib.request, "urlopen", _boom)
+    tele._emit_umami("who_said_about_topic", True)  # no raise
+    # released by _send's finally, so a fresh acquire succeeds
+    assert tele._UMAMI_INFLIGHT.acquire(blocking=False)
+    tele._UMAMI_INFLIGHT.release()
+
+
+def test_umami_pool_submit_failure_releases_semaphore(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A shut-down pool drops the event AND releases the semaphore — no leak (200-201)."""
+    import podcast_scraper.mcp.telemetry as tele
+
+    monkeypatch.setenv("PODCAST_MCP_UMAMI_WEBSITE_ID", "s")
+    monkeypatch.setenv("PODCAST_MCP_UMAMI_URL", "https://a/api/send")
+
+    def _boom(_fn: object) -> None:
+        raise RuntimeError("pool is shut down")
+
+    monkeypatch.setattr(tele._UMAMI_POOL, "submit", _boom)
+    tele._emit_umami("top_people", False)  # no raise
+    assert tele._UMAMI_INFLIGHT.acquire(blocking=False)  # not leaked
+    tele._UMAMI_INFLIGHT.release()
+
+
+def test_observe_swallows_user_context_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A broken user contextvar degrades to user=None rather than breaking the call (113-114)."""
+    import podcast_scraper.mcp.telemetry as tele
+
+    class _BrokenVar:
+        def get(self) -> str:
+            raise RuntimeError("contextvar broken")
+
+    monkeypatch.setattr(tele, "current_mcp_user", _BrokenVar())
+    with tele.observe_tool_call("episode_digest") as call:
+        call.set_result({"ok": True})  # no raise
+
+
+def test_emit_swallows_span_metric_and_log_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every emit sink (span attr, metric, log) is independently best-effort (125-132, 141-142)."""
+    import podcast_scraper.mcp.telemetry as tele
+
+    class _BadSpan:
+        def set_attribute(self, _k: str, _v: object) -> None:
+            raise RuntimeError("span dead")
+
+    def _boom(*_a: object, **_k: object) -> object:
+        raise RuntimeError("sink dead")
+
+    assert tele._CALLS is not None  # prometheus installed in the unit env
+    monkeypatch.setattr(tele._CALLS, "labels", _boom)
+    monkeypatch.setattr(tele._LOGGER, "info", _boom)
+    tele._emit("t", True, 0.0, "u", _BadSpan())  # all three failures swallowed → no raise
+
+
 def test_metrics_endpoint_serves_prometheus_and_delegates_else() -> None:
     import asyncio
 

--- a/tests/unit/mcp/test_telemetry.py
+++ b/tests/unit/mcp/test_telemetry.py
@@ -1,0 +1,51 @@
+"""Per-tool MCP observability (#1505): span/log/metric emission is best-effort + never breaks."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from podcast_scraper.mcp.telemetry import observe_tool_call
+
+
+def _messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [r.getMessage() for r in caplog.records]
+
+
+def test_observe_logs_tool_and_ok_true(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO, logger="podcast_scraper.mcp.tool"):
+        with observe_tool_call("search_corpus") as call:
+            call.set_result({"ok": True, "data": {"results": [1]}})
+    assert any("tool=search_corpus" in m and "ok=True" in m for m in _messages(caplog))
+
+
+def test_observe_logs_ok_false_from_envelope(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO, logger="podcast_scraper.mcp.tool"):
+        with observe_tool_call("bridge") as call:
+            call.set_result({"ok": False, "data": {}, "note": "unsupported"})
+    assert any("tool=bridge" in m and "ok=False" in m for m in _messages(caplog))
+
+
+def test_observe_records_ok_false_and_reraises_on_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.INFO, logger="podcast_scraper.mcp.tool"):
+        with pytest.raises(ValueError):
+            with observe_tool_call("resolve_entity"):
+                raise ValueError("boom")
+    # A raised body → recorded as not-ok, and the failure still propagates (telemetry is passive).
+    assert any("tool=resolve_entity" in m and "ok=False" in m for m in _messages(caplog))
+
+
+def test_observe_carries_user_id_when_set(caplog: pytest.LogCaptureFixture) -> None:
+    from podcast_scraper.mcp.auth import current_mcp_user
+
+    token = current_mcp_user.set("u_test123")
+    try:
+        with caplog.at_level(logging.INFO, logger="podcast_scraper.mcp.tool"):
+            with observe_tool_call("corpus_trending") as call:
+                call.set_result({"ok": True, "data": {}})
+    finally:
+        current_mcp_user.reset(token)
+    assert any("user=u_test123" in m for m in _messages(caplog))

--- a/tests/unit/mcp/test_telemetry.py
+++ b/tests/unit/mcp/test_telemetry.py
@@ -58,15 +58,14 @@ def test_umami_noop_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PODCAST_MCP_UMAMI_URL", raising=False)
 
     def _boom(*a: object, **k: object) -> None:
-        raise AssertionError("must not spawn a sender when Umami is unconfigured")
+        raise AssertionError("must not submit a sender when Umami is unconfigured")
 
-    monkeypatch.setattr(tele.threading, "Thread", _boom)
-    tele._emit_umami("search_corpus", True)  # returns early — no thread, no raise
+    monkeypatch.setattr(tele._UMAMI_POOL, "submit", _boom)
+    tele._emit_umami("search_corpus", True)  # returns early — no submit, no raise
 
 
 def test_umami_posts_event_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
     import json as _json
-    import types
 
     import podcast_scraper.mcp.telemetry as tele
 
@@ -80,11 +79,7 @@ def test_umami_posts_event_when_configured(monkeypatch: pytest.MonkeyPatch) -> N
         captured["ua"] = req.headers.get("User-agent")  # type: ignore[attr-defined]
 
     # Run the sender inline (no real thread) so the assertion is deterministic.
-    monkeypatch.setattr(
-        tele.threading,
-        "Thread",
-        lambda target, name=None, daemon=None: types.SimpleNamespace(start=target),
-    )
+    monkeypatch.setattr(tele._UMAMI_POOL, "submit", lambda fn: fn())
     monkeypatch.setattr(tele.urllib.request, "urlopen", fake_urlopen)
 
     tele._emit_umami("who_said_about_topic", False)
@@ -98,8 +93,6 @@ def test_umami_posts_event_when_configured(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_umami_hostname_is_bare_host_from_url(monkeypatch: pytest.MonkeyPatch) -> None:
     """Umami wants a bare host; the env often carries the full resource URL (advisor M2)."""
-    import types
-
     import podcast_scraper.mcp.telemetry as tele
 
     monkeypatch.setenv("PODCAST_MCP_UMAMI_WEBSITE_ID", "site-abc")
@@ -113,11 +106,7 @@ def test_umami_hostname_is_bare_host_from_url(monkeypatch: pytest.MonkeyPatch) -
         payload = _json.loads(req.data)["payload"]  # type: ignore[attr-defined]
         captured["hostname"] = payload["hostname"]
 
-    monkeypatch.setattr(
-        tele.threading,
-        "Thread",
-        lambda target, name=None, daemon=None: types.SimpleNamespace(start=target),
-    )
+    monkeypatch.setattr(tele._UMAMI_POOL, "submit", lambda fn: fn())
     monkeypatch.setattr(tele.urllib.request, "urlopen", fake_urlopen)
     tele._emit_umami("corpus_trending", True)
     assert captured["hostname"] == "mcp.closelistening.app"  # scheme stripped

--- a/tests/unit/podcast_scraper/server/test_app_oauth_server.py
+++ b/tests/unit/podcast_scraper/server/test_app_oauth_server.py
@@ -326,3 +326,41 @@ def test_consent_remember_and_revoke(tmp_path: Path) -> None:
     assert oa.revoke_consent(tmp_path, user_id=_UID, client_id=cid) is True
     assert oa.has_consent(tmp_path, user_id=_UID, client_id=cid, scope="mcp:read") is False
     assert oa.revoke_consent(tmp_path, user_id=_UID, client_id=cid) is False  # nothing left
+
+
+def _challenge(verifier: str) -> str:
+    return (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    )
+
+
+def test_pkce_verifier_length_enforced() -> None:
+    """RFC 7636 §4.1: reject a verifier outside 43–128, even if the challenge matches (MED)."""
+    short = "abc"  # < 43
+    assert oa._pkce_ok(short, _challenge(short)) is False
+    valid = "v" * 50  # 43–128
+    assert oa._pkce_ok(valid, _challenge(valid)) is True
+    toolong = "v" * 200  # > 128
+    assert oa._pkce_ok(toolong, _challenge(toolong)) is False
+
+
+def test_prune_stale_clients() -> None:
+    """Old clients with no live grant are reclaimed; granted/recent ones kept (advisor LOW)."""
+    now = oa._now()
+    old = now - oa._CLIENT_UNUSED_TTL_S - 10
+    clients = {
+        "old_unused": {"client_id": "old_unused", "created_at": old},
+        "old_active": {"client_id": "old_active", "created_at": old},
+        "recent": {"client_id": "recent", "created_at": now - 5},
+    }
+    grants = {"h1": {"kind": "refresh", "client_id": "old_active", "expires_at": now + 3600}}
+    kept = oa._prune_stale_clients(clients, grants)
+    assert set(kept) == {"old_active", "recent"}  # old_unused pruned
+
+
+def test_prune_ignores_expired_grant_when_keeping_client() -> None:
+    """A client whose only grant has EXPIRED is treated as un-granted → pruned if old."""
+    now = oa._now()
+    clients = {"c": {"client_id": "c", "created_at": now - oa._CLIENT_UNUSED_TTL_S - 10}}
+    grants = {"h": {"kind": "access", "client_id": "c", "expires_at": now - 1}}  # expired
+    assert oa._prune_stale_clients(clients, grants) == {}


### PR DESCRIPTION
## What

Full production-grade observability for the remote MCP surface (#1505), plus
OAuth/PKCE hardening from two advisor reviews. Brings the MCP to o11y parity
with the API: **traces, logs, metrics, GlitchTip errors, and Umami analytics** —
all five signals, best-effort and unable to break a tool call (ADR-120).

## Commits

- **`59aea55`** — per-tool observability core: OTel spans (`mcp.tool.<name>`),
  structured logs (tool/user/duration/ok + trace correlation), Prometheus
  metrics (`mcp_tool_calls_total`, `mcp_tool_duration_seconds`), GlitchTip via
  `init_sentry("mcp")` with `component`/`environment` tags.
- **`b6bcd2d`** — docs/wip: validation backlog + design gaps.
- **`ccf5c47`** — `/metrics` endpoint + Umami server-side tool-call events.
- **`989fbc9`** — advisor round 1: scope Caddy off `/metrics` (not public),
  drop dead DSN, bare Umami host.
- **`88ce444`** — advisor round 2: bounded Umami sender (pool+semaphore, no
  unbounded daemon threads), PKCE verifier length check, stale-client prune.
- **`54dd01c`** — MCP prod DSN falls back to the player-API GlitchTip project
  (component-tagged) so o11y works from first deploy.

## Privacy

Only tool **name**, `user_id`, `ok`, and timing leave the process — never query
args, corpus content, or transcripts.

## Validation

- New unit tests: `tests/unit/mcp/test_telemetry.py` (span/log/metric emission,
  Umami configured/unconfigured/backpressure/hostname, `/metrics` endpoint).
- OAuth hardening tests: `test_pkce_verifier_length_enforced`,
  `test_prune_stale_clients`, `test_prune_ignores_expired_grant`; OAuth-route +
  app-auth return_to round-trip + open-redirect guard.
- Two advisor reviews (MCP arc + OAuth internals): all findings fixed; RFC 8707
  audience enforcement confirmed; no deploy-blockers.

## Not covered / follow-ups (tracked, not in this PR)

- Corpus/search/GI-quality bugs surfaced by live MCP testing are **separate**
  from this code: grounded_only filter (indexer), long-episode insight
  truncation (GI), briefing_pack coverage reporting. None touch o11y/OAuth.
- Dedicated prod GlitchTip project + full staging↔prod parity (#18) — this PR
  ships the shared-project fallback; the dedicated project is follow-up.

Part of #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
