### PR TITLE
fix(incremental+o11y): make incremental processing truly incremental + observable

### DIFF
--- a/.github/workflows/deploy-all-prod.yml
+++ b/.github/workflows/deploy-all-prod.yml
@@ -1,0 +1,93 @@
+name: Deploy ALL prod planes (control -> operator -> player)
+
+# D1 — one-trigger orchestrator. Rolls the three prod deploys IN ORDER (control plane, then public
+# operator, then public player), waiting for each to FINISH — including its `prod` environment
+# approval — before starting the next, and STOPS if any plane fails. So the public operator/player
+# surfaces never roll onto a control-plane engine that didn't deploy, and no plane is forgotten.
+#
+# It does NOT modify the three underlying workflows: each keeps its own typed confirm + `prod`
+# approval gate, so you still approve each plane in the Actions UI (ONE trigger, three approvals, in
+# the correct order, stop-on-failure). Collapsing to a single approval would require restructuring
+# the per-plane `environment: prod` gates — deliberately out of scope so each workflow stays
+# independently safe when run on its own. See docs/guides/PROD_RUNBOOK.md "The two operator planes +
+# deploy map" for what each plane deploys.
+#
+# Requires a PAT in `secrets.DEPLOY_ORCHESTRATOR_PAT` with `actions:write` on this repo: the default
+# GITHUB_TOKEN cannot trigger another workflow_dispatch (GitHub blocks token-initiated workflow
+# recursion), so this orchestrator needs its own token to dispatch the downstream deploys.
+#
+# NOTE: GitHub Actions behaviour cannot be validated locally — dispatch this once and watch the run
+# before relying on it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type DEPLOY_ALL_PROD to roll all three planes in order'
+        required: true
+        default: ''
+
+permissions:
+  actions: write
+
+concurrency:
+  # A distinct group from `deploy-prod` — sharing it would DEADLOCK (this job holds the group while
+  # waiting for the deploy-prod run it triggered, which would then queue behind it).
+  group: deploy-all-prod
+  cancel-in-progress: false
+
+jobs:
+  orchestrate:
+    runs-on: ubuntu-latest
+    # Each plane pauses for a human approval, so the whole chain can be long-lived.
+    timeout-minutes: 180
+    steps:
+      - name: Confirm DEPLOY_ALL_PROD
+        run: |
+          if [ "${{ inputs.confirm }}" != "DEPLOY_ALL_PROD" ]; then
+            echo "::error::Must type DEPLOY_ALL_PROD to confirm. Got: '${{ inputs.confirm }}'"
+            exit 1
+          fi
+
+      - name: Roll all three planes in order (stop on failure)
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOY_ORCHESTRATOR_PAT }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::secrets.DEPLOY_ORCHESTRATOR_PAT is required (a PAT with actions:write; the default GITHUB_TOKEN cannot dispatch downstream workflows)."
+            exit 1
+          fi
+
+          roll() {
+            wf="$1"
+            token="$2"
+            echo "::group::Deploy via ${wf}"
+            since="$(date -u +%FT%TZ)"
+            gh workflow run "${wf}" --repo "${REPO}" -f confirm="${token}"
+            # Resolve the run we just triggered (created at/after `since`); the dispatch is async.
+            id=""
+            for _ in $(seq 1 20); do
+              id="$(gh run list --repo "${REPO}" --workflow "${wf}" --event workflow_dispatch \
+                     --created ">=${since}" --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)"
+              if [ -n "${id}" ] && [ "${id}" != "null" ]; then
+                break
+              fi
+              sleep 6
+            done
+            if [ -z "${id}" ] || [ "${id}" = "null" ]; then
+              echo "::error::could not resolve the triggered run for ${wf}"
+              return 1
+            fi
+            echo "watching ${wf} run ${id} (waits for its prod approval + completion)..."
+            # --exit-status makes a failed/cancelled downstream run fail this step (set -e stops the
+            # chain here → later planes are NOT deployed onto a bad engine).
+            gh run watch "${id}" --repo "${REPO}" --exit-status --interval 20
+            echo "::endgroup::"
+          }
+
+          roll deploy-prod.yml     PROD_DEPLOY
+          roll deploy-operator.yml OPERATOR_DEPLOY
+          roll deploy-player.yml   PLAYER_DEPLOY
+          echo "All three prod planes deployed in order."

--- a/docs/wip/DESIGN-D8-incremental-indexer-skip.md
+++ b/docs/wip/DESIGN-D8-incremental-indexer-skip.md
@@ -1,0 +1,113 @@
+# Design note — D8: incremental (unchanged-skip) reindex for the two-tier indexer
+
+**Status:** APPROVED + IMPLEMENTED (2026-08-11) on branch `feat/incremental-processing-and-o11y`.
+Companion to `docs/wip/PROD-DEPLOY-ANOMALIES-2026-08-11.md` (§D8 RCA + Implementation status).
+Implemented exactly as designed below: fingerprint = sha256 of the collected `(doc_id, text)` rows +
+model_id + `_FP_SCHEMA_VERSION`, persisted to `search/episode_fingerprints.json`, skip when matched,
+full rebuild ignores fingerprints. Code: `search/two_tier_indexer.py` (`_episode_fingerprint`,
+`_episode_scope_key`, `_fingerprint_skip_unchanged`, `_load/_write_episode_fingerprints`,
+`_finalize_index_build`) + `search/indexer.py` (wires the real `episodes_skipped_unchanged`). Tests:
+`tests/integration/search/test_two_tier_indexer_incremental.py` + the multi-run composition test.
+Promote to a numbered ADR when the branch merges.
+
+## Problem (RCA recap)
+
+`build_two_tier_index` (`src/podcast_scraper/search/two_tier_indexer.py`) re-embeds the **entire
+corpus** on every reindex. It loops `discover_metadata_files(out)` and calls `_embed()` for every
+doc of every episode; there is **no unchanged-skip**. `index_corpus` sets
+`episodes_reindexed = tt.episodes` and never populates `episodes_skipped_unchanged` (a dead metric
+from the retired FAISS path). `episode_fingerprints.json` does not exist on prod. Upsert is
+idempotent for **storage** (merge on id) but not for **compute** — it re-embeds, then merges.
+
+Measured: adding ONE episode to a 107-episode corpus = `vector_index_seconds=635` (~10.6 min),
+`episodes_skipped_unchanged=0`. Complexity is **O(corpus)** per add (~50 min at ~500 eps). This
+blocks Step-2 volume scaling as hard as D7 (skip-existing) does.
+
+## Goals / Non-goals
+
+**Goals**
+- An incremental reindex embeds only **new or changed** episodes → O(changed), not O(corpus).
+- Correctness first: a changed episode MUST be re-embedded (never a stale index from a false skip).
+- Zero behavior change for a **full** reindex (`rebuild=true` / schema/model change) — still rebuilds
+  everything from a clean slate.
+- Populate the real `episodes_skipped_unchanged` metric + a log line (feeds D9).
+
+**Non-goals**
+- Orphan/deletion sweep on the incremental path (rollback still uses full rebuild — unchanged from
+  today; documented limitation).
+- Changing the embedding model, chunking, or the tier schema.
+- Cross-episode work (topic clusters still rebuild after; that is a separate, cheaper step).
+
+## Design
+
+### Fingerprint = hash of the collected rows (not source mtimes)
+
+`_collect_docs_for_episode` (parse metadata + chunk transcript + read gi/kg) is **cheap**; only
+`_embed` is expensive. So we still *collect* every episode's rows each build, then decide whether to
+embed:
+
+1. For each episode, run `_collect_docs_for_episode` (as today) to get the `(doc_id, text, meta)`
+   rows.
+2. Compute `fp = sha256(canonical(sorted (doc_id, text) pairs) + model_id + FP_SCHEMA_VERSION)`.
+   Hashing the **collected rows** (the exact text that would be embedded) captures every input that
+   affects the index output — transcript, insights, quotes, kg, titles/summaries — in one hash,
+   without guessing which source files matter. `model_id` + `FP_SCHEMA_VERSION` make a model or
+   indexer change invalidate every fingerprint.
+3. Key by the STABLE `index_fingerprint_scope_key(feed_id, episode_id)` (already in
+   `corpus_scope.py`).
+
+### Skip decision
+
+- Load `episode_fingerprints.json` (next to the lance index, `search/`) at build start:
+  `{scope_key: {"fp": "<sha>", "model_id": "<id>"}}`.
+- Per episode: if `not clear_requested` AND stored `fp` == current `fp` AND stored `model_id` ==
+  current `model_id` → **skip** embed+upsert for this episode; `stats.episodes_skipped_unchanged += 1`.
+  Else embed+upsert (as today) and record the new `fp`.
+- After a successful build, write the updated fingerprints file atomically (temp + rename).
+
+### Interactions
+
+- **Full / stale reindex** (`drop_existing` or schema bump → `clear_requested`): ignore fingerprints,
+  rebuild all, then write a fresh fingerprints file. Guarantees a clean rebuild always fixes drift.
+- **D2 (stats cache):** after any build that changed the index, clear the index-stats perf_cache (or
+  bump the lance dir mtime) so `/api/index/stats` reflects the new state. Handled in the D2 change;
+  D8 just makes "changed" precise.
+- **Incremental vs upsert correctness:** a skipped episode's rows are already in the tables (prior
+  build upserted them by the same stable `doc_id`), so skipping embed+upsert leaves them intact.
+
+### Persistence & atomicity
+
+- File: `search/episode_fingerprints.json` (co-located with `lance_index/`, same dir the stats +
+  clusters live in). Small (one row per episode).
+- Written atomically at the end of a successful build only (a failed build must not poison
+  fingerprints → next build re-embeds).
+
+## Edge cases & risks
+
+- **False skip = stale index (the one real risk).** Mitigated by hashing the *collected rows'
+  text*, which is exactly the embedded content — if any embedded text changes, the hash changes.
+  A re-run that only rewrites unrelated metadata (not embedded) correctly skips (no index impact).
+- **model_id / chunking / schema change:** `model_id` is in the hash; `FP_SCHEMA_VERSION` bumps on
+  any change to chunking or row construction → global invalidation. A stale-schema reindex already
+  sets `clear_requested` → full rebuild.
+- **Missing/corrupt fingerprints file:** treated as "no prior fingerprints" → full embed (safe,
+  slow) → file rewritten. Self-healing.
+- **Deleted episode (rollback):** incremental leaves its rows; same as today. Full rebuild sweeps.
+  Documented; unchanged behavior.
+- **Concurrent builds:** the existing per-corpus rebuild gate already serializes builds.
+
+## Testing (Tier-2, added with the change)
+
+- Build index for N episodes → assert `episodes_skipped_unchanged=0`, all embedded.
+- Re-run with no changes → `episodes_skipped_unchanged=N`, 0 embedded, vectors unchanged, wall time
+  bounded (no `_embed` calls — assert via a spy/counter).
+- Add 1 episode → exactly 1 embedded, `episodes_skipped_unchanged=N`, new episode searchable.
+- Change 1 episode's transcript → exactly that 1 re-embedded.
+- `rebuild=true` → ignores fingerprints, embeds all, rewrites file.
+- Model-id change in config → all re-embedded.
+
+## Rollout
+
+Ships in the same image as D7/D2/D9. After deploy, re-run Step 0: expect the reindex to embed only
+the new episode (seconds, not ~10 min) and `episodes_skipped_unchanged=106`. First reindex after
+deploy re-embeds all once (no fingerprints yet) — expected, one-time.

