### PR TITLE
infra(tailscale): DGX telemetry to homelab-svc:443 over TLS (Level 2)

### DIFF
--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -193,12 +193,15 @@
     },
     // Per-service Caddy tailnet nodes (tag:homelab-svc): each obs service is its own
     // node <name>.tail6d0ed4.ts.net serving its own Tailscale cert (caddy-tailscale).
-    // Admin devices reach them over HTTPS. Durable successor to the port/path serve
+    // Admin devices reach them over HTTPS (dashboards). tag:dgx-llm-host pushes
+    // telemetry over TLS to vm./vlogs. — the durable successor to plaintext pushes at
+    // tag:homelab-host:8428/9428. (The grant also gives DGX netmap visibility, so
+    // MagicDNS resolves the node names.) Durable successor to the port/path serve
     // grants on tag:homelab-host above — those get trimmed once every service has
     // moved to its own node. (agentic-ai-homelab docs/wip/mac-mini-headless-server.md)
     {
       "action": "accept",
-      "src":    ["autogroup:admin"],
+      "src":    ["autogroup:admin", "tag:dgx-llm-host"],
       "dst":    ["tag:homelab-svc:443"]
     },
     {


### PR DESCRIPTION
Adds `tag:dgx-llm-host` as a source on the `tag:homelab-svc:443` grant.

**Why:** Level 2 of the homelab exposure migration. The DGX's Grafana Alloy currently pushes metrics + logs to the mini over **plaintext raw ports** (`tag:homelab-host:8428`/`9428`). This moves it onto the per-service caddy-tailscale nodes (`vm.` / `vlogs.tail6d0ed4.ts.net`, real Tailscale certs). The grant also gives the DGX **netmap visibility** to those nodes so MagicDNS resolves them (they're NXDOMAIN on the DGX today — ACL-gated).

Verified: ingest through the nodes works (`vm.…/api/v1/import/prometheus` and `vlogs.…/insert/loki/api/v1/push` both return 204). After merge I repoint the DGX Alloy `.env` and restart it.

Plan: `agentic-ai-homelab/docs/wip/mac-mini-headless-server.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)