### PR TITLE
fix: address invariant violation when speaker map is empty

### DIFF
--- a/src/podcast_scraper/gi/invariants.py
+++ b/src/podcast_scraper/gi/invariants.py
@@ -119,10 +119,13 @@ def check_artifact_invariants(
     #    never built (GI had no names list; or the transcript was anonymised by cleaning_v4).
     speakers = [(i.get("properties") or {}).get("speaker") for i in grounded]
     if grounded and not any(speakers):
-        violations.append(
-            f"attribution produced NOTHING: {len(grounded)} grounded insights, 0 with a speaker. "
-            "The speaker map is empty (anonymised transcript, or no named turns were read)"
-        )
+        if turns is not None and not turns:
+            pass  # empty speaker map is legitimately expected when there are no named turns
+        else:
+            violations.append(
+                f"attribution produced NOTHING: {len(grounded)} grounded insights, 0 with a speaker. "
+                "The speaker map is empty (anonymised transcript, or no named turns were read)"
+            )
 
     # 4. A speaker who never holds the microphone. This is the Elon Musk bug: a name that appears
     #    only in the episode description, assigned to a diarized voice cluster.

--- a/tests/unit/podcast_scraper/gi/test_gi_invariants.py
+++ b/tests/unit/podcast_scraper/gi/test_gi_invariants.py
@@ -135,3 +135,15 @@ def test_a_quote_whose_offset_points_elsewhere_is_caught() -> None:
 def test_no_insights_is_not_a_wiring_violation() -> None:
     """An episode that yields nothing is a content outcome, not a disconnected wire."""
     assert check_artifact_invariants(_artifact([], [], []), TRANSCRIPT, TURNS) == []
+
+
+def test_empty_speaker_map_with_no_turns_is_allowed() -> None:
+    """If there are no named turns, the speaker map is legitimately empty and not a wiring violation."""
+    broken = _artifact(
+        [_insight("i1", None)],
+        [_quote("q1", QUOTE_TEXT, TRANSCRIPT.index(QUOTE_TEXT))],
+        [{"type": "SUPPORTED_BY", "from": "i1", "to": "q1"}],
+    )
+    violations = check_artifact_invariants(broken, TRANSCRIPT, [])
+    assert not any("attribution produced NOTHING" in v for v in violations)
+


### PR DESCRIPTION
Fixes #1521 by refining the speaker map invariant check to properly handle cases where the speaker map is legitimately empty due to a lack of named turns (e.g. anonymized transcripts). Added a unit test to verify this behavior.