--- a/docs/wip/PROD-DEPLOY-ANOMALIES-2026-08-11.md
+++ b/docs/wip/PROD-DEPLOY-ANOMALIES-2026-08-11.md
@@ -1,0 +1,394 @@
+# Prod deploy + incremental rollout — anomalies & homework (2026-08-11)
+
+Running log of **unusual things** seen while deploying all 3 prod planes (control / operator /
+player) and starting the incremental-processing rollout. Each entry: what happened, whether it
+blocked, the follow-up.
+
+Session context: deployed engine `sha-371e925` (main HEAD `371e9256`, PR #1547
+`fix/long-term-fixes` merged, CI green). Validation is observability-first (GlitchTip /
+VictoriaLogs / tailnet API); SSH is last-resort (operator staged the key).
+
+---
+
+## Validation results — end state (all green)
+
+| Check | Result |
+| --- | --- |
+| 3 planes deployed on `sha-371e925` | control `31462318117` · operator `31463210839` · player `31463411280` — all GREEN |
+| Control-plane `/api/health` (tailnet) | 200, `code_version 2.7.0.dev0`, `artifacts_api:true`, `search_api:true` |
+| Player `<player-domain>/api/health` | 200 (0.24s) |
+| Operator `<operator-domain>/api/health` | 200 (0.16s) |
+| Corpus | **107** episodes / 9 feeds (after Step 0; The Daily 12→13) |
+| Search index (LanceDB, real) | **107** episodes / **13,397** vectors; `/api/search` returns hits |
+| `/api/index/stats` (after D2 touch) | 107 / 13,397, `reindex_recommended:false` |
+| Step 0 (one ep, cloud_balanced) | **DONE, GO** — Deepgram + LiteLLM/DeepSeek verified (B4) |
+| VictoriaLogs (`{app="podcast"}` 1h) | 13,852 lines ingesting; 0 error/Exception/Traceback |
+| GlitchTip project 1 (pipeline+api) | 0 new issues (the 2 in project 6 = <other-project>-staging, unrelated) |
+
+Prod mutations this session (all operator-approved / benign): index incremental upsert (B1), two
+mtime `touch`es on the index dir to unstick the stats cache (B3/B4), and the Step-0 pipeline run
+(B4, +1 episode, +$0.132).
+
+**Step 1 (skip-existing crux) = FAIL / NO-GO (B5).** Re-running the same feed reprocessed the
+already-present episode (+$0.13 wasted) instead of skipping; catalog stayed 107 (no dup). Root cause:
+skip is guid-keyed but run-dir-scoped, not corpus-wide (D7). **HOLD volume until D7 lands.** Single
+genuinely-new adds still work (Step 0).
+
+---
+
+## A. Deploy-time anomalies
+
+### A1 — Local worktree was 17 commits behind `origin/main` (non-issue, noted)
+
+- `main...origin/main [behind 17]` at session start. Local HEAD `ee99b9ae`; remote `371e9256`.
+- Cause: the other agent's `fix/long-term-fixes` (PR #1547) merged to remote main after this
+  worktree's last sync. Strictly behind (not diverged) → all local commits are ancestors.
+- Impact: none on deploy (GHA deploys from remote main + GHCR image). Flagged only so nobody
+  deploys from the stale local tree by hand.
+- **Homework:** `git pull` this worktree to `371e9256` before any local build/validation work.
+
+### A2 — `gh` token lacks `read:packages` scope
+
+- Could not list GHCR image tags via `gh api /users/<org>/packages/...` (403 "need read:packages").
+- Worked around with `docker manifest inspect ghcr.io/<org>/podcast-scraper-stack-api:sha-371e925`
+  → "IMAGE EXISTS". Verification succeeded via a different path; not blocking.
+- **Homework:** add `read:packages` to the local `gh` token if GHCR introspection is wanted from
+  the laptop (optional; the deploy workflow validates the manifest itself pre-SSH).
+
+### A3 — Control-plane deploy: two NON-FATAL o11y emit failures — RESOLVED (transient)
+
+Run `31462318117` (deploy-prod.yml, `sha-371e925`, 2m7s, deploy itself GREEN). Two annotations:
+
+- `! Sentry release boundary failed (non-fatal)`
+- `! deploy-event emit failed (non-fatal)` — "Emit deploy event to VictoriaLogs"
+
+Deploy health was fine (`/api/health OK` after 5s; post-deploy smoke on 6 surfaces ✓). The
+operator + player deploys' VictoriaLogs emit steps were ✓, and post-deploy VictoriaLogs shows
+**13,852** `{app="podcast"}` lines in 1h with 0 errors → the log path is healthy, the control-plane
+emit failure was **transient**. Sentry release marker still worth a glance (see D3).
+
+### A4 — Operator plane clean
+
+Run `31463210839` (deploy-operator.yml, 1m6s) GREEN, no anomaly annotations. Pinned to the
+control-plane engine sha (no drift).
+
+### A5 — Player plane clean
+
+Run `31463411280` (deploy-player.yml, 1m55s) GREEN, no anomaly annotations. Pinned to the operator
+stack's running engine sha (`sha-371e925`, no drift).
+
+---
+
+## B. Rollout-time anomalies
+
+### B1 — Post-deploy index "reads 94" → actually TWO issues; RESOLVED
+
+Initial read after all 3 planes deployed: `GET /api/index/stats` = **94** for episode_*,
+`total_vectors 12294`, `last_updated 2026-08-10T16:36:19Z`; but `GET /api/corpus/stats`
+`catalog_episode_count` = **106**. Investigation split this into two distinct facts:
+
+1. **The real LanceDB index WAS short at 94** (12 Planet Money eps missing) — the handover landmine
+   was real. `discover_metadata_files` (deployed) correctly yields **106**, so the fixed discovery
+   works; the on-disk table just hadn't been rebuilt since the pre-fix drop.
+2. **The `/api/index/stats` endpoint ALSO mis-reported** — see B3; it kept showing 94 even after
+   the table reached 106.
+
+**Remediation applied (operator approved):** ONE incremental upsert
+`POST /api/index/rebuild?path=/app/output&rebuild=false` (WITH the operator key — the route IS
+gated; see correction below). It ran ~06:14→06:23, wrote new Lance versions (aux v36 / insights
+v19 / segments v22 @ 06:23:04), bringing the table to **106 episodes / 13,328 vectors** (verified by
+direct pyarrow query: aux episode_title/description/summary_short = 106 each; insights 106 distinct
+eps; segments 105 — one ep has no transcript segments). NOT `rebuild=true` (full-rebuild = mimalloc
+SIGSEGV under torch). Search verified functional. **Index RESOLVED: 106, search works.**
+
+**CORRECTION to my earlier claim:** I first said `/api/index/rebuild` was ungated ("tailnet
+privacy is the gate", app.py:248-249). WRONG — that was the router-mount deps; the
+`OperatorWriteGuard` *middleware* gates by path, and `/api/index/rebuild` IS in `_OPERATOR_BASES`
+(app_operator_guard.py). So the upsert needs a valid operator key; the first POST without it → 403.
+
+### B2 — Saved operator API key on the laptop was STALE (rotated) — RESOLVED
+
+- Key file `~/podcast_operator_api_key.txt` was 110 chars, `PROD…` prefix.
+- Verified against prod: `GET /api/ops/summary` and `GET /api/jobs` WITH `X-Operator-Key: <file>`
+  both returned **403 `Admin access required`** → did NOT match the server's `APP_OPERATOR_API_KEY`
+  (`_valid_key`, app_operator_guard.py:82).
+- **Cause:** rotated by the "Recreate operator api (apply rotated APP_OPERATOR_API_KEY)" workflow
+  (`330711492`, 2026-08-10); the laptop copy predated it.
+- **RESOLVED:** the current key is a file-mounted secret (`.env` has none). Read it from
+  `/run/secrets/app_operator_api_key` inside `compose-api-1` (64-char, `6a6f…` — a different, newer
+  key). Refreshed the laptop file (0600); re-verified `ops/summary → 200`, `jobs → 200`.
+- **Homework:** whenever the key is rotated again, refresh the laptop file — it drifts silently.
+
+### B3 — `/api/index/stats` served STALE counts after an in-place upsert (REAL code bug)
+
+- After the upsert brought the table to 106, `/api/index/stats` still reported **94 / 12294** with a
+  frozen `last_updated 2026-08-10T16:36:19Z`, while a direct LanceDB query showed **106 / 13328**
+  and the tables' latest versions were written 06:23:04. So the endpoint was wrong, not the index.
+- **Root cause:** `read_lance_index_stats` (search/lance_index_stats.py) memoizes in `perf_cache`
+  keyed on **`perf_cache.lance_mtime(lance_dir)`** — the top-level `lance_index/` dir mtime. LanceDB
+  upserts write into per-**table** subdirectories and do NOT bump the parent dir's mtime (it stayed
+  Aug 10 16:36). So the cache key never changed → the endpoint kept returning the 94 it computed at
+  api start. `_spawn_rebuild_thread` calls `invalidate_newest_index_source_mtime_cache` (a DIFFERENT
+  cache), never `clear_index_stats_cache()`. `stats.last_updated` derives from that same stale mtime.
+- **Operational fix applied:** `touch /srv/podcast-scraper/corpus/search/lance_index` (mtime-only,
+  no data change) → cache key changed → stats now correctly reads **106 / 13328**,
+  `reindex_recommended:false`, `last_updated 2026-08-11T06:29:36Z`. This also PROVED the diagnosis.
+- **Impact was cosmetic/monitoring only** — search always served the real 106; only stats + the
+  viewer index card + `reindex_recommended` were stale. Genuine defect — code fix in D2.
+
+### B4 — Step 0 executed (The Daily, cloud_balanced) — GO, with notes
+
+Triggered `POST /api/jobs?feed=<The Daily>&max_episodes=1&episode_order=newest&skip_existing=true`
+(job `5d249ecb`, ~14 min, `succeeded` exit 0). Added "Why Adults Are Getting Cancer at…".
+
+- Corpus **106 → 107** (The Daily 12→13); NOT 108 → no duplication. Outcome `{ok:1,failed:0,skipped:0}`.
+- **Providers verified from the episode `config_snapshot` (on-disk, authoritative):** transcription
+  = **Deepgram `nova-3`** (9 speakers, `transcribe_time=9.7s` — cloud, not local Whisper); LLM =
+  **LiteLLM → `podcast-flash-0731` → `openrouter/deepseek/deepseek-v4-flash`** with app-level
+  RFC-106 failover to native DeepSeek (infra/litellm/config.yaml). Matches cloud_balanced exactly.
+  (Note: `content.whisper_model=nova-3` is a legacy MISNOMER — the value is the Deepgram model, and
+  `content.transcript_source=whisper_transcription` is likewise a stale label; the real provider
+  fields under `ml_providers.transcription` say deepgram. Confusing naming — cleanup candidate.)
+- Index reindexed to **107 / 13,397 vectors** (`episodes_reindexed=107, errors=[]`).
+- Cost **+$0.132** for one episode (0.8345→0.9664) — **~2× the handover's ~$0.05 estimate**;
+  by_stage shows non-zero transcription + cleaning + GI + KG. Worth understanding why per-episode is
+  higher than expected before scaling (Step 2 `$5/run` soft cap assumes cheaper eps).
+- 0 new errors in GlitchTip podcast project 1. (2 issues in project **6 = <other-project>-staging**, a
+  DIFFERENT app, unrelated.)
+- **D2 bug RECURS after the pipeline reindex too:** post-run `/api/index/stats` showed stale 106 +
+  `reindex_recommended:True` until a manual `touch` of the lance dir. So D2 affects the normal
+  processing path, not just manual upserts — bumps its priority.
+- **Watch:** `enrich-edges: HAS_EPISODE=1 MENTIONS=0 SPOKEN_BY=0` for the new episode despite 9
+  diarized speakers — the handover's Step-0 EXIT expected SPOKEN_BY edges. Possible GI-edge
+  derivation gap for incrementally-added episodes; verify before Step 1/2.
+
+### B5 — Step 1 (skip-existing crux) FAILED — reprocess, no dup; NO-GO for scaling
+
+Re-ran the SAME feed (The Daily) with `skip_existing=true` (job `bea9f8bd`, succeeded exit 0).
+**It did NOT skip** — it re-ran the full pipeline on the already-present episode:
+
+- Fresh Deepgram transcript + asr/cleaned/gi/kg/media all re-derived under a NEW run dir
+  `run_bea9f8bd_…` (transcript written 07:11). Cost **+$0.130** wasted (0.9664→1.0967, run_count 12).
+- Corpus stayed **107** (The Daily still 13) → **no duplicate episode** (episode_id dedup +
+  newest-run-wins protect the catalog COUNT). But the reprocess is real spend + a second run dir for
+  the same episode (the Step-0 `run_5d249ecb` is now orphaned/superseded).
+- **Verdict: NO-GO** per the handover — hold volume; do not scale to Step 2 until fixed.
+
+**Root cause (deployed code, episode_processor.py:321-346):** the GUID fix (#1) landed —
+`skip_idx = run_index.resolve_ondisk_idx_for_episode(episode, effective_output_dir)` keys on the
+STABLE guid, and skip triggers on `os.path.exists(final_out_path)`. BUT both the guid lookup and
+`final_out_path` are scoped to `effective_output_dir`, which under `--single-feed-uses-corpus-layout`
+is the FRESH run dir (empty at check time). The episode lives in a PRIOR run dir, so the check
+can't see it → falls back to `episode.idx` → path absent → reprocess. **The skip is guid-keyed but
+run-dir-scoped, not corpus-wide** — the same latent "only look at one run" assumption that
+`3c01787d` fixed for index discovery, still present in the skip path. → homework D7.
+
+---
+
+## Phase 1 investigation conclusions (2026-08-11) — RE-SCOPED
+
+Ran every homework item to ground before committing to implement. Outcome: scope SHRANK a lot.
+
+| ID | Verdict | Needs image rebuild? | Effort |
+| --- | --- | --- | --- |
+| **D7** skip corpus-wide | **REAL — the only scaling blocker.** cfg.output_dir=corpus root is in scope; `_scan_corpus_metadata_index` already globs `feeds/*/run_*/metadata` corpus-wide. Fix = resolve + existence-check against corpus root (via entry's real path) in corpus-layout mode, not the fresh run dir. 3 call sites (episode_processor.py:325/2766/2877 + `_check_existing_transcript` glob). | YES (pipeline) | Moderate + Tier-2 test |
+| **D2** stats cache | **REAL, small.** `perf_cache.lance_mtime` = `getmtime(lance_dir)` (top dir only); in-place upserts don't bump it. Fix = clear_index_stats_cache() after build / walk-newest / os.utime. Also hits the pipeline reindex path. | YES (api) | Small + test |
+| **D1** unified deploy workflow | Operator ask, valid. **Pure GHA workflow YAML — NO image rebuild, ships on merge.** | **NO** | Moderate (YAML) |
+| **D6** whisper_* misnomer | Baked into a schema enum `Literal[...,"whisper_transcription"]`; correct data already in `config_snapshot.ml_providers`. Document now; full rename is a later schema change. | (only if renamed) | Low (doc) / Large (rename) |
+| **D3** deploy-event/Sentry | **NON-ISSUE.** `sha-371e925` release IS in GlitchTip (05:53:55); VictoriaLogs healthy (13.8k lines/1h). Only the cosmetic deploy-boundary annotation sub-step is flaky. | — | Drop |
+| **D4** SPOKEN_BY/MENTIONS=0 | **FALSE ALARM.** Episode gi.json has 14 SPOKEN_BY edges + 2 Person nodes; speaker attribution ran (named=3, no alarm). MENTIONS=0 corpus-wide (247/247) — not implemented, pre-existing. The enrich-edges "0" was the corpus-linkage delta. | — | Drop |
+| **D5** cost 2× | **EXPLAINED, not a bug.** `metrics.json llm_transcription_cost_usd=0.1203` on 1577s (~26min) of Deepgram nova-3 ≈ correct pricing. The $0.05 estimate was wrong. speaker_detection cost=0 because free self-intro heuristics resolved names (no LLM call). | — | Doc: update planning to ~$0.13/ep |
+| **D8** full reindex per add | **NEW.** `vector_index_seconds=635` — every incremental add does a full ~10.6min corpus reindex (no incremental checkpoint). Real scaling cost; larger change. | (future) | Defer — investigate separately |
+
+**Net implementation scope for THIS round:** **D7** (blocker) + **D2** (rides the rebuild) require the
+image rebuild+deploy. **D1** ships independently (workflow only). D6 = doc note. D3/D4/D5 = closed.
+D8 = deferred.
+
+---
+
+## Implementation status (2026-08-11) — branch `feat/incremental-processing-and-o11y`
+
+Repro-first (each bug reproduced RED, then fixed to GREEN). Not committed/pushed yet.
+
+| Item | Status | Code | Guardrail tests (new) |
+| --- | --- | --- | --- |
+| **D8** indexer incremental skip | ✅ DONE | `search/two_tier_indexer.py` (fingerprint skip + `_finalize_index_build`), `search/indexer.py` (wire `episodes_skipped_unchanged`) | `test_two_tier_indexer_incremental.py` (5), composition test |
+| **D7** skip-existing corpus-wide | ✅ DONE | `workflow/run_index.py` (`episode_metadata_rel_in_corpus`, `existing_transcript_path_in_corpus`), `workflow/episode_processor.py` (both `_check_existing_transcript` + the ASR path) | `test_skip_existing_across_runs.py` (4, incl. ASR path) |
+| **D2** index-stats freshness | ✅ DONE | `search/two_tier_indexer.py` (`os.utime` the index dir on a changed build — crosses the pipeline-subprocess boundary) | `test_index_stats_freshness.py` (1) |
+| **D9** observability | ✅ DONE | `providers/ml/embedding_loader.py` (`show_progress_bar=False` — kills the "Batches" flood), `providers/deepgram/deepgram_provider.py` (announce provider+model like Whisper) | `test_deepgram_provider.py::test_transcribe_logs_provider_and_model` |
+| **Composition** (Step 0+1 codified) | ✅ DONE | — | `test_multi_run_corpus_incremental_index.py` (union+newest-wins → index count; unchanged reindex = 0 embeds) |
+| **D1** deploy-all-prod | ✅ FILE ADDED (actionlint-clean) | `.github/workflows/deploy-all-prod.yml` — one trigger, control→operator→player, stop-on-failure; keeps per-plane approval. Needs `secrets.DEPLOY_ORCHESTRATOR_PAT` + a live dispatch to validate (GHA can't be tested locally). | — |
+| **D6** `whisper_*` misnomer | ⏸ DEFERRED (rationale) | Field VALUE already = the actual provider's model; provider is now unambiguous in logs (D9) + `config_snapshot.ml_providers`. A true rename touches a schema `Literal` enum + many readers — a separate, higher-risk change, not rushed here. | — |
+| D3 / D4 / D5 | CLOSED | non-issues / cost doc-corrected (~$0.13/ep) | — |
+
+**Verification:** affected suites green — search unit/integration 450+, workflow unit 800, deepgram
+36, the 5 new guardrail files red→green; flake8 clean on all changed source+tests; actionlint clean
+on the new workflow. NOT run yet: full `make ci-fast` (final pre-push gate).
+
+---
+
+## D8 RCA (2026-08-11) — search reindex is O(corpus), no incremental skip [BLOCKER for scaling]
+
+Every incremental add re-embeds the ENTIRE corpus. Step-0 metrics: `episodes_scanned=107,
+episodes_skipped_unchanged=0, episodes_reindexed=107, vector_index_seconds=635` (~10.6 min for ONE
+new episode).
+
+**Confirmed root cause:**
+- `build_two_tier_index` (two_tier_indexer.py:295) loops `discover_metadata_files(out)` and calls
+  `_embed(text)` for every doc of every episode (lines 338/352/365). **No fingerprint gate, no
+  unchanged-skip.**
+- `index_corpus` sets `episodes_reindexed = tt.episodes` (all) and NEVER sets
+  `episodes_skipped_unchanged` → it is a DEAD metric (always 0), left from the retired FAISS indexer.
+- `episode_fingerprints.json` does NOT exist on the box — the skip mechanism is not active.
+- Upsert is idempotent for STORAGE (merge on id) but NOT for COMPUTE: it re-embeds all N first,
+  then merges. Embedding is the 635s.
+- Complexity is O(N) per add → 107 eps = 10.6 min; ~500 eps ≈ ~50 min per single-episode add.
+
+**Fix direction:** add a per-episode unchanged-skip to `build_two_tier_index`: hash each episode's
+index-relevant content (transcript chunks + insights + gi/kg), keyed by the STABLE
+`index_fingerprint_scope_key(feed_id, episode_id)` (already exists in corpus_scope.py), persist to
+`episode_fingerprints.json`, and skip embed+upsert for episodes whose hash is unchanged. Makes an
+incremental add O(new episodes). Moderate-large change in the indexer hot loop + tests. **This is a
+hard prerequisite for Step 2 volume, alongside D7.**
+
+## D9 RCA (2026-08-11) — pipeline is observable only AFTER the run, not during
+
+The session hit real "did Deepgram even run?" confusion. Root causes:
+- **No stage→provider logging.** The pipeline log mentions deepgram/litellm/nova-3 **0 times** (grep
+  count 0, any level). Provider truth lives ONLY in the episode `config_snapshot` metadata, written
+  at the END of the run. You cannot tell from logs which provider is running a stage live.
+- **Log signal-to-noise is terrible.** 13,889 lines dominated by docker-pull progress + `Batches:
+  100%` embedding bars + `Loading weights`. Real stage lines are buried; the per-job byte cap can
+  truncate real errors (the code comments on this).
+- **log-tail API friction.** `GET /jobs/{id}/log-tail` enforces `max_bytes>=4096` (I passed 1200 →
+  422). Field is `text`. Even used correctly it returns the noisy raw tail, not a stage summary.
+- **Cost/spend not live-queryable.** LiteLLM SpendLogs was empty at query time (spend-push batch
+  delay) and `LITELLM_MASTER_KEY` is a file-mounted secret (not in `.env`), so the documented
+  `gateway_spend.py` path didn't work live. The per-run truth is `metrics.json` in the run dir.
+- **Misnamed fields (D6)** point at "Whisper" when Deepgram ran (`whisper_model=nova-3`,
+  `transcript_source=whisper_transcription`) — actively misleading.
+
+**Fix direction (D9):** (a) emit one structured INFO line per stage naming provider+model+timing
+(`transcribe: provider=deepgram model=nova-3 speech_s=1577 cost=$0.12`; `llm summarize:
+provider=litellm model=podcast-flash-0731→openrouter/deepseek-v4-flash`); (b) route tqdm/progress
+bars to non-tty / DEBUG so the log-tail shows stages, not embedding spam; (c) surface a live
+stage/cost signal (metrics.json tail or a `/api/jobs/{id}/progress` summarizing current stage +
+running cost); (d) fix the D6 field names so provider identity is unambiguous.
+
+---
+
+## C. Known landmines carried in from the handover (watch for these)
+
+- **Index may read 94 not 106** if the pre-fix image was live when the index was last built → ONE
+  incremental upsert (`rebuild=false`), NEVER full-rebuild (mimalloc SIGSEGV under torch). (Hit +
+  resolved this session — B1/B3.)
+- Run container commands as **`podcast`, never root** (root-owned index files → api "no_index").
+- **skip-existing is idx-keyed, not GUID** → silent duplicate reprocessing if a feed published
+  between runs. Step 1 is the go/no-go test for this. **Not yet run.**
+- Rollback is **SSH-only** today (no DELETE API) — the one hard prod-SSH dependency.
+
+---
+
+## D. Homework — proposed follow-up work
+
+### D1 — One unified "deploy all prod planes" workflow (operator ask, 2026-08-11)
+
+Today deploying the full app is **3 separate `workflow_dispatch` runs** (deploy-prod →
+deploy-operator → deploy-player), each with its OWN typed confirm AND its OWN `prod`
+required-reviewer gate → **3 triggers + 3 approval clicks**. Painful and error-prone (easy to
+forget a plane → engine drift).
+
+**Want:** a single orchestrator workflow (e.g. `deploy-all-prod.yml`) that runs the three planes
+**sequentially in the correct order** (control → operator → player), with **one trigger + ideally
+one approval**, and a **validation gate after each plane** before proceeding to the next.
+
+Design notes / constraints:
+
+- Order is load-bearing: control plane FIRST (owns/writes the corpus + defines the engine sha the
+  public planes pin to), then operator, then player.
+- **Stop-on-failure:** if control fails, do NOT roll operator/player onto a bad engine.
+- Per-plane validation between steps (reuse `scripts/ops/post_deploy_smoke.sh` / the external
+  health probes each plane already runs; add the index-freshness check after control).
+- Approval model: a single `environment: prod` gate on the orchestrator job (one click) is the
+  goal — confirm that satisfies the "one human checkpoint" intent vs. per-plane gates. Reuse
+  `workflow_call` / a `needs` chain of the three existing workflows rather than duplicating the
+  deploy logic — keep one source of truth.
+- All three pin the SAME sha so "roll all three to one sha" (PROD_RUNBOOK coupling rule) holds by
+  construction.
+
+### D2 — Fix the index-stats cache invalidation after in-place upserts (from B3)
+
+`/api/index/stats` (and the viewer index card + `reindex_recommended`) go stale after an
+incremental `POST /api/index/rebuild?rebuild=false`, because the perf_cache key
+(`perf_cache.lance_mtime` = top-level `lance_index/` dir mtime) doesn't change when LanceDB upserts
+write into table subdirectories. Fix options (pick one, add a regression test):
+
+- Have `_spawn_rebuild_thread` (routes/index_rebuild.py) call `clear_index_stats_cache()` in its
+  `finally` (it already calls `invalidate_newest_index_source_mtime_cache` — add this sibling). Most
+  direct + local.
+- OR make `perf_cache.lance_mtime` stat the NEWEST file recursively under the dir (not just the top
+  dir). More robust but touches a shared helper.
+- OR `os.utime(lance_dir)` at the end of a successful build so the dir mtime tracks table writes.
+- Regression test: build index → upsert a new episode → assert `/api/index/stats` count increments
+  WITHOUT an api restart or manual touch.
+- Land it as its own small fix on `main` (independent of the naming-arc branch).
+
+### D3 — Verify the deploy-event → VictoriaLogs / Sentry release path (from A3)
+
+VictoriaLogs ingestion is confirmed healthy (13,852 lines/1h), so the control-plane
+`deploy-event emit failed` was transient. Still worth confirming the Sentry/GlitchTip **release
+marker** actually lands for `sha-371e925` (the "Sentry release boundary failed" annotation). If a
+real gap, fix at cause (don't suppress).
+
+### D4 — `enrich-edges` produced no SPOKEN_BY / MENTIONS for the Step-0 episode (from B4)
+
+Despite Deepgram diarization finding 9 speakers, the new episode's GI edges show
+`HAS_EPISODE=1 MENTIONS=0 SPOKEN_BY=0`. Investigate whether incrementally-added episodes get their
+speaker/mention edges derived (compare to a batch-run episode's gi.json). If a real gap, it under-
+populates the KG for every incremental add. Verify before scaling (Step 1/2).
+
+### D5 — Per-episode cost is ~2× the planning estimate (from B4)
+
+Step 0 cost +$0.132 for one episode vs the handover's ~$0.05–0.06. Break down `by_stage`
+(transcription vs cleaning vs GI vs KG) for a single episode and confirm it's expected, because the
+Step 2 `$5/run` soft cap + "≤5 eps/feed" batching math assumes the cheaper number.
+
+### D6 — Rename the legacy `whisper_*` transcription fields (from B4)
+
+`content.whisper_model` and `content.transcript_source=whisper_transcription` are stale misnomers —
+they carried a Deepgram `nova-3` value this run and nearly triggered a false "wrong profile" alarm.
+Rename to provider-neutral fields (or set them from the actual provider) so logs/metadata don't
+imply Whisper when Deepgram ran.
+
+### D7 — Make skip-existing corpus-wide, not run-dir-scoped (from B5) — BLOCKS scaling
+
+`skip_existing` is guid-keyed (good) but its existence check
+(`resolve_ondisk_idx_for_episode(episode, effective_output_dir)` + `os.path.exists(final_out_path)`,
+episode_processor.py:321-346) only looks in the CURRENT run's `effective_output_dir`. Under
+`--single-feed-uses-corpus-layout` that's a fresh empty run dir, so an episode already present in a
+PRIOR run dir is not detected → full reprocess (Deepgram + LLM spend) on every incremental re-run,
+though episode_id dedup prevents a duplicate in the catalog COUNT.
+
+Fix: resolve the episode's existence by guid across ALL run dirs for the feed (reuse the
+`corpus_scope` union / newest-run-wins discovery that `3c01787d` built for the index), not just the
+current run dir. Add a Tier-2 matrix row: add an episode, re-run same feed with `skip_existing`,
+assert 0 transcription cost + episode skipped + no new run dir with content.
+
+**Until D7 lands: HOLD volume.** Each incremental re-add reprocesses already-present episodes
+(wasted spend). Single genuinely-new episodes still add correctly (Step 0 worked). Also clean up the
+orphaned duplicate run dir for the Step-0/1 Daily episode (`run_5d249ecb` superseded by
+`run_bea9f8bd`).
+
+---
+
+## E. Next actual step (rollout, deferred)
+
+Deploy + post-deploy validation are DONE and green. The real incremental-processing rollout has NOT
+started. Resume point (needs a pipeline run + the now-valid operator key):
+
+- **Step 0** — one episode, one feed, full end-to-end via `cloud_balanced`; diff the whole chain
+  against baseline (episode count +1, outcome `ok`, index/clusters/cost move, 0 errors).
+- **Step 1 (the crux)** — re-run the same feed with skip-existing; PASS = count stays flat + episode
+  skipped (idx-skip holds), FAIL = duplicate → hold volume until GUID-keyed skip (fix #1) lands.
+
+See `docs/wip/INCREMENTAL-PROCESSING-VALIDATION-ROLLOUT.md` for the full step-by-step + toolkit.

--- a/src/podcast_scraper/providers/deepgram/deepgram_provider.py
+++ b/src/podcast_scraper/providers/deepgram/deepgram_provider.py
@@ -263,6 +263,11 @@ class DeepgramTranscriptionProvider:
         if not os.path.exists(audio_path):
             raise FileNotFoundError(f"Audio file not found: {audio_path}")
 
+        # D9: announce the provider + model like the Whisper path does (ml_provider "transcribing
+        # with Whisper (...)"). Cloud providers were silent in the log, so an operator watching a
+        # run could not tell WHICH engine transcribed (the 2026-08-11 "did Deepgram run?" case).
+        logger.info("    transcribing with Deepgram (model=%s, diarize=on)...", self.model)
+
         # Own the call_metrics lifecycle like every sibling provider: instantiate
         # when the caller passes None so retry_with_metrics has somewhere to record
         # retries/backoff, and finalize() below so `retries`/`rate_limit_sleep_sec`

--- a/src/podcast_scraper/providers/ml/embedding_loader.py
+++ b/src/podcast_scraper/providers/ml/embedding_loader.py
@@ -202,6 +202,10 @@ def encode(
         texts_list,
         normalize_embeddings=normalize,
         batch_size=batch_size,
+        # D9: the index build calls encode() once per doc, so the default per-call tqdm bar floods
+        # the pipeline log ("Batches: 100%|...") — thousands of lines that bury real stage output
+        # and can truncate errors under the per-job log cap. The build reports its own progress.
+        show_progress_bar=False,
     )
 
     if return_numpy:

--- a/src/podcast_scraper/search/indexer.py
+++ b/src/podcast_scraper/search/indexer.py
@@ -557,7 +557,10 @@ def index_corpus(
         stats.errors.append(f"two-tier index build: {exc}")
         return stats
     stats.episodes_scanned = tt.episodes
-    stats.episodes_reindexed = tt.episodes
+    # D8: the two-tier builder now skips re-embedding UNCHANGED episodes. Reflect the real split so
+    # the stat + the "0 new vectors" warning below are accurate (previously always 0 = dead metric).
+    stats.episodes_skipped_unchanged = tt.episodes_skipped_unchanged
+    stats.episodes_reindexed = tt.episodes - tt.episodes_skipped_unchanged
     stats.vectors_upserted = tt.segments + tt.insights + tt.aux
     _warn_if_zero_vectors_built(stats)
     return stats

--- a/src/podcast_scraper/search/two_tier_indexer.py
+++ b/src/podcast_scraper/search/two_tier_indexer.py
@@ -20,8 +20,10 @@ migration left them empty (it had no edges to supply), so compounds need a nativ
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, cast, Dict, List, Optional, Tuple
@@ -30,7 +32,11 @@ from .. import config as _config, config_constants as _config_constants
 from ..providers.ml import embedding_loader
 from .backend import AuxDocument, InsightDocument, SegmentDocument
 from .backends.lancedb_backend import lance_index_is_stale, LanceDBBackend
-from .corpus_scope import discover_metadata_files, episode_root_from_metadata_path
+from .corpus_scope import (
+    discover_metadata_files,
+    episode_root_from_metadata_path,
+    index_fingerprint_scope_key,
+)
 from .indexer import _collect_docs_for_episode, _gi_path, _load_metadata_file
 from .segments import link_insights_to_segments, link_insights_to_segments_by_text
 
@@ -64,6 +70,14 @@ _AUX_DOC_TYPES = frozenset(
 )
 
 
+# D8: per-episode content fingerprints let an incremental reindex skip re-embedding UNCHANGED
+# episodes (embedding is the O(N) cost; upsert-merge-on-id is idempotent for storage but was not
+# for compute). Persisted next to the lance index. Bump ``_FP_SCHEMA_VERSION`` whenever the row
+# construction / chunking changes so every fingerprint invalidates and the next build re-embeds all.
+_EPISODE_FINGERPRINTS_FILENAME = "episode_fingerprints.json"
+_FP_SCHEMA_VERSION = 1
+
+
 @dataclass
 class TwoTierIndexStats:
     """Counts from a from-corpus two-tier index build."""
@@ -73,6 +87,8 @@ class TwoTierIndexStats:
     insights: int = 0
     aux: int = 0
     linked: int = 0
+    # D8: episodes whose content fingerprint matched the last build → embed+upsert skipped.
+    episodes_skipped_unchanged: int = 0
 
 
 def _embed(text: str, model_id: str, *, allow_download: bool) -> List[float]:
@@ -86,6 +102,97 @@ def _embed(text: str, model_id: str, *, allow_download: bool) -> List[float]:
         provider=cfg.vector_embedding_provider,
     )
     return [float(x) for x in cast(List[float], vec)]
+
+
+def _episode_fingerprint(rows: List[Tuple[str, str, dict]], model_id: str) -> str:
+    """Content hash of an episode's embeddable rows (D8).
+
+    Hashes the exact ``(doc_id, text)`` pairs that would be embedded, plus ``model_id`` +
+    ``_FP_SCHEMA_VERSION`` — so any change to embedded content, the embedding model, or the row
+    construction changes the hash and forces a re-embed. Order-independent (rows are sorted).
+    """
+    h = hashlib.sha256()
+    h.update(f"v{_FP_SCHEMA_VERSION}\x1f{model_id}".encode("utf-8"))
+    for doc_id, text, _meta in sorted(rows, key=lambda r: str(r[0])):
+        h.update(b"\x1e")
+        h.update(str(doc_id).encode("utf-8"))
+        h.update(b"\x1f")
+        h.update(str(text).encode("utf-8"))
+    return h.hexdigest()
+
+
+def _episode_scope_key(rows: List[Tuple[str, str, dict]], doc: dict) -> Optional[str]:
+    """Stable per-episode fingerprint key: ``index_fingerprint_scope_key(feed_id, episode_id)``.
+
+    Resolves ``(feed_id, episode_id)`` from the embeddable rows' meta (each carries them), falling
+    back to the loaded episode metadata. ``None`` when no episode_id is resolvable (never skip).
+    """
+    for _doc_id, _text, meta in rows:
+        eid = meta.get("episode_id")
+        if isinstance(eid, str) and eid:
+            return index_fingerprint_scope_key(meta.get("feed_id"), eid)
+    ep = doc.get("episode") if isinstance(doc, dict) else None
+    if isinstance(ep, dict):
+        eid = ep.get("episode_id")
+        if isinstance(eid, str) and eid:
+            return index_fingerprint_scope_key(ep.get("feed_id"), eid)
+    return None
+
+
+def _fingerprints_path(lance_path: Path | str) -> Path:
+    return Path(lance_path).parent / _EPISODE_FINGERPRINTS_FILENAME
+
+
+def _load_episode_fingerprints(lance_path: Path | str) -> Dict[str, str]:
+    """Load ``{scope_key: fingerprint}`` from the sidecar next to the index; ``{}`` if absent."""
+    try:
+        data = json.loads(_fingerprints_path(lance_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    fps = data.get("fingerprints") if isinstance(data, dict) else None
+    return {str(k): str(v) for k, v in fps.items()} if isinstance(fps, dict) else {}
+
+
+def _write_episode_fingerprints(lance_path: Path | str, fps: Dict[str, str]) -> None:
+    """Atomically persist the fingerprints sidecar (temp + rename). Non-fatal on failure."""
+    p = _fingerprints_path(lance_path)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_name(p.name + ".tmp")
+        tmp.write_text(
+            json.dumps({"schema": _FP_SCHEMA_VERSION, "fingerprints": fps}, sort_keys=True),
+            encoding="utf-8",
+        )
+        tmp.replace(p)
+    except OSError as exc:  # a fingerprint-write hiccup must never fail the index build
+        logger.warning("could not write %s: %s", p, exc)
+
+
+def _fingerprint_skip_unchanged(
+    rows: List[Tuple[str, str, dict]],
+    doc: dict,
+    model_id: str,
+    stored_fps: Dict[str, str],
+    result_fps: Dict[str, str],
+    clear_requested: bool,
+    index_metadata: Dict[str, dict],
+) -> bool:
+    """D8: decide whether this episode is UNCHANGED and can skip embed+upsert.
+
+    Records the episode's current fingerprint in ``result_fps`` (so it carries forward), and when
+    skipping, populates ``index_metadata`` (cheap, no embed) so the rewritten metadata.json sidecar
+    stays complete. Returns True only when a prior fingerprint matches and it is not a full rebuild.
+    """
+    fp = _episode_fingerprint(rows, model_id)
+    scope_key = _episode_scope_key(rows, doc)
+    if not scope_key:
+        return False  # no stable key → always (re)embed
+    result_fps[scope_key] = fp
+    if clear_requested or stored_fps.get(scope_key) != fp:
+        return False
+    for doc_id, _text, meta in rows:
+        index_metadata[doc_id] = {k: v for k, v in meta.items() if k != "text"}
+    return True
 
 
 def _insight_grounding_quotes(gi_path: Path) -> Dict[str, Tuple[float, Optional[float]]]:
@@ -233,6 +340,13 @@ def build_two_tier_index(
     stats = TwoTierIndexStats()
     backend: Optional[LanceDBBackend] = None
 
+    # D8: load prior per-episode fingerprints so an incremental build can skip re-embedding
+    # UNCHANGED episodes. A full/stale reindex (clear_requested) ignores them, rebuilds every
+    # episode, then rewrites a fresh sidecar. ``result_fps`` accumulates every walked episode's
+    # current fingerprint (skipped + embedded) and replaces the file on success.
+    stored_fps: Dict[str, str] = {} if clear_requested else _load_episode_fingerprints(lance_path)
+    result_fps: Dict[str, str] = {}
+
     def _ensure_backend(vec_len: int) -> LanceDBBackend:
         # Lazy: size the schema from the model's real dim (or an explicit override) on
         # the first embedded doc, so a non-MiniLM model can't silently mismatch — and an
@@ -309,6 +423,14 @@ def build_two_tier_index(
             overlap_tokens=overlap_tokens,
             metadata_relative_path=meta_rel,
         )
+        # D8: skip re-embedding an UNCHANGED episode. ``_collect_docs_for_episode`` above is cheap;
+        # ``_embed`` below is the O(N) cost. If the episode's content fingerprint matches the last
+        # build, its rows are already embedded+upserted (merge on id) — skip embed+upsert.
+        if _fingerprint_skip_unchanged(
+            rows, doc, model_id, stored_fps, result_fps, clear_requested, index_metadata
+        ):
+            stats.episodes_skipped_unchanged += 1
+            continue
         # Collect this episode's docs first, then link insights to the segment that
         # contains their grounding quote, then upsert — so linked_insight_ids /
         # source_segment_id are populated (the compound-result path needs them).
@@ -409,21 +531,60 @@ def build_two_tier_index(
     _flush_insights()
     _flush_auxes()
 
-    # Full/stale reindex: MVCC-empty any tier that existed before but got no rows this
-    # build, so its stale rows don't survive the "clear" (rmtree parity, no reader stranded).
+    _finalize_index_build(
+        backend,
+        lance_path,
+        clear_requested=clear_requested,
+        pre_existing_tiers=pre_existing_tiers,
+        overwritten_tiers=overwritten_tiers,
+        index_metadata=index_metadata,
+        model_id=model_id,
+    )
+    # D8: persist fingerprints on success so the NEXT incremental build can skip unchanged episodes.
+    # A mid-build failure returns/raises before here, leaving the old sidecar → next build re-embeds
+    # (safe). Skipped on a limited walk (a partial episode set would drop fingerprints for un-walked
+    # episodes, forcing needless re-embeds — but never staleness).
+    if limit_episodes is None:
+        _write_episode_fingerprints(lance_path, result_fps)
+    return stats
+
+
+def _finalize_index_build(
+    backend: Optional[LanceDBBackend],
+    lance_path: str | Path,
+    *,
+    clear_requested: bool,
+    pre_existing_tiers: set,
+    overwritten_tiers: set,
+    index_metadata: Dict[str, dict],
+    model_id: str,
+) -> None:
+    """Post-walk finalize: clear stale tiers, write index meta, compact, re-emit the sidecar, and
+    bump the index dir mtime (D2). Extracted from ``build_two_tier_index`` to keep it under the
+    complexity gate."""
+    # Full/stale reindex: MVCC-empty any tier that existed before but got no rows this build, so its
+    # stale rows don't survive the "clear" (rmtree parity, no reader stranded).
     if clear_requested:
         _finalize_reindex_clear(Path(lance_path), backend, pre_existing_tiers, overwritten_tiers)
-
-    if backend is not None:
-        backend.write_index_meta(model_id)  # query path must embed in the same space
-        backend.create_indices()
-        # Reclaim the fragments + superseded versions this build created, so the index
-        # stays bounded across full AND incremental reindexes.
-        backend.compact()
-        # Re-emit the FAISS-era ``metadata.json`` sidecar (doc_id -> meta) next to the index;
-        # the GIL chunk-offset verifier reads char_start/char_end from it (see note above).
-        (Path(lance_path).parent / "metadata.json").write_text(
-            json.dumps(index_metadata, ensure_ascii=False, sort_keys=True),
-            encoding="utf-8",
-        )
-    return stats
+    if backend is None:
+        return
+    backend.write_index_meta(model_id)  # query path must embed in the same space
+    backend.create_indices()
+    # Reclaim the fragments + superseded versions this build created, so the index stays bounded
+    # across full AND incremental reindexes.
+    backend.compact()
+    # Re-emit the FAISS-era ``metadata.json`` sidecar (doc_id -> meta) next to the index; the GIL
+    # chunk-offset verifier reads char_start/char_end from it.
+    (Path(lance_path).parent / "metadata.json").write_text(
+        json.dumps(index_metadata, ensure_ascii=False, sort_keys=True),
+        encoding="utf-8",
+    )
+    # D2: LanceDB upserts write into per-table SUBDIRS and don't bump the top-level index dir
+    # mtime — but read_lance_index_stats() caches on that mtime (perf_cache.lance_mtime) and derives
+    # last_updated from it. Bump it after any build that changed the index so the stats endpoint +
+    # viewer index card refresh — INCLUDING a pipeline-subprocess reindex (an in-process cache clear
+    # can't cross that boundary; the on-disk mtime can).
+    try:
+        os.utime(lance_path, None)
+    except OSError:  # non-fatal: a stale stats card must never fail the index build
+        pass

--- a/src/podcast_scraper/workflow/episode_processor.py
+++ b/src/podcast_scraper/workflow/episode_processor.py
@@ -343,7 +343,21 @@ def download_media_for_transcription(
             metadata_named=list(metadata_named) if metadata_named else None,
             episode=episode,
         )
-    if cfg.skip_existing and os.path.exists(final_out_path):
+    # D7: under --single-feed-uses-corpus-layout each run writes a FRESH run dir, so an
+    # already-processed episode's transcript is in a PRIOR run dir — NOT final_out_path (this run's
+    # OUTPUT path). Resolve presence corpus-wide by stable guid; else skip-existing scoped to the
+    # empty run dir silently re-transcribes it (the Step-1 NO-GO, 2026-08-11).
+    _corpus_layout = bool(getattr(cfg, "single_feed_uses_corpus_layout", False))
+    if cfg.skip_existing and _corpus_layout and cfg.output_dir:
+        _existing_transcript = run_index.existing_transcript_path_in_corpus(
+            episode, str(cfg.output_dir)
+        )
+    elif cfg.skip_existing and os.path.exists(final_out_path):
+        _existing_transcript = final_out_path
+    else:
+        _existing_transcript = None
+
+    if cfg.skip_existing and _existing_transcript is not None:
         if _force_reprocess_for_source(episode, effective_output_dir, run_suffix, cfg):
             # #925: a scoped reprocess (--reprocess-source) forces matching episodes
             # (e.g. whisper_transcription) back through download+transcribe so diarization
@@ -355,25 +369,26 @@ def download_media_for_transcription(
                 "[%s] [#925] forcing re-transcription + diarization (reprocess-source=%s): %s",
                 episode.idx,
                 cfg.reprocess_source,
-                final_out_path,
+                _existing_transcript,
             )
             # Fall through: schedule download/transcribe.
-        elif _should_retranscribe_for_gi_segments(cfg, final_out_path):
+        elif _should_retranscribe_for_gi_segments(cfg, _existing_transcript):
             logger.info(
                 "[%s] Transcript exists without .segments.json; will re-transcribe to populate "
                 "sidecar for GI quote timestamps and segment-backed speaker_id when segments "
                 "carry speaker labels (backfill_transcript_segments + generate_gi): %s",
                 episode.idx,
-                final_out_path,
+                _existing_transcript,
             )
             # Fall through: do not return — schedule download/transcribe to populate sidecar (#542).
-        # If generate_summaries is enabled, still return a job so transcript path can be used
-        # for summarization (even though we won't re-transcribe)
-        elif cfg.generate_summaries:
+        # If generate_summaries is enabled, still return a job so transcript path can be used for
+        # summarization (even though we won't re-transcribe). NOT in corpus-layout: there the
+        # episode is already fully processed in a prior run — reusing re-summarizes; skip instead.
+        elif cfg.generate_summaries and not _corpus_layout:
             logger.debug(
                 "[%s] Transcript exists, but will use for summarization: %s",
                 episode.idx,
-                final_out_path,
+                _existing_transcript,
             )
             # Return a job with empty temp_media since we won't download/transcribe
             # CRITICAL: Create a copy of detected_speaker_names to prevent shared mutable state
@@ -393,7 +408,7 @@ def download_media_for_transcription(
                 "[%s] %stranscript already exists; skipping (--skip-existing): %s",
                 episode.idx,
                 prefix,
-                final_out_path,
+                _existing_transcript,
             )
             return None
 
@@ -2765,6 +2780,20 @@ def _check_existing_transcript(
             cfg.reprocess_source,
             episode.title_safe,
         )
+        return False
+
+    # D7: under --single-feed-uses-corpus-layout each run writes a FRESH run dir, so the episode's
+    # transcript lives in a PRIOR run dir, not effective_output_dir. Resolve presence corpus-wide by
+    # stable guid (all feeds/runs) — else skip-existing scoped to the empty run dir silently
+    # re-transcribes an already-present episode (the Step-1 NO-GO, 2026-08-11).
+    if getattr(cfg, "single_feed_uses_corpus_layout", False) and cfg.output_dir:
+        present = run_index.episode_metadata_rel_in_corpus(episode, str(cfg.output_dir))
+        if present:
+            prefix = "[dry-run] " if cfg.dry_run else ""
+            logger.info(
+                "    %salready present in corpus, skipping (--skip-existing): %s", prefix, present
+            )
+            return True
         return False
 
     run_tag = f"_{run_suffix}" if run_suffix else ""

--- a/src/podcast_scraper/workflow/run_index.py
+++ b/src/podcast_scraper/workflow/run_index.py
@@ -375,6 +375,54 @@ def resolve_ondisk_idx_for_episode(episode: Any, output_dir: str) -> int:
     return int(episode.idx)
 
 
+def episode_metadata_rel_in_corpus(episode: Any, corpus_root: str) -> Optional[str]:
+    """Return the metadata path (relative to *corpus_root*) if this episode already exists ANYWHERE
+    in the corpus (by STABLE guid), else ``None`` (D7).
+
+    Corpus-wide: ``corpus_metadata_index`` globs ``feeds/*/run_*/metadata/*`` across ALL runs, so an
+    episode processed under a PRIOR run dir is found even when the current run writes a fresh run
+    dir (``--single-feed-uses-corpus-layout``). Without this, skip-existing scoped to the fresh
+    (empty) run dir silently re-transcribes an already-present episode.
+    """
+    guid = _episode_guid(episode)
+    if not guid:
+        return None
+    entry = corpus_metadata_index(corpus_root)["by_guid"].get(guid)
+    if entry is None:
+        return None
+    if os.path.isfile(os.path.join(corpus_root, entry.metadata_rel)):
+        return entry.metadata_rel
+    return None
+
+
+def existing_transcript_path_in_corpus(episode: Any, corpus_root: str) -> Optional[str]:
+    """Absolute path to this episode's existing transcript (or its metadata, as a presence marker)
+    ANYWHERE in the corpus, else ``None`` (D7). Used by the corpus-layout skip-existing path so the
+    reuse/segment-backfill/skip sub-cases resolve against the real prior-run artifact.
+    """
+    meta_rel = episode_metadata_rel_in_corpus(episode, corpus_root)
+    if meta_rel is None:
+        return None
+    meta_abs = Path(corpus_root) / meta_rel
+    stem = meta_abs.name
+    base = stem
+    for suffix in (".metadata.json", ".metadata.yaml", ".metadata.yml"):
+        if stem.endswith(suffix):
+            base = stem[: -len(suffix)]
+            break
+    transcripts_dir = meta_abs.parent.parent / "transcripts"
+    if transcripts_dir.is_dir():
+        preferred = transcripts_dir / f"{base}.txt"
+        if preferred.is_file():
+            return str(preferred)
+        for candidate in sorted(transcripts_dir.glob(f"{base}.*")):
+            if candidate.is_file():
+                return str(candidate)
+    # Metadata present but no transcript file located → the metadata itself marks the episode as
+    # processed (skip-existing only needs presence; the path is used for logging).
+    return str(meta_abs)
+
+
 def find_episode_metadata_relative_path(
     episode: Any,
     effective_output_dir: str,

--- a/tests/integration/search/test_incremental_indexer_helpers.py
+++ b/tests/integration/search/test_incremental_indexer_helpers.py
@@ -1,0 +1,86 @@
+"""Unit coverage for the D8/D2 incremental-indexer helpers (fingerprint + scope key + persistence).
+
+Pure-function branches of ``two_tier_indexer`` that the integration build tests don't exercise:
+fingerprint determinism/sensitivity, scope-key resolution + fallback + None, fingerprint file
+load (missing/malformed), and the D2 ``os.utime`` failure being non-fatal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.critical_path]
+
+pytest.importorskip("lancedb")
+
+from podcast_scraper.search import two_tier_indexer as tti  # noqa: E402
+
+
+def _rows(ep_id="ep1", feed="s", text="hello"):
+    return [
+        (f"insight:{ep_id}", text, {"doc_type": "insight", "episode_id": ep_id, "feed_id": feed})
+    ]
+
+
+def test_fingerprint_is_deterministic_and_order_independent():
+    a = tti._episode_fingerprint(_rows(), "m")
+    b = tti._episode_fingerprint(list(reversed(_rows() + _rows(ep_id="ep2"))), "m")
+    c = tti._episode_fingerprint(_rows() + _rows(ep_id="ep2"), "m")
+    assert a == tti._episode_fingerprint(_rows(), "m")  # stable
+    assert b == c  # order-independent
+
+
+def test_fingerprint_changes_with_content_and_model():
+    base = tti._episode_fingerprint(_rows(text="x"), "m")
+    assert base != tti._episode_fingerprint(_rows(text="y"), "m")  # content
+    assert base != tti._episode_fingerprint(_rows(text="x"), "other-model")  # model
+
+
+def test_scope_key_from_rows_then_doc_fallback_then_none():
+    # resolves (feed_id, episode_id) from the rows' meta
+    assert tti._episode_scope_key(_rows("epR", "f"), {}) == tti.index_fingerprint_scope_key(
+        "f", "epR"
+    )
+    # rows carry no episode_id → fall back to the loaded metadata's episode
+    no_id_rows = [("q:1", "t", {"doc_type": "quote"})]
+    assert tti._episode_scope_key(
+        no_id_rows, {"episode": {"episode_id": "epD", "feed_id": "f"}}
+    ) == tti.index_fingerprint_scope_key("f", "epD")
+    # neither rows nor doc resolve an episode_id → None (never skip)
+    assert tti._episode_scope_key(no_id_rows, {"episode": {}}) is None
+
+
+def test_load_fingerprints_missing_or_malformed_returns_empty(tmp_path):
+    lance = tmp_path / "search" / "lance_index"
+    lance.mkdir(parents=True)
+    assert tti._load_episode_fingerprints(lance) == {}  # absent
+    tti._fingerprints_path(lance).write_text("not json", encoding="utf-8")
+    assert tti._load_episode_fingerprints(lance) == {}  # malformed
+    tti._write_episode_fingerprints(lance, {"k": "v"})
+    assert tti._load_episode_fingerprints(lance) == {"k": "v"}  # round-trip
+
+
+def test_utime_failure_is_non_fatal(tmp_path, monkeypatch, caplog):
+    """D2: bumping the index dir mtime must never fail a build."""
+
+    def _boom(*a, **k):
+        raise OSError("nope")
+
+    monkeypatch.setattr(tti.os, "utime", _boom)
+    corpus = tmp_path / "corpus"
+    (corpus / "metadata").mkdir(parents=True)
+    meta = corpus / "metadata" / "ep1.metadata.json"
+    monkeypatch.setattr(tti, "discover_metadata_files", lambda root: [meta])
+    monkeypatch.setattr(tti, "_load_metadata_file", lambda p: {"episode": {"episode_id": "ep1"}})
+    monkeypatch.setattr(tti, "episode_root_from_metadata_path", lambda p: corpus)
+    monkeypatch.setattr(
+        tti,
+        "_collect_docs_for_episode",
+        lambda *a, **k: [
+            ("insight:ep1", "t", {"doc_type": "insight", "episode_id": "ep1", "feed_id": "s"})
+        ],
+    )
+    monkeypatch.setattr(tti, "_embed", lambda text, m, *, allow_download: [0.1] * 8)
+
+    stats = tti.build_two_tier_index(corpus, corpus / "search" / "lance_index", drop_existing=True)
+    assert stats.episodes == 1  # build succeeded despite os.utime raising

--- a/tests/integration/search/test_index_stats_freshness.py
+++ b/tests/integration/search/test_index_stats_freshness.py
@@ -1,0 +1,88 @@
+"""Guardrail: /api/index/stats must not go STALE after an incremental index write (D2).
+
+Prod defect (2026-08-11): ``read_lance_index_stats`` memoizes in ``perf_cache`` keyed on
+``perf_cache.lance_mtime`` = the top-level ``lance_index/`` dir mtime. LanceDB upserts write into
+per-TABLE subdirectories and do NOT bump the parent dir mtime, so after an incremental add the cache
+key never changed and the endpoint kept reporting the pre-add counts (94 while the table held 106),
+with a frozen ``last_updated``. The fix bumps the index dir mtime after a build that changed the
+index (works across the pipeline subprocess boundary, unlike an in-process cache clear).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.critical_path]
+
+pytest.importorskip("lancedb")
+
+from podcast_scraper.search import two_tier_indexer as tti  # noqa: E402
+from podcast_scraper.search.lance_index_stats import (  # noqa: E402
+    clear_index_stats_cache,
+    read_lance_index_stats,
+)
+
+_DIM = 8
+
+
+def _fake_embed(text: str, model_id: str, *, allow_download: bool):
+    h = abs(hash(text))
+    return [float((h >> (i * 3)) & 0x7) / 7.0 for i in range(_DIM)]
+
+
+def _rows(ep_id: str):
+    return [
+        (
+            f"insight:{ep_id}",
+            f"insight {ep_id}",
+            {"doc_type": "insight", "episode_id": ep_id, "feed_id": "s"},
+        ),
+        (
+            f"chunk:{ep_id}",
+            f"chunk {ep_id}",
+            {
+                "doc_type": "transcript",
+                "episode_id": ep_id,
+                "feed_id": "s",
+                "timestamp_start_ms": 0,
+                "timestamp_end_ms": 1000,
+            },
+        ),
+    ]
+
+
+def _install(monkeypatch, tmp_path, episode_ids):
+    corpus = tmp_path / "corpus"
+    (corpus / "metadata").mkdir(parents=True, exist_ok=True)
+    metas = {ep: corpus / "metadata" / f"{ep}.metadata.json" for ep in episode_ids}
+    monkeypatch.setattr(tti, "discover_metadata_files", lambda root: list(metas.values()))
+    monkeypatch.setattr(
+        tti, "_load_metadata_file", lambda p: {"episode": {"episode_id": p.name.split(".")[0]}}
+    )
+    monkeypatch.setattr(tti, "episode_root_from_metadata_path", lambda p: corpus)
+    monkeypatch.setattr(
+        tti, "_collect_docs_for_episode", lambda er, mp, *a, **k: _rows(mp.name.split(".")[0])
+    )
+    monkeypatch.setattr(tti, "_embed", _fake_embed)
+    return corpus
+
+
+def test_index_stats_reflects_incremental_add(tmp_path, monkeypatch):
+    clear_index_stats_cache()
+    episode_ids = ["ep1"]
+    corpus = _install(monkeypatch, tmp_path, episode_ids)
+    lance = corpus / "search" / "lance_index"
+
+    tti.build_two_tier_index(corpus, lance, drop_existing=True)
+    first = read_lance_index_stats(lance)
+    assert first is not None and first.total_vectors == 2  # 1 insight + 1 chunk
+
+    # Incremental add of a NEW episode: writes into existing table subdirs (does NOT bump the
+    # top-level lance_index/ dir mtime by itself). The cached stats must still refresh.
+    episode_ids.append("ep2")
+    _install(monkeypatch, tmp_path, episode_ids)
+    tti.build_two_tier_index(corpus, lance, drop_existing=False)
+
+    second = read_lance_index_stats(lance)
+    assert second is not None
+    assert second.total_vectors == 4, "index/stats went stale after an incremental add (D2)"

--- a/tests/integration/search/test_two_tier_indexer_incremental.py
+++ b/tests/integration/search/test_two_tier_indexer_incremental.py
@@ -1,0 +1,160 @@
+"""Guardrail: the two-tier indexer must be INCREMENTAL — re-embedding only new/changed episodes.
+
+This is the D8 regression suite (see docs/wip/DESIGN-D8-incremental-indexer-skip.md). It reproduces
+the prod defect where every incremental corpus add re-embedded the ENTIRE corpus (O(N)): adding one
+episode to 107 took ~10.6 min because ``build_two_tier_index`` had no unchanged-episode skip and
+``episodes_skipped_unchanged`` was a dead stat.
+
+The guardrail asserts EMBED CALL COUNT (compute), not just stored rows — upsert is idempotent for
+storage but was not for compute. ``_embed`` is stubbed as a counter so the assertions are exact and
+model-free.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.critical_path]
+
+pytest.importorskip("lancedb")
+
+from podcast_scraper.search import two_tier_indexer as tti  # noqa: E402
+
+_EMBED_DIM = 8
+
+
+class _EmbedCounter:
+    """Deterministic fake embedder that counts calls. Distinct text -> distinct vector so the
+    LanceDB upsert path behaves; the test only asserts the CALL COUNT."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.texts: list[str] = []
+
+    def __call__(self, text: str, model_id: str, *, allow_download: bool):  # matches tti._embed
+        self.calls += 1
+        self.texts.append(text)
+        h = abs(hash(text))
+        return [float((h >> (i * 3)) & 0x7) / 7.0 for i in range(_EMBED_DIM)]
+
+
+def _episode_rows(ep_id: str, *, variant: str = "a"):
+    """Two embeddable docs per episode (one insight, one transcript chunk)."""
+    return [
+        (
+            f"insight:{ep_id}",
+            f"insight text for {ep_id} {variant}",
+            {"doc_type": "insight", "episode_id": ep_id, "feed_id": "show1", "grounded": True},
+        ),
+        (
+            f"chunk:{ep_id}",
+            f"transcript chunk for {ep_id} {variant}",
+            {
+                "doc_type": "transcript",
+                "episode_id": ep_id,
+                "feed_id": "show1",
+                "timestamp_start_ms": 0,
+                "timestamp_end_ms": 1000,
+            },
+        ),
+    ]
+
+
+def _install_corpus(monkeypatch, tmp_path, episodes: dict[str, str], counter: _EmbedCounter):
+    """Wire the indexer to a synthetic corpus of ``{episode_id: variant}`` with a counting embedder.
+
+    ``episodes`` maps episode_id -> content variant; changing a variant changes the collected rows
+    (so a "changed episode" re-embeds). Re-call to mutate the corpus between builds.
+    """
+    corpus = tmp_path / "corpus"
+    (corpus / "metadata").mkdir(parents=True, exist_ok=True)
+    meta_paths = {ep: corpus / "metadata" / f"{ep}.metadata.json" for ep in episodes}
+
+    monkeypatch.setattr(tti, "discover_metadata_files", lambda root: list(meta_paths.values()))
+    monkeypatch.setattr(
+        tti, "_load_metadata_file", lambda p: {"episode": {"episode_id": p.name.split(".")[0]}}
+    )
+    monkeypatch.setattr(tti, "episode_root_from_metadata_path", lambda p: corpus)
+    monkeypatch.setattr(
+        tti,
+        "_collect_docs_for_episode",
+        lambda episode_root, meta_path, *a, **k: _episode_rows(
+            meta_path.name.split(".")[0], variant=episodes[meta_path.name.split(".")[0]]
+        ),
+    )
+    monkeypatch.setattr(tti, "_embed", counter)
+    return corpus
+
+
+def test_full_build_embeds_all_episodes(tmp_path, monkeypatch):
+    counter = _EmbedCounter()
+    corpus = _install_corpus(monkeypatch, tmp_path, {"ep1": "a", "ep2": "a"}, counter)
+    lance = corpus / "search" / "lance_index"
+
+    stats = tti.build_two_tier_index(corpus, lance, drop_existing=True)
+
+    assert stats.episodes == 2
+    assert counter.calls == 4  # 2 episodes x 2 docs
+    assert getattr(stats, "episodes_skipped_unchanged", 0) == 0
+
+
+def test_reindex_unchanged_corpus_embeds_nothing(tmp_path, monkeypatch):
+    """THE core D8 guardrail: rebuilding an unchanged corpus must re-embed ZERO episodes."""
+    counter = _EmbedCounter()
+    corpus = _install_corpus(monkeypatch, tmp_path, {"ep1": "a", "ep2": "a"}, counter)
+    lance = corpus / "search" / "lance_index"
+
+    tti.build_two_tier_index(corpus, lance, drop_existing=True)
+    first = counter.calls
+    assert first == 4
+
+    stats2 = tti.build_two_tier_index(corpus, lance, drop_existing=False)
+
+    assert counter.calls - first == 0, "unchanged corpus must not re-embed any episode (D8)"
+    assert stats2.episodes_skipped_unchanged == 2
+
+
+def test_incremental_add_embeds_only_new_episode(tmp_path, monkeypatch):
+    counter = _EmbedCounter()
+    episodes = {"ep1": "a", "ep2": "a"}
+    corpus = _install_corpus(monkeypatch, tmp_path, episodes, counter)
+    lance = corpus / "search" / "lance_index"
+    tti.build_two_tier_index(corpus, lance, drop_existing=True)
+    baseline = counter.calls
+
+    episodes["ep3"] = "a"  # add one episode
+    _install_corpus(monkeypatch, tmp_path, episodes, counter)
+    stats = tti.build_two_tier_index(corpus, lance, drop_existing=False)
+
+    assert counter.calls - baseline == 2, "only the new episode's 2 docs should embed (D8)"
+    assert stats.episodes_skipped_unchanged == 2
+    assert stats.episodes == 3
+
+
+def test_changed_episode_is_reembedded(tmp_path, monkeypatch):
+    counter = _EmbedCounter()
+    episodes = {"ep1": "a", "ep2": "a"}
+    corpus = _install_corpus(monkeypatch, tmp_path, episodes, counter)
+    lance = corpus / "search" / "lance_index"
+    tti.build_two_tier_index(corpus, lance, drop_existing=True)
+    baseline = counter.calls
+
+    episodes["ep1"] = "b"  # content change -> fingerprint differs
+    _install_corpus(monkeypatch, tmp_path, episodes, counter)
+    stats = tti.build_two_tier_index(corpus, lance, drop_existing=False)
+
+    assert counter.calls - baseline == 2, "only the changed episode's docs re-embed (D8)"
+    assert stats.episodes_skipped_unchanged == 1
+
+
+def test_full_rebuild_ignores_fingerprints_and_reembeds_all(tmp_path, monkeypatch):
+    counter = _EmbedCounter()
+    corpus = _install_corpus(monkeypatch, tmp_path, {"ep1": "a", "ep2": "a"}, counter)
+    lance = corpus / "search" / "lance_index"
+    tti.build_two_tier_index(corpus, lance, drop_existing=True)
+    baseline = counter.calls
+
+    stats = tti.build_two_tier_index(corpus, lance, drop_existing=True)
+
+    assert counter.calls - baseline == 4, "drop_existing=True must re-embed everything"
+    assert stats.episodes_skipped_unchanged == 0

--- a/tests/integration/test_multi_run_corpus_incremental_index.py
+++ b/tests/integration/test_multi_run_corpus_incremental_index.py
@@ -1,0 +1,96 @@
+"""Composition guardrail: discovery + two-tier indexer over a realistic MULTI-RUN corpus (D7/D8).
+
+Codifies the prod Step-0/Step-1 scenario as an automated test — the exact path that had ZERO
+coverage and let D7 (skip re-transcribe) and D8 (re-embed whole corpus) ship. Uses the shared
+``build_multi_run_fixture`` generator (3 runs per feed with GUID overlap) so the assertions run over
+the real ``feeds/<slug>/run_*/metadata`` layout, not a hand-built flat dir:
+
+* discovery union + newest-run-wins → the index episode set == cumulative-UNIQUE episodes (not the
+  sum across runs, and not the last-run-only count);
+* a second reindex of the unchanged corpus re-embeds NOTHING (D8 incremental skip).
+
+``_embed`` is stubbed as a counter (compute assertion, model-free); ``_collect_docs_for_episode`` /
+``discover_metadata_files`` run for real against the fixture so the discovery path is exercised.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.critical_path]
+
+pytest.importorskip("lancedb")
+
+_GENERATOR = (
+    Path(__file__).resolve().parents[2] / "scripts" / "tools" / "build_multi_run_fixture.py"
+)
+_spec = importlib.util.spec_from_file_location("_build_multi_run_fixture_index", _GENERATOR)
+fixture = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(fixture)  # type: ignore[union-attr]
+
+from podcast_scraper.search import two_tier_indexer as tti  # noqa: E402
+
+_DIM = 8
+
+
+class _EmbedCounter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, text: str, model_id: str, *, allow_download: bool):
+        self.calls += 1
+        h = abs(hash(text))
+        return [float((h >> (i * 3)) & 0x7) / 7.0 for i in range(_DIM)]
+
+
+def _distinct_indexed_episodes(lance) -> int:
+    from podcast_scraper.search.backends.lancedb_backend import LanceDBBackend
+
+    be = LanceDBBackend(str(lance))
+    eps: set[str] = set()
+    for tier in ("segment", "insight", "aux"):
+        tbl = be._open_if_exists(tier)
+        if tbl is None:
+            continue
+        n = tbl.count_rows()
+        if "episode_id" in tbl.schema.names and n:
+            for r in tbl.search().limit(n).select(["episode_id"]).to_list():
+                if r.get("episode_id"):
+                    eps.add(str(r["episode_id"]))
+    return len(eps)
+
+
+def test_index_over_multi_run_corpus_unions_newest_run(tmp_path, monkeypatch):
+    counter = _EmbedCounter()
+    monkeypatch.setattr(tti, "_embed", counter)
+
+    corpus = tmp_path / "corpus"
+    summary = fixture.build_fixture(
+        corpus,
+        n_feeds=1,
+        probe_episodes=1,
+        middle_episodes=3,
+        latest_episodes=3,
+        overlap=2,
+    )
+    # cumulative unique = middle + (latest - overlap) = 3 + (3 - 2) = 4 (newest run wins on overlap).
+    expected_unique = summary["cumulative_unique_total"]
+    assert expected_unique == 4
+
+    lance = corpus / "search" / "lance_index"
+    stats = tti.build_two_tier_index(corpus, lance, drop_existing=True)
+
+    # The indexer must see the UNION across runs with newest-run-wins — 4 distinct episodes, not the
+    # 7 written across the three run dirs, and not the 3 of the latest run alone.
+    assert stats.episodes == expected_unique
+    assert _distinct_indexed_episodes(lance) == expected_unique
+    assert counter.calls > 0
+
+    # D8 composition: reindex the unchanged multi-run corpus → zero re-embeds.
+    before = counter.calls
+    stats2 = tti.build_two_tier_index(corpus, lance, drop_existing=False)
+    assert counter.calls - before == 0
+    assert stats2.episodes_skipped_unchanged == expected_unique

--- a/tests/unit/podcast_scraper/providers/deepgram/test_deepgram_provider.py
+++ b/tests/unit/podcast_scraper/providers/deepgram/test_deepgram_provider.py
@@ -170,6 +170,38 @@ class TestDeepgramTranscriptionProvider:
         mock_create_client.assert_called_once_with("dg-test-key", base_url=None)
 
     @patch("podcast_scraper.providers.deepgram.deepgram_provider._create_deepgram_client")
+    def test_transcribe_logs_provider_and_model(self, mock_create_client, caplog) -> None:
+        """D9: cloud transcription announces provider+model so an operator watching a run can tell
+        WHICH engine ran (the 2026-08-11 'did Deepgram even run?' confusion — cloud was silent)."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+        mock_client.listen.v1.media.transcribe_file.return_value = {
+            "results": {"channels": [{"alternatives": [{"transcript": "hi"}]}]}
+        }
+        cfg = config.Config(
+            rss="https://example.com/feed.xml",
+            transcription_provider="deepgram",
+            deepgram_api_key="dg-test-key",
+            deepgram_model="nova-3",
+        )
+        provider = DeepgramTranscriptionProvider(cfg)
+        provider.initialize()
+        with (
+            patch("builtins.open", create=True) as mock_open,
+            patch(
+                "podcast_scraper.providers.deepgram.deepgram_provider.os.path.exists",
+                return_value=True,
+            ),
+            caplog.at_level("INFO", logger="podcast_scraper.providers.deepgram.deepgram_provider"),
+        ):
+            mock_open.return_value.__enter__.return_value.read.return_value = b"audio"
+            provider.transcribe_with_segments("/tmp/ep.mp3", language="en")
+
+        assert any(
+            "Deepgram" in r.message and "nova-3" in r.message for r in caplog.records
+        ), "transcription must log the provider + model (D9)"
+
+    @patch("podcast_scraper.providers.deepgram.deepgram_provider._create_deepgram_client")
     def test_initialize_passes_api_base_override(self, mock_create_client) -> None:
         """deepgram_api_base (self-hosted / mock server) is forwarded to the client."""
         mock_create_client.return_value = MagicMock()

--- a/tests/unit/podcast_scraper/workflow/test_skip_existing_across_runs.py
+++ b/tests/unit/podcast_scraper/workflow/test_skip_existing_across_runs.py
@@ -1,0 +1,200 @@
+"""Guardrail: skip-existing must be CORPUS-WIDE, not scoped to the current run dir (D7).
+
+The prod defect (Step 1 NO-GO, 2026-08-11): under ``--single-feed-uses-corpus-layout`` each run
+writes a FRESH ``feeds/<slug>/run_<id>/`` dir. ``--skip-existing`` resolved the episode's existence
+against ``effective_output_dir`` (that fresh, empty run dir), so an episode already present in a
+PRIOR run dir was NOT found → the pipeline re-transcribed it (wasted Deepgram + LLM spend), though
+episode_id dedup kept the catalog count stable.
+
+The guid fix (#1) is present but was run-dir-scoped. These tests pin the cross-run-dir scenario:
+an episode processed under ``run_A`` must be recognised as present when the next run is ``run_B``.
+
+``Config(single_feed_uses_corpus_layout=True)`` rewrites ``output_dir`` to ``<root>/feeds/<slug>``,
+so ``cfg.output_dir`` is the FEED dir that contains every ``run_*`` for the feed — the correct
+corpus-wide scan root for skip-existing.
+"""
+
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from podcast_scraper import Config, models
+from podcast_scraper.workflow import episode_processor, run_index
+from podcast_scraper.workflow.helpers import get_episode_id_from_episode
+
+pytestmark = pytest.mark.unit
+
+FEED_URL = "https://example.com/podcast.xml"
+
+
+@pytest.fixture(autouse=True)
+def _reset_index_cache():
+    run_index.reset_corpus_metadata_index_cache_for_tests()
+    yield
+    run_index.reset_corpus_metadata_index_cache_for_tests()
+
+
+def _episode(guid: str, idx: int) -> models.Episode:
+    item = ET.Element("item")
+    ET.SubElement(item, "title").text = "Ep A"
+    ET.SubElement(item, "guid").text = guid
+    return models.Episode(idx=idx, title="Ep A", title_safe="Ep A", item=item, transcript_urls=[])
+
+
+def _corpus_layout_cfg(tmp_path: Path) -> Config:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir(parents=True, exist_ok=True)
+    return Config(
+        rss=FEED_URL,
+        output_dir=str(corpus),
+        skip_existing=True,
+        single_feed_uses_corpus_layout=True,
+    )
+
+
+def _seed_prior_run(feed_dir: Path, guid: str, on_disk_idx: int = 1) -> None:
+    """Write a processed episode under <feed_dir>/run_A/{metadata,transcripts}/ (a PRIOR run)."""
+    run_dir = feed_dir / "run_20260101-000000_priorAA"
+    name = f"{on_disk_idx:04d} - Ep A"
+    (run_dir / "transcripts").mkdir(parents=True, exist_ok=True)
+    (run_dir / "metadata").mkdir(parents=True, exist_ok=True)
+    (run_dir / "transcripts" / f"{name}.txt").write_text("hello", encoding="utf-8")
+    eid, _ = get_episode_id_from_episode(_episode(guid, on_disk_idx), FEED_URL)
+    (run_dir / "metadata" / f"{name}.metadata.json").write_text(
+        json.dumps(
+            {
+                "episode": {"guid": guid, "episode_id": eid},
+                "content": {"transcript_file_path": f"transcripts/{name}.txt"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _fresh_run(feed_dir: Path) -> Path:
+    fresh = feed_dir / "run_20260102-000000_freshBB"
+    fresh.mkdir(parents=True, exist_ok=True)
+    return fresh
+
+
+def test_skip_existing_finds_episode_in_prior_run_dir(tmp_path: Path):
+    """Direct-download skip path: episode from run_A is recognised when the fresh run is run_B."""
+    cfg = _corpus_layout_cfg(tmp_path)
+    feed_dir = Path(str(cfg.output_dir))
+    _seed_prior_run(feed_dir, "gA", on_disk_idx=1)
+    fresh_run = _fresh_run(feed_dir)
+
+    # The fresh run dir has NO transcript — the run-dir-scoped check would MISS the episode.
+    assert not (fresh_run / "transcripts" / "0001 - Ep A.txt").exists()
+    result = episode_processor._check_existing_transcript(
+        _episode("gA", idx=1), str(fresh_run), None, cfg
+    )
+    assert result is True
+
+
+def test_asr_path_skips_episode_in_prior_run_dir(tmp_path: Path):
+    """ASR/Deepgram skip path (the actual prod bug): download_media_for_transcription returns None
+    (skipped) for an already-present episode instead of re-downloading + re-transcribing."""
+    cfg = _corpus_layout_cfg(tmp_path)
+    feed_dir = Path(str(cfg.output_dir))
+    _seed_prior_run(feed_dir, "gA", on_disk_idx=1)
+    fresh_run = _fresh_run(feed_dir)
+    ep = _episode("gA", idx=1)
+    ep.media_url = "https://example.com/media/gA.mp3"  # would be downloaded if NOT skipped
+
+    job = episode_processor.download_media_for_transcription(
+        ep, cfg, str(tmp_path / "tmp"), str(fresh_run), None
+    )
+    assert job is None, "an already-present episode must be skipped, not re-transcribed (D7)"
+
+
+def test_new_episode_not_skipped_in_corpus_layout(tmp_path: Path):
+    cfg = _corpus_layout_cfg(tmp_path)
+    feed_dir = Path(str(cfg.output_dir))
+    _seed_prior_run(feed_dir, "gA", on_disk_idx=1)
+    fresh_run = _fresh_run(feed_dir)
+
+    assert (
+        episode_processor._check_existing_transcript(
+            _episode("gBRAND_NEW", idx=2), str(fresh_run), None, cfg
+        )
+        is False
+    )
+
+
+def test_non_corpus_layout_unchanged_flat_dir(tmp_path: Path):
+    """Non-corpus-layout (single flat dir) keeps the original run-dir-scoped behaviour."""
+    corpus = tmp_path / "flat"
+    name = "0001 - Ep A"
+    (corpus / "transcripts").mkdir(parents=True, exist_ok=True)
+    (corpus / "metadata").mkdir(parents=True, exist_ok=True)
+    (corpus / "transcripts" / f"{name}.txt").write_text("hi", encoding="utf-8")
+    eid, _ = get_episode_id_from_episode(_episode("gA", 1), FEED_URL)
+    (corpus / "metadata" / f"{name}.metadata.json").write_text(
+        json.dumps({"episode": {"guid": "gA", "episode_id": eid}}), encoding="utf-8"
+    )
+    cfg = Config(rss=FEED_URL, output_dir=str(corpus), skip_existing=True)
+    assert (
+        episode_processor._check_existing_transcript(_episode("gA", 1), str(corpus), None, cfg)
+        is True
+    )
+
+
+def _episode_no_guid(idx: int = 1) -> models.Episode:
+    item = ET.Element("item")
+    ET.SubElement(item, "title").text = "Ep A"
+    return models.Episode(idx=idx, title="Ep A", title_safe="Ep A", item=item, transcript_urls=[])
+
+
+def _seed_metadata_only(feed_dir: Path, run_name: str, guid: str) -> Path:
+    run_dir = feed_dir / run_name
+    (run_dir / "metadata").mkdir(parents=True, exist_ok=True)
+    eid, _ = get_episode_id_from_episode(_episode(guid, 1), FEED_URL)
+    (run_dir / "metadata" / "0001 - Ep A.metadata.json").write_text(
+        json.dumps({"episode": {"guid": guid, "episode_id": eid}}), encoding="utf-8"
+    )
+    return run_dir
+
+
+def test_metadata_rel_none_without_guid(tmp_path: Path):
+    feed_dir = Path(str(_corpus_layout_cfg(tmp_path).output_dir))
+    _seed_prior_run(feed_dir, "gA")
+    assert run_index.episode_metadata_rel_in_corpus(_episode_no_guid(), str(feed_dir)) is None
+
+
+def test_metadata_rel_none_when_not_present(tmp_path: Path):
+    feed_dir = Path(str(_corpus_layout_cfg(tmp_path).output_dir))
+    _seed_prior_run(feed_dir, "gA")
+    assert run_index.episode_metadata_rel_in_corpus(_episode("gMISS", 9), str(feed_dir)) is None
+
+
+def test_existing_transcript_prefers_txt(tmp_path: Path):
+    feed_dir = Path(str(_corpus_layout_cfg(tmp_path).output_dir))
+    _seed_prior_run(feed_dir, "gA")  # writes a .txt transcript
+    p = run_index.existing_transcript_path_in_corpus(_episode("gA", 1), str(feed_dir))
+    assert p is not None and p.endswith("0001 - Ep A.txt")
+
+
+def test_existing_transcript_globs_non_txt(tmp_path: Path):
+    feed_dir = Path(str(_corpus_layout_cfg(tmp_path).output_dir))
+    run = _seed_metadata_only(feed_dir, "run_20260101-000000_vtt00000", "gA")
+    (run / "transcripts").mkdir(parents=True, exist_ok=True)
+    (run / "transcripts" / "0001 - Ep A.vtt").write_text("v", encoding="utf-8")
+    p = run_index.existing_transcript_path_in_corpus(_episode("gA", 1), str(feed_dir))
+    assert p is not None and p.endswith("0001 - Ep A.vtt")
+
+
+def test_existing_transcript_metadata_only_fallback(tmp_path: Path):
+    feed_dir = Path(str(_corpus_layout_cfg(tmp_path).output_dir))
+    _seed_metadata_only(feed_dir, "run_20260101-000000_meta0000", "gA")  # no transcripts/ dir
+    p = run_index.existing_transcript_path_in_corpus(_episode("gA", 1), str(feed_dir))
+    assert p is not None and p.endswith("0001 - Ep A.metadata.json")
+
+
+def test_existing_transcript_none_when_absent(tmp_path: Path):
+    feed_dir = Path(str(_corpus_layout_cfg(tmp_path).output_dir))
+    assert run_index.existing_transcript_path_in_corpus(_episode("gNONE", 1), str(feed_dir)) is None


### PR DESCRIPTION
## Why

The 2026-08-11 incremental-processing rollout hit a **Step 1 NO-GO** in prod: re-running a feed
re-transcribed an already-present episode (wasted Deepgram + LLM spend). Root-causing that surfaced
**two hard scaling blockers** plus an observability gap that made them difficult to diagnose. This
PR fixes all of them, **repro-first** — every defect reproduced RED, then fixed to GREEN, with
guardrail tests over the incremental path that previously had **zero coverage**.

Full write-up + RCAs: `docs/wip/PROD-DEPLOY-ANOMALIES-2026-08-11.md` and the D8 design note
`docs/wip/DESIGN-D8-incremental-indexer-skip.md`.

## What changed

### D8 — search reindex was O(corpus) [scaling blocker]
Every incremental add re-embedded the **entire** corpus (~10.6 min for +1 of 107) — the two-tier
indexer had no unchanged-skip and `episodes_skipped_unchanged` was a dead metric. Added a
per-episode content fingerprint (sha256 of the collected `(doc_id, text)` rows + `model_id` + schema
version) persisted to `search/episode_fingerprints.json`; unchanged episodes skip embed+upsert; a
full rebuild ignores fingerprints. Incremental add is now **O(changed)**.

### D7 — skip-existing was run-dir-scoped, not corpus-wide [scaling blocker]
Under `--single-feed-uses-corpus-layout` each run writes a fresh run dir, so an episode present in a
**prior** run dir was re-transcribed. Now resolves presence **corpus-wide by stable guid** across
all runs — fixed in **both** `_check_existing_transcript` and the ASR/Deepgram path.

### D2 — `/api/index/stats` went stale after an in-place upsert
`read_lance_index_stats` caches on the top-level index-dir mtime, which LanceDB subdir upserts don't
bump (stats read 94 while the table held 106). Now `os.utime`s the index dir after a build that
changed the index — which crosses the pipeline **subprocess** boundary an in-process cache clear
can't.

### D9 — observability ("did Deepgram even run?")
Silenced the per-doc embedding tqdm flood (`show_progress_bar=False`) that buried real stage output,
and the cloud transcription path (Deepgram) now announces `provider + model` like the Whisper path
already did.

### D1 — `deploy-all-prod.yml`
One-trigger orchestrator that rolls **control → operator → player** in order with **stop-on-failure**
(keeps each plane's approval gate; actionlint-clean). Needs `secrets.DEPLOY_ORCHESTRATOR_PAT`; GHA
behaviour can only be validated by a live dispatch.

## Guardrail tests (the incremental path had ZERO coverage)
- `tests/integration/search/test_two_tier_indexer_incremental.py` — embed-**call-count** across
  rebuilds (build N → N; re-run unchanged → **0**; add 1 → 1; full rebuild → all).
- `tests/unit/podcast_scraper/workflow/test_skip_existing_across_runs.py` — skip across run dirs,
  incl. the ASR path returning skipped.
- `tests/integration/search/test_index_stats_freshness.py` — stats reflect an incremental add.
- `tests/.../providers/deepgram/...::test_transcribe_logs_provider_and_model` — provider logged.
- `tests/integration/test_multi_run_corpus_incremental_index.py` — **Step 0 + Step 1 codified** over
  the shared multi-run fixture (union+newest-wins → index count; unchanged reindex = 0 embeds).

## Not in scope / deferred
- **D6** (`whisper_*` field misnomer) — deferred with rationale: the field value is already the
  actual provider's model, and D9 makes the provider unambiguous in logs + `config_snapshot`; a true
  rename touches a schema `Literal` enum + many readers (a separate, higher-risk change).
- **D3/D4/D5** closed as non-issues (details in the anomalies doc).

## Validation
`make ci-fast` green locally; 1408 tests across all touched areas pass; flake8 + mypy + actionlint
clean. Post-merge + deploy, re-running the Step-0/Step-1 rollout should now PASS the skip test.

Closes #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)
