### PR TITLE
infra(tailscale): prod → homelab-svc:443 over TLS (Level 3 prep)

### DIFF
--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -201,7 +201,7 @@
     // moved to its own node. (agentic-ai-homelab docs/wip/mac-mini-headless-server.md)
     {
       "action": "accept",
-      "src":    ["autogroup:admin", "tag:dgx-llm-host"],
+      "src":    ["autogroup:admin", "tag:dgx-llm-host", "tag:prod"],
       "dst":    ["tag:homelab-svc:443"]
     },
     {


### PR DESCRIPTION
Adds `tag:prod` to the `tag:homelab-svc:443` grant (alongside admin + dgx-llm-host).

**Why:** Level 3 prep. Prod's Alloy (metrics/logs) + Caddy telemetry/analytics vhosts (GlitchTip/Umami ingest) will move off the mini's **plaintext raw ports** onto the per-service caddy-tailscale TLS nodes (`vm./vlogs./glitchtip./umami.tail6d0ed4.ts.net`, real certs). This grant lets `tag:prod` reach them and gives netmap visibility so MagicDNS resolves them.

**Non-breaking:** additive only — prod keeps pushing to the raw ports until its box-side endpoints (`/opt/vps-observability/.env`, Caddy `GLITCHTIP_UPSTREAM`) are repointed, which is the **prod agent's** step. Verified the nodes already accept all four ingest types (vm/vlogs 204, glitchtip 403=routed, umami 400=routed).

Handover: `agentic-ai-homelab/docs/wip/level3-prod-handover.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)